### PR TITLE
fix: MCP 자식 env 화이트리스트를 접두사 방식으로 전환

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,8 @@ OLLAMA_MODEL=gemma4:e4b
 OLLAMA_API_KEY=ollama
 
 # KIS (Korea Investment Securities) Configuration
+# 주의: KIS_ 접두사는 mcp-trading 자식 프로세스 전용 네임스페이스로 예약돼 있습니다
+# (backend/config.py의 _MCP_ENV_ALLOWED_PREFIXES). backend 전용 비밀값에는 쓰지 마세요.
 KIS_API_KEY=your_kis_api_key_here
 KIS_API_SECRET=your_kis_api_secret_here
 KIS_ACCOUNT_NO=1234567801
@@ -36,6 +38,12 @@ KIS_REAL_ORDER_ENABLED=false
 # 동일 주문 중복 차단 시간(ms, 선택). 기본 120000(2분). 재빌드를 동반한 재배포는 보통
 # 2분을 넘겨 TTL이 이미 만료되므로, 배포 창을 실제로 덮으려면 상향이 필요합니다.
 # KIS_ORDER_DEDUP_TTL_MS=120000
+
+# 조회 TR ID 재정의(선택). 미설정 시 mcp-trading이 KIS_URL로 모의/실전 여부를
+# 판별해 자동으로 고릅니다. 특수 계좌 등으로 다른 TR ID가 필요할 때만 설정하세요.
+# FINUS_KIS_TR_ID_DAILY_CCLD / FINUS_KIS_TR_ID_BALANCE_RLZ_PL로도 설정할 수 있습니다.
+# KIS_TR_ID_DAILY_CCLD=TTTC0081R
+# KIS_TR_ID_BALANCE_RLZ_PL=TTTC8494R
 
 #실전투자계좌일 경우
 #KIS_URL=https://openapi.koreainvestment.com:9443

--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,8 @@ KIS_ACCOUNT_NO=1234567801
 #모의투자계좌일 경우
 KIS_URL=https://openapivts.koreainvestment.com:29443
 KIS_ORDER_ENV=demo
+# 주의: KIS_ORDER_ENV=real 과 함께 true로 두면 실제 자금으로 주문이 체결됩니다.
+# (이전 버전에서는 이 값이 mcp-trading 자식 프로세스에 전달되지 않아 항상 차단됐습니다 — #129에서 수정)
 KIS_REAL_ORDER_ENABLED=false
 
 # KIS OAuth 토큰 캐시(선택). 미설정 시 mcp-trading이 OS 임시 디렉터리(os.tmpdir())에

--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,9 @@ OLLAMA_MODEL=gemma4:e4b
 OLLAMA_API_KEY=ollama
 
 # KIS (Korea Investment Securities) Configuration
-# 주의: KIS_ 접두사는 mcp-trading 자식 프로세스 전용 네임스페이스로 예약돼 있습니다
-# (backend/config.py의 _MCP_ENV_ALLOWED_PREFIXES). backend 전용 비밀값에는 쓰지 마세요.
+# 주의: KIS_ 접두사는 MCP 자식 프로세스(mcp-trading·mcp-news·mcp-dart) 전용
+# 네임스페이스로 예약돼 있습니다(backend/config.py의 _MCP_ENV_ALLOWED_PREFIXES).
+# backend 전용 비밀값에는 쓰지 마세요.
 KIS_API_KEY=your_kis_api_key_here
 KIS_API_SECRET=your_kis_api_secret_here
 KIS_ACCOUNT_NO=1234567801
@@ -20,7 +21,8 @@ KIS_ACCOUNT_NO=1234567801
 KIS_URL=https://openapivts.koreainvestment.com:29443
 KIS_ORDER_ENV=demo
 # 주의: KIS_ORDER_ENV=real 과 함께 true로 두면 실제 자금으로 주문이 체결됩니다.
-# (이전 버전에서는 이 값이 mcp-trading 자식 프로세스에 전달되지 않아 항상 차단됐습니다 — #129에서 수정)
+# (이전 버전에서는 Docker 배포에서 이 값이 mcp-trading 자식 프로세스에 전달되지 않아 차단됐습니다.
+#  Docker를 쓰지 않는 로컬 실행에서는 mcp-trading이 .env를 직접 읽어 이미 적용됐습니다 — #129에서 통일)
 KIS_REAL_ORDER_ENABLED=false
 
 # KIS OAuth 토큰 캐시(선택). 미설정 시 mcp-trading이 OS 임시 디렉터리(os.tmpdir())에

--- a/README.md
+++ b/README.md
@@ -336,7 +336,9 @@ Backend 스케줄러는 매 거래일 오전 8시 30분에 Telegram 모닝 브�
 >
 > 대기 중인 주문이 있으면 새 주문을 낼 수 없습니다. 먼저 확정하거나 취소해야 합니다.
 >
-> 실계좌 주문은 `KIS_ORDER_ENV=real`과 `KIS_REAL_ORDER_ENABLED=true`가 모두 설정되어야 실행됩니다. 기본값은 모의투자(`demo`)입니다.
+> 실계좌 주문은 `KIS_ORDER_ENV=real`과 `KIS_REAL_ORDER_ENABLED=true`가 모두 설정되어야 실행됩니다. 기본값은 모의투자(`demo`)입니다. `KIS_REAL_ORDER_ENABLED`는 **정확히 `true`** 여야 하며 `TRUE`·`1`·`yes`는 인정되지 않습니다.
+>
+> **업그레이드 시 확인하세요.** 이전 버전은 Docker 배포에서 이 값을 `mcp-trading` 자식 프로세스에 전달하지 않아, `.env`에 `true`를 넣어 두었어도 실계좌 주문이 항상 차단됐습니다(#129). 이제 전달되므로 같은 `.env`로 실제 자금이 움직입니다. Docker를 쓰지 않는 로컬 실행에서는 `mcp-trading`이 `.env`를 직접 읽어 이전에도 적용됐습니다.
 
 `mcp-trading/data/stocks.json`은 KIS 공개 코스피/코스닥 종목 마스터 기반의 종목명 해석 캐시입니다. 신규 상장 등으로 종목명이 잡히지 않으면 6자리 종목코드를 직접 입력하거나 아래 명령으로 캐시를 갱신합니다.
 
@@ -361,6 +363,8 @@ python3 mcp-trading/scripts/update_stock_master.py
 **"실계좌 주문은 KIS_REAL_ORDER_ENABLED=true 설정이 필요합니다"**
 
 의도한 것이면 `.env`에 해당 값을 넣고 스택을 재기동하세요. 의도하지 않았다면 실계좌 모드로 잘못 설정된 것입니다.
+
+값을 이미 넣었는데도 이 메시지가 나온다면 철자를 확인하세요. `true` 외의 표기(`TRUE`·`True`·`1`·`yes`·`y`)는 인정되지 않으며, 백엔드와 `mcp-trading` 양쪽이 같은 기준으로 판정합니다.
 
 **텔레그램 봇이 반응이 없어요**
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -56,34 +56,22 @@ _MCP_ENV_ALLOWED_KEYS = {
     "NAVER_CLIENT_SECRET",
     "DART_API_KEY",
 }
-# mcp-trading이 읽는 KIS_* 변수 집합(index.js, order-dedup.js)을 하나씩 나열하면
-# 새 변수가 추가될 때마다 화이트리스트가 누락되는 드리프트가 반복된다
-# (#124 → #127에서 KIS_ORDER_DEDUP_*를 놓쳤고, #130에서 KIS_TOKEN_CACHE_PATH·
-# KIS_TR_ID_*·FINUS_KIS_TR_ID_*를, #129에서 KIS_REAL_ORDER_ENABLED를 놓쳤다).
-# 그래서 개별 KIS_* 키 나열을 접두사 규칙으로 대체해 mcp-trading 쪽 소스가
-# 유일한 진실 공급원이 되게 한다 — 새 KIS_* 변수를 mcp-trading이 추가로 읽게 되면
-# 이 파일을 고치지 않아도 자동으로 전달된다.
+# mcp-trading이 읽는 KIS_* 변수를 하나씩 나열하면 새 변수가 추가될 때마다
+# 화이트리스트가 누락되는 드리프트가 반복된다(#124, #127, #129, #130이 각각
+# 다른 키를 놓쳤다). 개별 키 나열 대신 접두사 규칙을 써서 mcp-trading 쪽
+# 소스가 유일한 진실 공급원이 되게 한다.
 #
-# 통과: KIS_로 시작하는 모든 변수(KIS_API_KEY, KIS_API_SECRET, KIS_ACCOUNT_NO,
-#       KIS_URL, KIS_ORDER_ENV, KIS_REAL_ORDER_ENABLED, KIS_ORDER_DEDUP_PATH,
-#       KIS_ORDER_DEDUP_TTL_MS, KIS_TOKEN_CACHE_PATH, KIS_TR_ID_* 등)과
-#       FINUS_KIS_로 시작하는 변수(FINUS_KIS_TR_ID_DAILY_CCLD,
-#       FINUS_KIS_TR_ID_BALANCE_RLZ_PL 등 — mcp-trading/index.js:46,54의
-#       TR ID 오버라이드)만 자식 프로세스로 전달한다.
-# 차단: KIS_로 시작하지 않는 나머지 모든 비밀값(DATABASE_URL, OPENAI_API_KEY,
-#       ANTHROPIC_API_KEY, TELEGRAM_BOT_TOKEN 등)과, KIS_ 접두사가 아닌 다른
-#       FINUS_* 변수(FINUS_BACKEND_URL, FINUS_MEM0_* 등 — backend/NAT 전용,
-#       mcp-trading이 읽지 않음)는 접두사 매칭 대상이 아니므로 여전히 차단된다.
+# 통과: KIS_로 시작하는 모든 변수(자식 프로세스 전용 네임스페이스)와
+#       FINUS_KIS_로 시작하는 변수(TR ID 오버라이드 포함 trading 에이전트
+#       설정 전반). 그 외 비밀값(DATABASE_URL 등)과 다른 FINUS_* 변수
+#       (FINUS_BACKEND_URL 등 — backend/NAT 전용)는 차단된다.
 #
-# KIS_REAL_ORDER_ENABLED는 이 접두사 규칙으로 함께 통과한다(#129). 주문 멱등
-# 원장 경로 전달(#127, 위 KIS_ORDER_DEDUP_* 통과 확인)이 선행 조건이었고 이미
-# 충족되어 있다. 미설정 시에는 os.environ에 키 자체가 없으므로 자식에도 전달되지
-# 않고, mcp-trading/index.js:344·order.js:56-61 가드는 `undefined === "true"`가
-# false이므로 fail-closed(실계좌 주문 차단)를 유지한다.
+# KIS_REAL_ORDER_ENABLED도 함께 통과한다(#129, 의도한 동작). 미설정 시
+# 키 자체가 자식에 전달되지 않으므로 mcp-trading/order.js의
+# validateRealOrderGuard는 fail-closed를 유지한다.
 #
-# finus_nat/src/nat_finus_nat/finus_api.py:28-49 에 같은 목적의 화이트리스트가
-# 별도로 존재한다(자식 프로세스로 mcp-trading 등을 직접 실행하는 경로). 이
-# 접두사 목록을 바꿀 때는 그쪽도 함께 갱신할 것.
+# finus_nat/src/nat_finus_nat/finus_api.py에 동일 목적의 화이트리스트가
+# 별도 존재한다(NAT 자식 프로세스 경로) — 접두사를 바꿀 때 함께 갱신할 것.
 _MCP_ENV_ALLOWED_PREFIXES = ("FIN_US_", "FINUS_KIS_", "KIS_")
 
 # SQLite 데이터베이스 파일 경로 설정 (backend 디렉토리 내 finus.db 생성)

--- a/backend/config.py
+++ b/backend/config.py
@@ -87,11 +87,15 @@ TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_CHAT_ID", "")
 VISUALIZATION_URL = os.getenv("VISUALIZATION_URL", "").strip()
 KIS_ORDER_ENV = os.environ.get("KIS_ORDER_ENV", "demo").strip().lower()
 
-_TRUTHY_FLAG_VALUES = {"1", "true", "yes", "y"}
-
-
 def _is_truthy_flag(value: str) -> bool:
-    return value.strip().lower() in _TRUTHY_FLAG_VALUES
+    # mcp-trading/index.js는 KIS_REAL_ORDER_ENABLED를 `=== "true"`로 비교한다 —
+    # 대소문자·다른 철자(1/yes/y/TRUE 등)를 인정하지 않는다. backend가 여기서
+    # 더 관대하게 받으면 backend 게이트는 통과하고 자식에서만 막히는 진단
+    # 트랩이 된다(#129와 같은 증상이 철자 차이로 재발). 그래서 자식과 정확히
+    # 같은 기준만 인정한다 — 이 값이 True가 되는 유일한 원본 문자열은
+    # 정확히 "true"이므로, 자식에 넘길 때 다시 쓸 필요가 없다
+    # (_mcp_child_env는 원본 문자열을 그대로 전달한다).
+    return value.strip() == "true"
 
 
 KIS_REAL_ORDER_ENABLED = _is_truthy_flag(os.environ.get("KIS_REAL_ORDER_ENABLED", ""))
@@ -110,28 +114,11 @@ ALLOW_ORIGINS = [origin.strip() for origin in _ALLOW_ORIGINS_RAW.split(",") if o
 
 
 def _mcp_child_env() -> dict[str, str]:
-    env = {
+    return {
         key: value
         for key, value in os.environ.items()
         if key in _MCP_ENV_ALLOWED_KEYS or key.startswith(_MCP_ENV_ALLOWED_PREFIXES)
     }
-    # backend는 KIS_REAL_ORDER_ENABLED를 1/true/yes/y(대소문자 무관)로 넓게
-    # 받지만(_is_truthy_flag), mcp-trading/index.js는 `=== "true"` 엄격 비교라
-    # 정규화하지 않으면 backend 게이트는 통과하고 자식에서만 막히는 진단 트랩이
-    # 된다(#129와 같은 증상). 자식에는 항상 정확히 "true"/"false"만 넘긴다.
-    #
-    # 아래 시점의 env[...]를 다시 파싱하는 대신 위쪽 모듈 스코프의
-    # KIS_REAL_ORDER_ENABLED(bool) 상수를 직접 쓰고 싶어질 수 있는데, 그러면
-    # 안 된다: 그 상수는 import 시점 os.environ 스냅샷으로 한 번만 계산되고,
-    # env 딕셔너리는 매 호출 os.environ.items()를 다시 읽는다. 테스트가
-    # monkeypatch.setenv로 import 이후 값을 바꾸므로(reload 없이), 모듈 상수를
-    # 쓰면 그 시점에는 여전히 옛 값이라 여기서만 값이 갈린다. 운영에서는
-    # os.environ이 프로세스 수명 동안 바뀌지 않아 둘이 항상 같지만, 이 재파싱
-    # 방식이 테스트가 이미 전제하는 "매 호출 os.environ을 다시 읽는다"는
-    # 동작과 일치해 더 안전하다.
-    if "KIS_REAL_ORDER_ENABLED" in env:
-        env["KIS_REAL_ORDER_ENABLED"] = "true" if _is_truthy_flag(env["KIS_REAL_ORDER_ENABLED"]) else "false"
-    return env
 
 
 def _stdio_server_params(mcp_dir: Path) -> StdioServerParameters:

--- a/backend/config.py
+++ b/backend/config.py
@@ -119,6 +119,16 @@ def _mcp_child_env() -> dict[str, str]:
     # 받지만(_is_truthy_flag), mcp-trading/index.js는 `=== "true"` 엄격 비교라
     # 정규화하지 않으면 backend 게이트는 통과하고 자식에서만 막히는 진단 트랩이
     # 된다(#129와 같은 증상). 자식에는 항상 정확히 "true"/"false"만 넘긴다.
+    #
+    # 아래 시점의 env[...]를 다시 파싱하는 대신 위쪽 모듈 스코프의
+    # KIS_REAL_ORDER_ENABLED(bool) 상수를 직접 쓰고 싶어질 수 있는데, 그러면
+    # 안 된다: 그 상수는 import 시점 os.environ 스냅샷으로 한 번만 계산되고,
+    # env 딕셔너리는 매 호출 os.environ.items()를 다시 읽는다. 테스트가
+    # monkeypatch.setenv로 import 이후 값을 바꾸므로(reload 없이), 모듈 상수를
+    # 쓰면 그 시점에는 여전히 옛 값이라 여기서만 값이 갈린다. 운영에서는
+    # os.environ이 프로세스 수명 동안 바뀌지 않아 둘이 항상 같지만, 이 재파싱
+    # 방식이 테스트가 이미 전제하는 "매 호출 os.environ을 다시 읽는다"는
+    # 동작과 일치해 더 안전하다.
     if "KIS_REAL_ORDER_ENABLED" in env:
         env["KIS_REAL_ORDER_ENABLED"] = "true" if _is_truthy_flag(env["KIS_REAL_ORDER_ENABLED"]) else "false"
     return env

--- a/backend/config.py
+++ b/backend/config.py
@@ -98,12 +98,15 @@ TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "")
 TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_CHAT_ID", "")
 VISUALIZATION_URL = os.getenv("VISUALIZATION_URL", "").strip()
 KIS_ORDER_ENV = os.environ.get("KIS_ORDER_ENV", "demo").strip().lower()
-KIS_REAL_ORDER_ENABLED = os.environ.get("KIS_REAL_ORDER_ENABLED", "").strip().lower() in {
-    "1",
-    "true",
-    "yes",
-    "y",
-}
+
+_TRUTHY_FLAG_VALUES = {"1", "true", "yes", "y"}
+
+
+def _is_truthy_flag(value: str) -> bool:
+    return value.strip().lower() in _TRUTHY_FLAG_VALUES
+
+
+KIS_REAL_ORDER_ENABLED = _is_truthy_flag(os.environ.get("KIS_REAL_ORDER_ENABLED", ""))
 
 
 def is_placeholder_secret(value: str | None) -> bool:
@@ -119,11 +122,18 @@ ALLOW_ORIGINS = [origin.strip() for origin in _ALLOW_ORIGINS_RAW.split(",") if o
 
 
 def _mcp_child_env() -> dict[str, str]:
-    return {
+    env = {
         key: value
         for key, value in os.environ.items()
         if key in _MCP_ENV_ALLOWED_KEYS or key.startswith(_MCP_ENV_ALLOWED_PREFIXES)
     }
+    # backend는 KIS_REAL_ORDER_ENABLED를 1/true/yes/y(대소문자 무관)로 넓게
+    # 받지만(_is_truthy_flag), mcp-trading/index.js는 `=== "true"` 엄격 비교라
+    # 정규화하지 않으면 backend 게이트는 통과하고 자식에서만 막히는 진단 트랩이
+    # 된다(#129와 같은 증상). 자식에는 항상 정확히 "true"/"false"만 넘긴다.
+    if "KIS_REAL_ORDER_ENABLED" in env:
+        env["KIS_REAL_ORDER_ENABLED"] = "true" if _is_truthy_flag(env["KIS_REAL_ORDER_ENABLED"]) else "false"
+    return env
 
 
 def _stdio_server_params(mcp_dir: Path) -> StdioServerParameters:

--- a/backend/config.py
+++ b/backend/config.py
@@ -52,24 +52,39 @@ _MCP_ENV_ALLOWED_KEYS = {
     "http_proxy",
     "https_proxy",
     "no_proxy",
-    "KIS_API_KEY",
-    "KIS_API_SECRET",
-    "KIS_ACCOUNT_NO",
-    "KIS_URL",
-    # 주문 멱등 원장(mcp-trading/order-dedup.js:50-51) 설정.
-    # Docker 이미지의 mcp-trading은 /opt/mcp-trading에 있고 .dockerignore가 .env를 배제하므로
-    # mcp-trading/index.js:34의 dotenv가 루트 .env를 읽지 못한다. 이 두 키를 자식 프로세스로
-    # 전달해야 원장 경로 재정의가 실제로 적용된다.
-    # KIS_REAL_ORDER_ENABLED는 의도적으로 제외한다 — 추가하면 Docker에서 실계좌 주문
-    # 가드(mcp-trading/order.js:56-61)에 사용자 .env 값이 반영되기 시작하므로,
-    # 전용 이슈·리뷰를 거쳐야 한다.
-    "KIS_ORDER_DEDUP_PATH",
-    "KIS_ORDER_DEDUP_TTL_MS",
     "NAVER_CLIENT_ID",
     "NAVER_CLIENT_SECRET",
     "DART_API_KEY",
 }
-_MCP_ENV_ALLOWED_PREFIXES = ("FIN_US_",)
+# mcp-trading이 읽는 KIS_* 변수 집합(index.js, order-dedup.js)을 하나씩 나열하면
+# 새 변수가 추가될 때마다 화이트리스트가 누락되는 드리프트가 반복된다
+# (#124 → #127에서 KIS_ORDER_DEDUP_*를 놓쳤고, #130에서 KIS_TOKEN_CACHE_PATH·
+# KIS_TR_ID_*·FINUS_KIS_TR_ID_*를, #129에서 KIS_REAL_ORDER_ENABLED를 놓쳤다).
+# 그래서 개별 KIS_* 키 나열을 접두사 규칙으로 대체해 mcp-trading 쪽 소스가
+# 유일한 진실 공급원이 되게 한다 — 새 KIS_* 변수를 mcp-trading이 추가로 읽게 되면
+# 이 파일을 고치지 않아도 자동으로 전달된다.
+#
+# 통과: KIS_로 시작하는 모든 변수(KIS_API_KEY, KIS_API_SECRET, KIS_ACCOUNT_NO,
+#       KIS_URL, KIS_ORDER_ENV, KIS_REAL_ORDER_ENABLED, KIS_ORDER_DEDUP_PATH,
+#       KIS_ORDER_DEDUP_TTL_MS, KIS_TOKEN_CACHE_PATH, KIS_TR_ID_* 등)과
+#       FINUS_KIS_로 시작하는 변수(FINUS_KIS_TR_ID_DAILY_CCLD,
+#       FINUS_KIS_TR_ID_BALANCE_RLZ_PL 등 — mcp-trading/index.js:46,54의
+#       TR ID 오버라이드)만 자식 프로세스로 전달한다.
+# 차단: KIS_로 시작하지 않는 나머지 모든 비밀값(DATABASE_URL, OPENAI_API_KEY,
+#       ANTHROPIC_API_KEY, TELEGRAM_BOT_TOKEN 등)과, KIS_ 접두사가 아닌 다른
+#       FINUS_* 변수(FINUS_BACKEND_URL, FINUS_MEM0_* 등 — backend/NAT 전용,
+#       mcp-trading이 읽지 않음)는 접두사 매칭 대상이 아니므로 여전히 차단된다.
+#
+# KIS_REAL_ORDER_ENABLED는 이 접두사 규칙으로 함께 통과한다(#129). 주문 멱등
+# 원장 경로 전달(#127, 위 KIS_ORDER_DEDUP_* 통과 확인)이 선행 조건이었고 이미
+# 충족되어 있다. 미설정 시에는 os.environ에 키 자체가 없으므로 자식에도 전달되지
+# 않고, mcp-trading/index.js:344·order.js:56-61 가드는 `undefined === "true"`가
+# false이므로 fail-closed(실계좌 주문 차단)를 유지한다.
+#
+# finus_nat/src/nat_finus_nat/finus_api.py:28-49 에 같은 목적의 화이트리스트가
+# 별도로 존재한다(자식 프로세스로 mcp-trading 등을 직접 실행하는 경로). 이
+# 접두사 목록을 바꿀 때는 그쪽도 함께 갱신할 것.
+_MCP_ENV_ALLOWED_PREFIXES = ("FIN_US_", "FINUS_KIS_", "KIS_")
 
 # SQLite 데이터베이스 파일 경로 설정 (backend 디렉토리 내 finus.db 생성)
 DATABASE_URL = os.environ.get("DATABASE_URL") or f"sqlite:///{_FIN_US_ROOT}/backend/finus.db"

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -47,10 +47,9 @@ def test_mcp_stdio_params_pass_order_dedup_ledger_settings(monkeypatch):
 
 
 def test_mcp_stdio_params_pass_kis_token_cache_and_tr_id_overrides(monkeypatch):
-    # #130 — mcp-trading/index.js:60의 토큰 캐시 경로, index.js:46,54의 TR ID
-    # 오버라이드. 이 값들이 전달되지 않으면 컨테이너가 재생성될 때마다 KIS
-    # OAuth 토큰을 새로 발급받거나(#124와 동일한 결함) TR ID 오버라이드가
-    # 무시된다.
+    # #130 — mcp-trading의 토큰 캐시 경로(index.js), TR ID 오버라이드(index.js).
+    # 이 값들이 전달되지 않으면 컨테이너가 재생성될 때마다 KIS OAuth 토큰을
+    # 새로 발급받거나(#124와 동일한 결함) TR ID 오버라이드가 무시된다.
     monkeypatch.setenv("KIS_TOKEN_CACHE_PATH", "/var/lib/finus/kis-token-cache.json")
     monkeypatch.setenv("KIS_TR_ID_DAILY_CCLD", "TTTC0081R")
     monkeypatch.setenv("KIS_TR_ID_BALANCE_RLZ_PL", "TTTC8494R")
@@ -63,8 +62,8 @@ def test_mcp_stdio_params_pass_kis_token_cache_and_tr_id_overrides(monkeypatch):
 
 
 def test_mcp_stdio_params_pass_real_order_enabled_and_fail_closed_when_unset(monkeypatch):
-    # #129 — mcp-trading/index.js:41,344와 order.js:56-61의 실계좌 주문 가드는
-    # 자식 프로세스의 process.env.KIS_REAL_ORDER_ENABLED를 직접 읽는다. 설정
+    # #129 — mcp-trading/index.js와 order.js의 validateRealOrderGuard는 자식
+    # 프로세스의 process.env.KIS_REAL_ORDER_ENABLED를 직접 읽는다. 설정
     # 시에는 반드시 통과해야 하고(그렇지 않으면 .env=true여도 Docker에서 항상
     # 차단된다), 미설정 시에는 os.environ에 키 자체가 없으므로 자식에도
     # 전달되지 않아 fail-closed(주문 차단)가 유지되어야 한다.
@@ -79,7 +78,7 @@ def test_mcp_stdio_params_pass_real_order_enabled_and_fail_closed_when_unset(mon
 
 def test_mcp_stdio_params_pass_finus_kis_tr_id_overrides_but_not_other_finus_vars(monkeypatch):
     # #130 — backend/config.py의 접두사는 기존 FIN_US_(밑줄 포함)와 겹치지
-    # 않는 FINUS_KIS_TR_ID_* 오버라이드(mcp-trading/index.js:46,54)를 놓치고
+    # 않는 FINUS_KIS_TR_ID_* 오버라이드(mcp-trading/index.js)를 놓치고
     # 있었다. FINUS_KIS_ 접두사로 이 변수들만 통과시키고, KIS_와 무관한 다른
     # FINUS_* 변수(backend/NAT 전용, mcp-trading이 읽지 않음)는 여전히
     # 차단되어야 접두사 경계가 필요 이상으로 넓어지지 않는다.
@@ -110,32 +109,55 @@ def test_mcp_stdio_params_forward_any_kis_prefixed_variable_by_mechanism(monkeyp
     assert params.env["KIS_FUTURE_VARIABLE_NOT_YET_INVENTED"] == "future-value"
 
 
-@pytest.mark.parametrize("raw_value", ["1", "yes", "TRUE", "Y"])
-def test_mcp_stdio_params_normalize_non_true_truthy_real_order_enabled(monkeypatch, raw_value):
-    # #129 재발 방지 — backend는 KIS_REAL_ORDER_ENABLED를 1/yes/y/true(대소문자
-    # 무관)로 넓게 허용하지만(config.py의 _is_truthy_flag), mcp-trading/index.js는
-    # `=== "true"` 엄격 비교다. 정규화가 없으면 이 값들은 backend 게이트를
-    # 통과한 뒤 자식에서만 막혀 "KIS_REAL_ORDER_ENABLED=true 설정이
-    # 필요합니다" 오진단을 낸다. _mcp_child_env()의 정규화 블록을 지우면 이
-    # 테스트는 자식이 받는 원본 문자열("1"/"yes"/"TRUE"/"Y")이 "true"와 달라
-    # 즉시 실패한다.
-    monkeypatch.setenv("KIS_REAL_ORDER_ENABLED", raw_value)
+@pytest.mark.parametrize(
+    "raw_value,expected",
+    [
+        ("true", True),
+        (" true ", True),
+        ("TRUE", False),
+        ("True", False),
+        ("1", False),
+        ("yes", False),
+        ("y", False),
+        ("0", False),
+        ("", False),
+    ],
+)
+def test_is_truthy_flag_requires_exact_lowercase_true(raw_value, expected):
+    # HIGH2 재발 방지 — mcp-trading/index.js는 KIS_REAL_ORDER_ENABLED를
+    # `=== "true"`로만 비교한다(대소문자·다른 철자 불허). backend가 여기서
+    # 조금이라도 더 관대하면(예: "TRUE"·"1"·"yes"도 인정) backend 게이트는
+    # 통과하고 자식은 거부하는 진단 트랩이 재발한다(#129 최초 증상이 정규화로
+    # 한 번 덮였다가, 이번엔 정규화 자체를 없애는 대신 두 기준을 완전히
+    # 일치시켜 근본적으로 막는다). _is_truthy_flag가 .lower()나 다른 철자를
+    # 다시 허용하도록 바뀌면 이 단언들이 즉시 실패한다.
+    assert config._is_truthy_flag(raw_value) is expected
+
+
+def test_mcp_stdio_params_forward_kis_real_order_enabled_raw_value_unchanged(monkeypatch):
+    # backend 게이트(_is_truthy_flag)와 자식 가드가 이제 정확히 같은 기준
+    # ("true" 리터럴)이므로, 자식에 넘기는 값은 원본 문자열을 다시 쓸 필요가
+    # 없다(정규화 블록 제거). 이 테스트는 정규화를 다시 끼워 넣는 회귀 —
+    # 원본과 다른 문자열로 rewrite하는 변경 — 을 잡는다.
+    monkeypatch.setenv("KIS_REAL_ORDER_ENABLED", "true")
 
     params = _stdio_server_params(Path("/opt/mcp-trading"))
 
     assert params.env["KIS_REAL_ORDER_ENABLED"] == "true"
 
 
-def test_mcp_stdio_params_normalize_falsy_real_order_enabled_to_canonical_false(monkeypatch):
-    # 정규화 정책이 대칭적인지 확인한다: "0"은 backend·mcp-trading 양쪽에서
-    # 이미 거부되는 값이지만(fail-closed라 자금 위험은 없다), 정규화가 값을
-    # 그대로 통과시키면(원본 "0") 이 단언이 실패해 정규화 블록이 truthy 쪽만
-    # 처리하고 falsy 쪽을 빠뜨리는 뮤테이션을 잡아낸다.
-    monkeypatch.setenv("KIS_REAL_ORDER_ENABLED", "0")
+def test_mcp_stdio_params_forward_non_true_spelling_unchanged_and_blocked_on_both_sides(monkeypatch):
+    # backend 게이트와 자식 가드가 이제 동일 기준을 쓰므로, "true"가 아닌
+    # 철자("yes" 등)는 두 쪽 모두에서 막혀야 한다 — 자식에는 원본 문자열이
+    # 그대로 전달되고("yes" != "true"이므로 자식도 거부), backend 게이트도
+    # 같은 이유로 거부한다. 어느 한쪽만 넓히는 뮤테이션(예: _is_truthy_flag를
+    # 다시 광범위한 집합으로 되돌리는 것)이 있으면 이 테스트가 잡는다.
+    monkeypatch.setenv("KIS_REAL_ORDER_ENABLED", "yes")
 
     params = _stdio_server_params(Path("/opt/mcp-trading"))
 
-    assert params.env["KIS_REAL_ORDER_ENABLED"] == "false"
+    assert params.env["KIS_REAL_ORDER_ENABLED"] == "yes"
+    assert config._is_truthy_flag("yes") is False
 
 
 def test_visualization_url_is_trimmed_and_trailing_slash_preserved(monkeypatch):

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -18,6 +18,10 @@ def test_mcp_stdio_params_do_not_pass_parent_only_secrets(monkeypatch):
     monkeypatch.setenv("FIN_US_TRACE_ID", "trace-id")
     monkeypatch.setenv("DATABASE_URL", "postgresql://user:secret@db/prod")
     monkeypatch.setenv("OPENAI_API_KEY", "openai-secret")
+    # 텔레그램 봇 토큰: mcp-trading/mcp-news/mcp-dart 중 어느 것도 읽지 않는
+    # backend 전용 비밀값이다. KIS_/FINUS_KIS_/FIN_US_ 어떤 접두사에도 걸리지
+    # 않으므로 자식 프로세스로 새어나가면 안 된다.
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "telegram-secret")
 
     params = _stdio_server_params(Path("/tmp/mcp-news"))
 
@@ -27,6 +31,7 @@ def test_mcp_stdio_params_do_not_pass_parent_only_secrets(monkeypatch):
     assert params.env["FIN_US_TRACE_ID"] == "trace-id"
     assert "DATABASE_URL" not in params.env
     assert "OPENAI_API_KEY" not in params.env
+    assert "TELEGRAM_BOT_TOKEN" not in params.env
 
 
 def test_mcp_stdio_params_pass_order_dedup_ledger_settings(monkeypatch):
@@ -37,6 +42,70 @@ def test_mcp_stdio_params_pass_order_dedup_ledger_settings(monkeypatch):
 
     assert params.env["KIS_ORDER_DEDUP_PATH"] == "/var/lib/finus/kis-order-dedup.json"
     assert params.env["KIS_ORDER_DEDUP_TTL_MS"] == "120000"
+
+
+def test_mcp_stdio_params_pass_kis_token_cache_and_tr_id_overrides(monkeypatch):
+    # #130 — mcp-trading/index.js:60의 토큰 캐시 경로, index.js:46,54의 TR ID
+    # 오버라이드. 이 값들이 전달되지 않으면 컨테이너가 재생성될 때마다 KIS
+    # OAuth 토큰을 새로 발급받거나(#124와 동일한 결함) TR ID 오버라이드가
+    # 무시된다.
+    monkeypatch.setenv("KIS_TOKEN_CACHE_PATH", "/var/lib/finus/kis-token-cache.json")
+    monkeypatch.setenv("KIS_TR_ID_DAILY_CCLD", "TTTC0081R")
+    monkeypatch.setenv("KIS_TR_ID_BALANCE_RLZ_PL", "TTTC8494R")
+
+    params = _stdio_server_params(Path("/opt/mcp-trading"))
+
+    assert params.env["KIS_TOKEN_CACHE_PATH"] == "/var/lib/finus/kis-token-cache.json"
+    assert params.env["KIS_TR_ID_DAILY_CCLD"] == "TTTC0081R"
+    assert params.env["KIS_TR_ID_BALANCE_RLZ_PL"] == "TTTC8494R"
+
+
+def test_mcp_stdio_params_pass_real_order_enabled_and_fail_closed_when_unset(monkeypatch):
+    # #129 — mcp-trading/index.js:41,344와 order.js:56-61의 실계좌 주문 가드는
+    # 자식 프로세스의 process.env.KIS_REAL_ORDER_ENABLED를 직접 읽는다. 설정
+    # 시에는 반드시 통과해야 하고(그렇지 않으면 .env=true여도 Docker에서 항상
+    # 차단된다), 미설정 시에는 os.environ에 키 자체가 없으므로 자식에도
+    # 전달되지 않아 fail-closed(주문 차단)가 유지되어야 한다.
+    monkeypatch.setenv("KIS_REAL_ORDER_ENABLED", "true")
+    params_enabled = _stdio_server_params(Path("/opt/mcp-trading"))
+    assert params_enabled.env["KIS_REAL_ORDER_ENABLED"] == "true"
+
+    monkeypatch.delenv("KIS_REAL_ORDER_ENABLED", raising=False)
+    params_unset = _stdio_server_params(Path("/opt/mcp-trading"))
+    assert "KIS_REAL_ORDER_ENABLED" not in params_unset.env
+
+
+def test_mcp_stdio_params_pass_finus_kis_tr_id_overrides_but_not_other_finus_vars(monkeypatch):
+    # #130 — backend/config.py의 접두사는 기존 FIN_US_(밑줄 포함)와 겹치지
+    # 않는 FINUS_KIS_TR_ID_* 오버라이드(mcp-trading/index.js:46,54)를 놓치고
+    # 있었다. FINUS_KIS_ 접두사로 이 변수들만 통과시키고, KIS_와 무관한 다른
+    # FINUS_* 변수(backend/NAT 전용, mcp-trading이 읽지 않음)는 여전히
+    # 차단되어야 접두사 경계가 필요 이상으로 넓어지지 않는다.
+    monkeypatch.setenv("FINUS_KIS_TR_ID_DAILY_CCLD", "TTTC0081R")
+    monkeypatch.setenv("FINUS_KIS_TR_ID_BALANCE_RLZ_PL", "TTTC8494R")
+    monkeypatch.setenv("FINUS_BACKEND_URL", "http://backend:8000")
+
+    params = _stdio_server_params(Path("/opt/mcp-trading"))
+
+    assert params.env["FINUS_KIS_TR_ID_DAILY_CCLD"] == "TTTC0081R"
+    assert params.env["FINUS_KIS_TR_ID_BALANCE_RLZ_PL"] == "TTTC8494R"
+    assert "FINUS_BACKEND_URL" not in params.env
+
+
+def test_mcp_stdio_params_forward_any_kis_prefixed_variable_by_mechanism(monkeypatch):
+    # 드리프트 방지 테스트. 개별 키 이름을 나열하는 테스트는 화이트리스트가
+    # 다시 개별 나열 방식으로 되돌아가면(즉 #124/#127/#129/#130이 반복될
+    # 새로운 KIS_* 변수가 mcp-trading에 추가되면) 그 이름을 목록에 추가해야만
+    # 통과하므로 같은 드리프트를 재인코딩할 뿐이다. 이 테스트는 목록에
+    # 존재한 적 없는 합성 변수명을 사용해 "KIS_로 시작하면 전달된다"는
+    # 접두사 매칭 메커니즘 자체를 검증한다 — 누군가 _MCP_ENV_ALLOWED_PREFIXES에서
+    # "KIS_"를 제거하거나 개별 키 나열로 되돌리면(뮤테이션) 이 테스트는
+    # 어떤 이름 목록 갱신 없이도 즉시 실패한다.
+    monkeypatch.setenv("KIS_FUTURE_VARIABLE_NOT_YET_INVENTED", "future-value")
+
+    params = _stdio_server_params(Path("/opt/mcp-trading"))
+
+    assert params.env["KIS_FUTURE_VARIABLE_NOT_YET_INVENTED"] == "future-value"
 
 
 def test_visualization_url_is_trimmed_and_trailing_slash_preserved(monkeypatch):

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,6 +1,8 @@
 import importlib
 from pathlib import Path
 
+import pytest
+
 import backend.config as config
 from backend.config import DART_MCP_PARAMS, NEWS_MCP_PARAMS, TRADING_MCP_PARAMS, _stdio_server_params
 
@@ -106,6 +108,34 @@ def test_mcp_stdio_params_forward_any_kis_prefixed_variable_by_mechanism(monkeyp
     params = _stdio_server_params(Path("/opt/mcp-trading"))
 
     assert params.env["KIS_FUTURE_VARIABLE_NOT_YET_INVENTED"] == "future-value"
+
+
+@pytest.mark.parametrize("raw_value", ["1", "yes", "TRUE", "Y"])
+def test_mcp_stdio_params_normalize_non_true_truthy_real_order_enabled(monkeypatch, raw_value):
+    # #129 재발 방지 — backend는 KIS_REAL_ORDER_ENABLED를 1/yes/y/true(대소문자
+    # 무관)로 넓게 허용하지만(config.py의 _is_truthy_flag), mcp-trading/index.js는
+    # `=== "true"` 엄격 비교다. 정규화가 없으면 이 값들은 backend 게이트를
+    # 통과한 뒤 자식에서만 막혀 "KIS_REAL_ORDER_ENABLED=true 설정이
+    # 필요합니다" 오진단을 낸다. _mcp_child_env()의 정규화 블록을 지우면 이
+    # 테스트는 자식이 받는 원본 문자열("1"/"yes"/"TRUE"/"Y")이 "true"와 달라
+    # 즉시 실패한다.
+    monkeypatch.setenv("KIS_REAL_ORDER_ENABLED", raw_value)
+
+    params = _stdio_server_params(Path("/opt/mcp-trading"))
+
+    assert params.env["KIS_REAL_ORDER_ENABLED"] == "true"
+
+
+def test_mcp_stdio_params_normalize_falsy_real_order_enabled_to_canonical_false(monkeypatch):
+    # 정규화 정책이 대칭적인지 확인한다: "0"은 backend·mcp-trading 양쪽에서
+    # 이미 거부되는 값이지만(fail-closed라 자금 위험은 없다), 정규화가 값을
+    # 그대로 통과시키면(원본 "0") 이 단언이 실패해 정규화 블록이 truthy 쪽만
+    # 처리하고 falsy 쪽을 빠뜨리는 뮤테이션을 잡아낸다.
+    monkeypatch.setenv("KIS_REAL_ORDER_ENABLED", "0")
+
+    params = _stdio_server_params(Path("/opt/mcp-trading"))
+
+    assert params.env["KIS_REAL_ORDER_ENABLED"] == "false"
 
 
 def test_visualization_url_is_trimmed_and_trailing_slash_preserved(monkeypatch):

--- a/finus_nat/src/nat_finus_nat/finus_api.py
+++ b/finus_nat/src/nat_finus_nat/finus_api.py
@@ -46,7 +46,11 @@ _MCP_ENV_ALLOWED_KEYS = frozenset({
     "NAVER_CLIENT_SECRET",
     "DART_API_KEY",
 })
-_MCP_ENV_ALLOWED_PREFIXES = ("FIN_US_", "FINUS_")
+# backend/config.py의 _MCP_ENV_ALLOWED_PREFIXES와 같은 규칙. 한쪽만 바꾸면
+# 같은 .env로 backend 경로와 NAT 경로의 동작이 갈린다(#130). FINUS_는 이미
+# 넓게 열려 있어 FINUS_KIS_*는 그대로 통과하므로, KIS_만 추가하면 양쪽이
+# 일치한다.
+_MCP_ENV_ALLOWED_PREFIXES = ("FIN_US_", "FINUS_", "KIS_")
 
 McpCallArguments: TypeAlias = dict[str, Any]
 

--- a/finus_nat/src/nat_finus_nat/finus_api.py
+++ b/finus_nat/src/nat_finus_nat/finus_api.py
@@ -37,19 +37,16 @@ _MCP_ENV_ALLOWED_KEYS = frozenset({
     "http_proxy",
     "https_proxy",
     "no_proxy",
-    "KIS_API_KEY",
-    "KIS_API_SECRET",
-    "KIS_ACCOUNT_NO",
-    "KIS_URL",
-    "KIS_TOKEN_CACHE_PATH",
     "NAVER_CLIENT_ID",
     "NAVER_CLIENT_SECRET",
     "DART_API_KEY",
 })
 # backend/config.py의 _MCP_ENV_ALLOWED_PREFIXES와 같은 규칙. 한쪽만 바꾸면
-# 같은 .env로 backend 경로와 NAT 경로의 동작이 갈린다(#130). FINUS_는 이미
-# 넓게 열려 있어 FINUS_KIS_*는 그대로 통과하므로, KIS_만 추가하면 양쪽이
-# 일치한다.
+# 같은 .env로 backend 경로와 NAT 경로의 동작이 갈린다(#130). KIS_API_KEY 등
+# 개별 KIS_* 키 나열은 이제 KIS_ 접두사에 포함되므로 위 목록에서 제거했다.
+# KIS_만 추가하면 자식 네임스페이스(KIS_)가 양쪽에서 일치한다. FINUS_ 범위는
+# 의도적으로 다르다 — backend는 FINUS_KIS_로 좁히고, NAT의 FINUS_는 이 PR
+# 이전부터 있던 기존 범위라 이번 변경의 대상이 아니다.
 _MCP_ENV_ALLOWED_PREFIXES = ("FIN_US_", "FINUS_", "KIS_")
 
 McpCallArguments: TypeAlias = dict[str, Any]

--- a/finus_nat/tests/test_env_whitelist.py
+++ b/finus_nat/tests/test_env_whitelist.py
@@ -1,23 +1,34 @@
 """NAT 경로 MCP 자식 프로세스 env 화이트리스트(_MCP_ENV_ALLOWED_PREFIXES) 테스트.
 
 backend/config.py에 같은 목적의 화이트리스트가 별도로 존재한다(#130). 이 파일은
-NAT 쪽 접두사 규칙만 검증하고, 마지막 테스트에서만 backend.config를 가져와 두
-경로가 반드시 같이 움직여야 하는 최소 차원(KIS_ 네임스페이스)이 어긋나지
-않는지 확인한다.
+NAT 쪽 접두사 규칙만 검증하고, 마지막 테스트에서만 backend/config.py 소스를
+정적으로 읽어(import하지 않는다) 두 경로가 반드시 같이 움직여야 하는 차원이
+어긋나지 않는지 확인한다.
 """
-import sys
+import ast
 from pathlib import Path
 
-# backend와 finus_nat은 별도 uv 프로젝트(별도 venv)라 기본적으로 서로의 패키지를
-# import할 수 없다. 마지막 테스트에서만 backend.config를 가져오기 위해 저장소
-# 루트를 sys.path에 추가한다 — backend/config.py는 dotenv·mcp만 있으면 되고
-# 둘 다 finus_nat venv에 이미 있다(nvidia-nat[mcp] 전이 의존성).
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-if str(_REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(_REPO_ROOT))
+from nat_finus_nat.finus_api import _MCP_ENV_ALLOWED_PREFIXES, _mcp_child_env
 
-import backend.config as backend_config  # noqa: E402
-from nat_finus_nat.finus_api import _MCP_ENV_ALLOWED_PREFIXES, _mcp_child_env  # noqa: E402
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _prefix_tuple(path: Path, name: str) -> tuple[str, ...]:
+    # backend와 finus_nat은 별도 uv 프로젝트(별도 venv)라 backend.config를
+    # import하면 dotenv·mcp 같은 전이 의존성 여부(현재는 우연히 finus_nat
+    # venv에도 있다)에 이 테스트 파일 전체의 수집(collection)이 묶이고,
+    # backend/config.py:9-10의 load_dotenv()가 import 시점에 실행되어 NAT
+    # 테스트 세션 전체의 os.environ을 개발자의 실제 저장소 루트 .env로
+    # 오염시킨다(CI는 .env가 없어 이 회귀가 CI에서는 절대 드러나지 않는다).
+    # 그래서 파일을 소스 텍스트로만 읽어 AST로 상수를 파싱한다 — 표준
+    # 라이브러리만 쓰고, import도 side effect도 없다.
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == name for target in node.targets
+        ):
+            return ast.literal_eval(node.value)
+    raise AssertionError(f"{name} not found in {path}")
 
 
 def test_mcp_child_env_forwards_kis_tr_id_overrides(monkeypatch):
@@ -74,17 +85,25 @@ def test_mcp_child_env_forwards_any_kis_prefixed_variable_by_mechanism(monkeypat
     assert env["KIS_FUTURE_VARIABLE_NOT_YET_INVENTED"] == "future-value"
 
 
-def test_kis_namespace_prefix_is_present_on_both_backend_and_nat_paths():
+def test_every_backend_prefix_is_subsumed_by_a_nat_prefix():
     # #130의 핵심은 "같은 목적의 화이트리스트 두 벌이 어긋난다"는 것이었다.
     # 두 _MCP_ENV_ALLOWED_PREFIXES 튜플을 완전히 동일한지(==) 비교하지는
     # 않는다 — backend는 FINUS_*를 FINUS_KIS_로 의도적으로 좁혀 FINUS_MEM0_*
-    # 등 backend/NAT 전용 변수가 새지 않게 막고, NAT는 이미 FINUS_ 전체를
-    # 넓게 허용한다(finus_api.py가 FINUS_BACKEND_URL 등도 스스로 쓰기
-    # 때문). 이 비대칭은 설계 의도이므로 완전 동일성 단언은 지금의 올바른
-    # 상태에서도 실패해 신호가 아니라 잡음이 된다.
+    # 등 backend/NAT 전용 변수가 새지 않게 막고, NAT의 FINUS_는 이 PR 이전부터
+    # 있던 기존 범위라 이번 변경의 대상이 아니다. 이 비대칭은 설계 의도이므로
+    # 완전 동일성 단언은 지금의 올바른 상태에서도 실패해 신호가 아니라
+    # 잡음이 된다.
     #
-    # 대신 두 경로가 반드시 같이 움직여야 하는 유일한 차원 — 자식 프로세스
-    # (mcp-trading 등)가 공유하는 KIS_ 네임스페이스 자체 — 만 고정한다. 이후
-    # 누군가 한쪽에서만 "KIS_"를 빼면 이 단언이 즉시 잡아낸다.
-    assert "KIS_" in backend_config._MCP_ENV_ALLOWED_PREFIXES
-    assert "KIS_" in _MCP_ENV_ALLOWED_PREFIXES
+    # 대신 더 정확한 불변식을 쓴다: backend가 통과시키는 모든 접두사는 NAT
+    # 접두사 중 하나로 시작해야 한다(포함 관계). 지금 상태에서 성립하는 이유는
+    # 각 backend 접두사가 그대로 NAT에도 있기 때문이다(FIN_US_→FIN_US_,
+    # FINUS_KIS_→FINUS_, KIS_→KIS_). 이 검사는 #130이 실제로 재발하는
+    # 시나리오 — 누군가 backend에 새 접두사를 추가하고 NAT을 깜빡하는 것 —
+    # 를 정확히 잡는다. 자기 자신과만 비교하는 "KIS_ in ..." 식의 단순 포함
+    # 검사보다 엄격하다.
+    backend_prefixes = _prefix_tuple(_REPO_ROOT / "backend" / "config.py", "_MCP_ENV_ALLOWED_PREFIXES")
+
+    assert all(
+        any(backend_prefix.startswith(nat_prefix) for nat_prefix in _MCP_ENV_ALLOWED_PREFIXES)
+        for backend_prefix in backend_prefixes
+    )

--- a/finus_nat/tests/test_env_whitelist.py
+++ b/finus_nat/tests/test_env_whitelist.py
@@ -1,0 +1,90 @@
+"""NAT 경로 MCP 자식 프로세스 env 화이트리스트(_MCP_ENV_ALLOWED_PREFIXES) 테스트.
+
+backend/config.py에 같은 목적의 화이트리스트가 별도로 존재한다(#130). 이 파일은
+NAT 쪽 접두사 규칙만 검증하고, 마지막 테스트에서만 backend.config를 가져와 두
+경로가 반드시 같이 움직여야 하는 최소 차원(KIS_ 네임스페이스)이 어긋나지
+않는지 확인한다.
+"""
+import sys
+from pathlib import Path
+
+# backend와 finus_nat은 별도 uv 프로젝트(별도 venv)라 기본적으로 서로의 패키지를
+# import할 수 없다. 마지막 테스트에서만 backend.config를 가져오기 위해 저장소
+# 루트를 sys.path에 추가한다 — backend/config.py는 dotenv·mcp만 있으면 되고
+# 둘 다 finus_nat venv에 이미 있다(nvidia-nat[mcp] 전이 의존성).
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+import backend.config as backend_config  # noqa: E402
+from nat_finus_nat.finus_api import _MCP_ENV_ALLOWED_PREFIXES, _mcp_child_env  # noqa: E402
+
+
+def test_mcp_child_env_forwards_kis_tr_id_overrides(monkeypatch):
+    # #130 — 이 수정 전에는 _MCP_ENV_ALLOWED_PREFIXES가 ("FIN_US_", "FINUS_")라
+    # KIS_TR_ID_DAILY_CCLD/KIS_TR_ID_BALANCE_RLZ_PL이 둘 중 어느 접두사에도
+    # 걸리지 않아 NAT 경로에서 조용히 빠졌다. NAT가 호출하는
+    # get_today_daily_orders/get_balance_rlz_pl(finus_api.py)이 정확히 이
+    # TR ID 오버라이드를 쓰는 도구들이라, 같은 .env로 backend 경로와 NAT
+    # 경로가 다른 TR ID를 쓰는 상황이 발생했다.
+    monkeypatch.setenv("KIS_TR_ID_DAILY_CCLD", "TTTC0081R")
+    monkeypatch.setenv("KIS_TR_ID_BALANCE_RLZ_PL", "TTTC8494R")
+
+    env = _mcp_child_env()
+
+    assert env["KIS_TR_ID_DAILY_CCLD"] == "TTTC0081R"
+    assert env["KIS_TR_ID_BALANCE_RLZ_PL"] == "TTTC8494R"
+
+
+def test_mcp_child_env_still_forwards_finus_kis_overrides(monkeypatch):
+    # 회귀 방지: 접두사 튜플에 "KIS_"를 추가한 것이 기존 "FINUS_" 매칭(FINUS_KIS_
+    # TR ID 오버라이드 포함)을 깨서는 안 된다.
+    monkeypatch.setenv("FINUS_KIS_TR_ID_DAILY_CCLD", "TTTC0081R")
+
+    env = _mcp_child_env()
+
+    assert env["FINUS_KIS_TR_ID_DAILY_CCLD"] == "TTTC0081R"
+
+
+def test_mcp_child_env_does_not_forward_backend_only_secret(monkeypatch):
+    # TELEGRAM_BOT_TOKEN: backend/config.py에 실재하는 값이고 mcp-trading·
+    # mcp-news·mcp-dart 중 어느 것도 읽지 않는 backend 전용 비밀값이다
+    # (backend/tests/test_config.py의 같은 단언과 동일 근거 — 임의의 더미가
+    # 아니라 경계가 무너지면 실제로 아픈 값을 고른다). KIS_/FINUS_/FIN_US_
+    # 어떤 접두사에도 걸리지 않으므로, 새로 넓힌 KIS_ 접두사가 여기까지
+    # 새지 않는지 고정한다.
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "telegram-secret")
+
+    env = _mcp_child_env()
+
+    assert "TELEGRAM_BOT_TOKEN" not in env
+
+
+def test_mcp_child_env_forwards_any_kis_prefixed_variable_by_mechanism(monkeypatch):
+    # backend/tests/test_config.py의 KIS_FUTURE_VARIABLE_NOT_YET_INVENTED와 같은
+    # 취지의 드리프트 방지 테스트. 존재한 적 없는 합성 변수명으로 "KIS_로
+    # 시작하면 통과한다"는 접두사 매칭 메커니즘 자체를 고정한다 — 이름을
+    # 나열하는 테스트라면 화이트리스트와 똑같은 방식으로 드리프트하지만, 이
+    # 테스트는 누군가 _MCP_ENV_ALLOWED_PREFIXES에서 "KIS_"를 빼거나 개별 키
+    # 나열로 되돌리면 이름 목록 갱신 없이도 즉시 실패한다.
+    monkeypatch.setenv("KIS_FUTURE_VARIABLE_NOT_YET_INVENTED", "future-value")
+
+    env = _mcp_child_env()
+
+    assert env["KIS_FUTURE_VARIABLE_NOT_YET_INVENTED"] == "future-value"
+
+
+def test_kis_namespace_prefix_is_present_on_both_backend_and_nat_paths():
+    # #130의 핵심은 "같은 목적의 화이트리스트 두 벌이 어긋난다"는 것이었다.
+    # 두 _MCP_ENV_ALLOWED_PREFIXES 튜플을 완전히 동일한지(==) 비교하지는
+    # 않는다 — backend는 FINUS_*를 FINUS_KIS_로 의도적으로 좁혀 FINUS_MEM0_*
+    # 등 backend/NAT 전용 변수가 새지 않게 막고, NAT는 이미 FINUS_ 전체를
+    # 넓게 허용한다(finus_api.py가 FINUS_BACKEND_URL 등도 스스로 쓰기
+    # 때문). 이 비대칭은 설계 의도이므로 완전 동일성 단언은 지금의 올바른
+    # 상태에서도 실패해 신호가 아니라 잡음이 된다.
+    #
+    # 대신 두 경로가 반드시 같이 움직여야 하는 유일한 차원 — 자식 프로세스
+    # (mcp-trading 등)가 공유하는 KIS_ 네임스페이스 자체 — 만 고정한다. 이후
+    # 누군가 한쪽에서만 "KIS_"를 빼면 이 단언이 즉시 잡아낸다.
+    assert "KIS_" in backend_config._MCP_ENV_ALLOWED_PREFIXES
+    assert "KIS_" in _MCP_ENV_ALLOWED_PREFIXES


### PR DESCRIPTION
Closes #129, #130

## 요약

MCP 자식 프로세스 env 화이트리스트를 개별 키 나열에서 접두사 규칙으로 바꿉니다.

```python
_MCP_ENV_ALLOWED_PREFIXES = ("FIN_US_", "FINUS_KIS_", "KIS_")
```

`KIS_TOKEN_CACHE_PATH`·`KIS_TR_ID_*`·`FINUS_KIS_TR_ID_*`·`KIS_REAL_ORDER_ENABLED` 누락이 한 번에 해소됩니다. 목록을 손으로 관리하는 한 다음 변수도 같은 방식으로 빠지기 때문입니다.

`FINUS_`로 넓히지 않고 `FINUS_KIS_`로 좁혔습니다. `finus_api.py`가 `FINUS_` 전체를 쓴다고 따라가면 `FINUS_MEM0_*`·`FINUS_BACKEND_URL`이 아무 이득 없이 자식으로 흘러갑니다.

## ⚠️ 기존 배포의 동작이 바뀝니다

`.env`에 `KIS_ORDER_ENV=real` + `KIS_REAL_ORDER_ENABLED=true`를 넣어둔 사용자는 backend 게이트(`telegram_commands.py`)를 이미 통과하고 있었고, **마지막 차단선이 이 버그였습니다.** 머지하면 같은 `.env`로 다음 배포부터 실제 자금이 움직입니다. 설정 변경 없이 동작이 바뀝니다.

#129가 의도한 동작이고 fail-closed 방향은 테스트로 고정돼 있지만, 대상이 금전 거래라 `.env.example`에 경고를 넣었습니다.

**다만 "지금까지 항상 차단됐다"는 것은 Docker 배포에서만 참입니다.** `mcp-trading/node_modules/dotenv/lib/main.js`의 `override`가 false라(`index.js`가 `{path}`만 넘김), 부모가 키를 보내지 않으면 자식이 **자기 `.env`를 직접 읽습니다.** `backend/config.py`의 `_TRADING_MCP_DIR` 기본값이 `<repo>/mcp-trading`이고 `index.js`가 `<repo>/.env`를 dotenv로 읽으므로, Docker를 쓰지 않는 로컬 실행에서는 `real` + `true` 사용자가 **이미 실주문을 내고 있었습니다.**

`.env.example` 문구가 이 구분을 담습니다. 노출된 적 없다고 안내할 뻔한 대상이 정확히 그 사용자들입니다.

## `KIS_REAL_ORDER_ENABLED` 판정을 양쪽에서 일치시켰습니다

backend는 `{1, true, yes, y}`를 대소문자 무관하게 받았고 `mcp-trading/index.js`는 `=== "true"` 엄격 비교였습니다. 값이 자식에 도달하지 않던 동안에는 이 불일치가 드러나지 않았습니다.

`KIS_REAL_ORDER_ENABLED=1`로 설정한 사용자는 backend 게이트를 통과해 주문 확인 플로우까지 진행한 뒤 자식에서 `실계좌 주문은 KIS_REAL_ORDER_ENABLED=true 설정이 필요합니다`로 실패합니다 — **#129가 신고한 증상과 글자 그대로 같은 메시지**입니다.

**자식 쪽으로 값을 정규화하는 대신 backend 게이트를 좁혔습니다.** 정규화는 닫는 방향이 반대입니다. `override:false` 때문에 정규화 이전에는 로컬 실행에서 자식이 원본 `"1"`을 읽어 차단됐는데, 정규화를 넣으면 부모가 `"true"`를 보내 `1`·`yes`·`y`·`YES`·`Y`가 **새로 활성화**됩니다. 어느 배포에서도 동작한 적 없던 철자들입니다.

`_is_truthy_flag`를 정확히 `"true"`만 인정하게 좁혔습니다. 지금 실주문이 되는 사용자는 영향받지 않고, 조용한 승격이 backend 단계의 명확한 거절로 바뀝니다. 두 기준이 실제로 같아지므로 자식에 넘길 때 값을 다시 쓸 필요가 없어 정규화 블록 자체가 사라졌습니다.

## 두 번째 화이트리스트

#130의 핵심은 "같은 목적의 화이트리스트 두 벌이 어긋난다"였는데, backend만 고치면 비대칭이 사라지는 게 아니라 방향만 뒤집힙니다. `finus_nat/src/nat_finus_nat/finus_api.py`에도 `KIS_`를 추가했습니다.

하필 NAT이 호출하는 도구가 정확히 그 TR ID를 쓰는 둘입니다 — `get_today_daily_orders`와 `get_balance_rlz_pl`. 고치지 않으면 `KIS_TR_ID_DAILY_CCLD`를 설정한 사용자가 텔레그램 조회에서는 오버라이드가 먹고 diary agent에서는 조용히 기본값으로 도는, 같은 `.env`에서 경로별로 다른 TR ID를 쓰는 상태가 됩니다.

NAT은 `place_order`를 호출하지 않아 실주문 안전성에는 영향이 없습니다(`grep -r place_order finus_nat` 결과 없음).

개별 `KIS_*` 키 5개도 함께 지웠습니다. 접두사가 이미 통과시키는데 목록에 남겨 두면 이 PR이 없애려는 열거 substrate가 유지되고, 다음 사람이 여섯 번째 키를 목록에 추가하게 됩니다.

## 테스트

231 → 246 (backend), 39 → 44 (finus_nat).

가장 중요한 것은 `KIS_FUTURE_VARIABLE_NOT_YET_INVENTED`입니다. 이름을 나열하는 테스트는 화이트리스트와 **같은 방식으로 드리프트**하므로, 한 번도 존재한 적 없는 변수명으로 메커니즘 자체를 고정합니다. 빠진 키 6개를 손으로 다 추가하고 접두사만 옛날 것으로 두면 이름 기반 테스트는 전부 통과하고 이것만 실패합니다.

두 화이트리스트 대조는 **`import` 대신 `ast`로 소스를 읽습니다.** `backend.config`를 import하면 `finus_nat/pyproject.toml`이 선언하지 않는 전이 의존성(`dotenv`·`mcp`)에 파일 전체의 수집이 묶이고, `backend/config.py`의 `load_dotenv()`가 import 시점에 실행되어 NAT 테스트 세션의 `os.environ`을 개발자의 실제 `.env`로 오염시킵니다. CI에는 `.env`가 없어 이 회귀는 CI에서 절대 드러나지 않습니다.

단언은 완전 동일성이 아니라 **포함 관계**입니다 — backend가 통과시키는 모든 접두사는 NAT 접두사 중 하나로 시작해야 합니다. `==`는 의도된 `FINUS_` 비대칭 때문에 지금의 올바른 상태에서도 실패해 신호가 아니라 잡음이 됩니다.

변형 검증:

| 변형 | 결과 |
| :--- | :--- |
| backend에 `BROKER_` 추가, NAT 누락 | 포함 관계 단언 red |
| NAT 접두사를 `("FIN_US_", "FINUS_")`로 되돌림 | 3건 red |
| `_is_truthy_flag`를 넓은 집합으로 되돌림 | 6건 red |
| `_MCP_ENV_ALLOWED_PREFIXES`에서 `KIS_` 제거 | 10건 red |
| 정규화 블록 삭제(이전 라운드) | 5건 red |

마지막 두 개가 의미 있습니다 — 열거 키를 지운 뒤로는 자격증명 전달 경로가 접두사 하나에만 의존하므로, 기존 테스트 둘이 그 경로를 양방향에서 고정합니다.

## 확인한 것

- `mcp/client/stdio/__init__.py`가 `server.env`를 `get_default_environment()` 위에 병합하는데, 그 기본값은 `os.environ`이 아니라 고정된 안전 부분집합(`DEFAULT_INHERITED_ENV_VARS`)입니다. 화이트리스트를 우회하는 경로가 없습니다.
- 저장소의 모든 `KIS_*` 변수를 열거해 backend 전용 비밀값이 없음을 확인했습니다. `KIS_ORDER_ENV`는 자식에서 읽히지 않습니다(`placeOrder`가 `args.order_env`를 씁니다).
- 접두사 방식은 deny-by-default를 allow-by-namespace로 바꿉니다. 앞으로 누군가 `KIS_WEBHOOK_SECRET` 같은 backend 전용 비밀에 이 접두사를 붙이면 자동으로 세 자식에 전달됩니다. `.env.example`의 KIS 섹션 머리말에 명시했습니다.

## 남긴 것

- ~~`README.md`~~ — #146이 머지되어 반영했습니다. 실계좌 주문 안내에 업그레이드 고지(Docker 한정으로 차단됐다는 구분 포함)와 `true` 철자 조건을 넣고, 「자주 겪는 문제」의 해당 항목에도 철자 안내를 추가했습니다.
- **NAT 경로의 `KIS_REAL_ORDER_ENABLED`** — `finus_api.py`는 값을 그대로 전달합니다. NAT이 읽기 전용 도구 셋만 등록하고 `place_order`가 도달 불가라 현재 위험이 없고 방향도 fail-closed이지만, NAT이 주문 도구를 갖게 되면 같은 부류의 문제가 됩니다.
