### PR TITLE
fix: 스케줄러가 잔고 연속조회 잘림을 감지하지 못하던 문제

### DIFF
--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -126,12 +126,17 @@ def extract_stocks_from_balance(balance_text: str) -> list[str]:
 # 상한")를 매칭 대상에 넣지 않아도 모든 현재·미래 사유를 잡는다. 사유별 문구까지
 # 매칭하면 새 사유가 추가될 때마다 이 목록도 함께 고쳐야 해서 더 잘 깨진다.
 #
+# 판별은 "조회가 중단되어" 하나로만 한다. "[안내]"는 mcp-trading/index.js:570의
+# 모의투자 실현손익 안내와도 공유하는 표지라 get_balance 밖에서도 등장할 수 있어
+# 판별력이 없고, 실제 discriminator는 잘림 문구에만 존재하는 이 접미사다. 고정할
+# 리터럴이 하나로 줄어 아래 결합 테스트도 이 한 줄만 지키면 된다.
+#
 # get_balance는 MCP 텍스트 응답만 backend로 넘어오고 truncated 값 자체(구조화된
 # 필드)는 MCP 경계를 넘어오지 않으므로, 이 함수는 문자열 매칭에 의존할 수밖에
 # 없다. mcp-trading/balance.js의 리터럴이 바뀌면 이 매칭도 함께 깨진다 — 그
-# 결합을 backend/tests/test_balance_parser.py의 관련 테스트가 명시적으로 고정한다.
-_BALANCE_TRUNCATION_MARKER = "[안내]"
-_BALANCE_TRUNCATION_SUFFIX = "조회가 중단되어"
+# 결합을 mcp-trading/tests/order.test.js의 잘림 노트 테스트가 `조회가 중단되어`를
+# 직접 단언해 고정하고, backend/tests/test_balance_parser.py가 픽스처로 재현한다.
+_BALANCE_TRUNCATION_MARKER = "조회가 중단되어"
 
 
 def is_balance_truncated(balance_text: str) -> bool:
@@ -140,10 +145,7 @@ def is_balance_truncated(balance_text: str) -> bool:
     extract_stocks_from_balance()는 이 문구를 의도적으로 무시하므로(안내 문구가
     종목명으로 오인식되지 않도록), 잘림 여부는 이 함수로 별도 확인해야 한다.
     """
-    return (
-        _BALANCE_TRUNCATION_MARKER in balance_text
-        and _BALANCE_TRUNCATION_SUFFIX in balance_text
-    )
+    return _BALANCE_TRUNCATION_MARKER in balance_text
 
 
 def _infer_catalyst_event_type(description: str) -> str:
@@ -361,9 +363,21 @@ async def _monitor_market_task(
         owned_stocks = extract_stocks_from_balance(balance_text)
 
         if is_balance_truncated(balance_text):
+            # 잘림 사유(max_pages/time_budget/error/...)마다 운영 대응이 다르므로,
+            # 안내 문구 줄을 그대로 실어 사유가 로그에 남게 한다. 사유 문자열을 따로
+            # 파싱하지 않으므로 balance.js에 새 사유가 추가돼도 자동으로 따라간다.
+            notice = next(
+                (
+                    line
+                    for line in balance_text.splitlines()
+                    if _BALANCE_TRUNCATION_MARKER in line
+                ),
+                "",
+            )
             logger.warning(
-                "잔고 연속조회가 잘려 감시 대상이 불완전할 수 있습니다: 보유 종목 %d건만 확보",
+                "잔고 연속조회가 잘려 감시 대상이 불완전할 수 있습니다: 보유 종목 %d건만 확보 — %s",
                 len(owned_stocks),
+                notice.strip(),
             )
 
         if watchlist_repo is None:

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -117,6 +117,35 @@ def extract_stocks_from_balance(balance_text: str) -> list[str]:
     return stocks
 
 
+# mcp-trading/balance.js의 formatTruncationNote()가 잘림 시 항상 덧붙이는 문구 중,
+# truncated 사유(max_pages/time_budget/no_cursor/repeated_cursor/error, 그리고
+# 목록에 없는 사유의 fallback "연속조회가 완료되지 않아")에 관계없이 고정으로 남는
+# 부분만 매칭한다:
+#   `\n\n[안내] ${reason} 조회가 중단되어 일부 보유 종목이 위 목록에서 ...`
+# ${reason}만 사유별로 바뀌고 앞뒤 리터럴은 고정이므로, 사유 문구 자체(예: "페이지
+# 상한")를 매칭 대상에 넣지 않아도 모든 현재·미래 사유를 잡는다. 사유별 문구까지
+# 매칭하면 새 사유가 추가될 때마다 이 목록도 함께 고쳐야 해서 더 잘 깨진다.
+#
+# get_balance는 MCP 텍스트 응답만 backend로 넘어오고 truncated 값 자체(구조화된
+# 필드)는 MCP 경계를 넘어오지 않으므로, 이 함수는 문자열 매칭에 의존할 수밖에
+# 없다. mcp-trading/balance.js의 리터럴이 바뀌면 이 매칭도 함께 깨진다 — 그
+# 결합을 backend/tests/test_balance_parser.py의 관련 테스트가 명시적으로 고정한다.
+_BALANCE_TRUNCATION_MARKER = "[안내]"
+_BALANCE_TRUNCATION_SUFFIX = "조회가 중단되어"
+
+
+def is_balance_truncated(balance_text: str) -> bool:
+    """get_balance 응답에 mcp-trading/balance.js의 잘림 안내 문구가 포함되어 있는지 확인합니다.
+
+    extract_stocks_from_balance()는 이 문구를 의도적으로 무시하므로(안내 문구가
+    종목명으로 오인식되지 않도록), 잘림 여부는 이 함수로 별도 확인해야 한다.
+    """
+    return (
+        _BALANCE_TRUNCATION_MARKER in balance_text
+        and _BALANCE_TRUNCATION_SUFFIX in balance_text
+    )
+
+
 def _infer_catalyst_event_type(description: str) -> str:
     text = description.lower()
     if any(keyword in description for keyword in ("실적", "분기보고서", "반기보고서", "사업보고서")):
@@ -330,6 +359,12 @@ async def _monitor_market_task(
         # 1. 실시간 잔고 조회 및 모니터링 대상 확정
         balance_text = await run_mcp_tool(TRADING_MCP_PARAMS, "get_balance", {})
         owned_stocks = extract_stocks_from_balance(balance_text)
+
+        if is_balance_truncated(balance_text):
+            logger.warning(
+                "잔고 연속조회가 잘려 감시 대상이 불완전할 수 있습니다: 보유 종목 %d건만 확보",
+                len(owned_stocks),
+            )
 
         if watchlist_repo is None:
             watchlist_repo = SqliteWatchlistRepo(lambda: Session(engine))

--- a/backend/tests/test_balance_parser.py
+++ b/backend/tests/test_balance_parser.py
@@ -5,7 +5,7 @@ mcp-trading/data/stocks.json`으로 직접 확인할 수 있다.
 """
 
 import unittest
-from backend.scheduler import extract_stocks_from_balance
+from backend.scheduler import extract_stocks_from_balance, is_balance_truncated
 
 # 아래 픽스처는 mcp-trading/balance.js의 formatBalanceReport()가 실제로 생성하는
 # 문자열을 그대로 재현한 것입니다. 근거(줄 번호 대신 심볼/테스트명으로 고정 — 이 저장소
@@ -169,6 +169,77 @@ class TestBalanceExtraction(unittest.TestCase):
         balance_text = "[보유 종목 리스트]\r\n- 삼성전자 (005930) · 3주\r\n  평단가 67,000원 → 평가금액 210,000원\r\n  손익 +9,000원 · 수익률 🔴 ▲ +4.48%"
         result = extract_stocks_from_balance(balance_text)
         self.assertEqual(result, ["삼성전자"])
+
+# 아래 픽스처는 mcp-trading/balance.js의 formatTruncationNote()가 실제로 만드는 문구를
+# 그대로 재현한 것입니다(이슈 #136). 근거:
+#   - 생성부: mcp-trading/balance.js 의 formatTruncationNote() — 사유별 reasons 맵과
+#     고정 접두/접미 리터럴("[안내] " / " 조회가 중단되어 일부 보유 종목이 위 목록에서
+#     누락되었을 수 있습니다. 실제 잔고는 별도로 확인하세요.")
+#   - 검증부: mcp-trading/tests/order.test.js 의 truncation note 관련 테스트들
+# formatTruncationNote()의 reasons 맵이나 고정 리터럴을 바꾸면 이 픽스처들과
+# is_balance_truncated()의 매칭 대상 문자열(backend/scheduler.py의
+# _BALANCE_TRUNCATION_MARKER/_BALANCE_TRUNCATION_SUFFIX) 양쪽을 함께 검토해야 합니다.
+TRUNCATION_NOTES_BY_REASON = {
+    "max_pages": "\n\n[안내] 페이지 상한(20회)에 도달하여 조회가 중단되어 일부 보유 종목이 위 목록에서 누락되었을 수 있습니다. 실제 잔고는 별도로 확인하세요.",
+    "time_budget": "\n\n[안내] 조회 시간 예산을 초과하여 조회가 중단되어 일부 보유 종목이 위 목록에서 누락되었을 수 있습니다. 실제 잔고는 별도로 확인하세요.",
+    "no_cursor": "\n\n[안내] 연속조회 커서가 오지 않아 조회가 중단되어 일부 보유 종목이 위 목록에서 누락되었을 수 있습니다. 실제 잔고는 별도로 확인하세요.",
+    "repeated_cursor": "\n\n[안내] 동일한 연속조회 커서가 반복되어 조회가 중단되어 일부 보유 종목이 위 목록에서 누락되었을 수 있습니다. 실제 잔고는 별도로 확인하세요.",
+    "error": "\n\n[안내] 연속조회 중 오류가 발생하여 조회가 중단되어 일부 보유 종목이 위 목록에서 누락되었을 수 있습니다. 실제 잔고는 별도로 확인하세요.",
+    # reasons 맵에 없는 사유(향후 추가될 수 있는 값)에 대한 fallback 문구.
+    "__unknown__": "\n\n[안내] 연속조회가 완료되지 않아 조회가 중단되어 일부 보유 종목이 위 목록에서 누락되었을 수 있습니다. 실제 잔고는 별도로 확인하세요.",
+}
+
+
+class TestBalanceTruncationDetection(unittest.TestCase):
+    """이슈 #136: 스케줄러가 잔고 연속조회 잘림을 감지하는 is_balance_truncated()를 검증합니다."""
+
+    def test_detects_every_known_truncation_reason(self):
+        """balance.js의 모든 truncated 사유(및 목록에 없는 사유의 fallback)에서
+        True를 반환하는지 확인합니다. 사유별 reason 문구가 아니라 고정 접두/접미
+        리터럴만 매칭하므로, 새 사유가 reasons 맵에 추가되어도 이 테스트는
+        코드 변경 없이 계속 통과해야 합니다.
+        """
+        for reason, note in TRUNCATION_NOTES_BY_REASON.items():
+            balance_text = (
+                "[보유 종목 리스트]\n"
+                "- 삼성전자 (005930) · 3주\n"
+                "  평단가 67,000원 → 평가금액 210,000원\n"
+                "  손익 +9,000원 · 수익률 🔴 ▲ +4.48%" + note
+            )
+            with self.subTest(reason=reason):
+                self.assertTrue(is_balance_truncated(balance_text))
+
+    def test_returns_false_for_untruncated_response(self):
+        """잘리지 않은 정상 응답(REAL_BALANCE_TEXT)에서는 False를 반환해, 매 주기마다
+        불필요한 경고가 울리지 않는지("늑대가 왔다" 오탐 방지) 확인합니다.
+        """
+        self.assertFalse(is_balance_truncated(REAL_BALANCE_TEXT))
+
+    def test_returns_false_for_text_without_notice(self):
+        balance_text = "일반 텍스트"
+        self.assertFalse(is_balance_truncated(balance_text))
+
+    def test_truncation_notice_is_not_extracted_as_a_stock(self):
+        """실제 스케줄러 흐름을 재현합니다: 잘림이 발생하면 balance_text 하나에 보유
+        종목 목록과 [안내] 잘림 문구가 함께 들어옵니다. is_balance_truncated()가
+        True를 반환하는 동시에, extract_stocks_from_balance()는 그 문구를 절대
+        종목명으로 추출하면 안 됩니다(둘 다 확인해야 [안내] 문구가 종목 목록에
+        섞여 들어가는 회귀를 잡을 수 있습니다).
+        """
+        balance_text = (
+            "[보유 종목 리스트]\n"
+            "- 삼성전자 (005930) · 3주\n"
+            "  평단가 67,000원 → 평가금액 210,000원\n"
+            "  손익 +9,000원 · 수익률 🔴 ▲ +4.48%"
+            + TRUNCATION_NOTES_BY_REASON["max_pages"]
+        )
+
+        self.assertTrue(is_balance_truncated(balance_text))
+        stocks = extract_stocks_from_balance(balance_text)
+        self.assertEqual(stocks, ["삼성전자"])
+        self.assertNotIn("[안내]", stocks)
+        self.assertTrue(all("[안내]" not in s for s in stocks))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_balance_parser.py
+++ b/backend/tests/test_balance_parser.py
@@ -175,10 +175,13 @@ class TestBalanceExtraction(unittest.TestCase):
 #   - 생성부: mcp-trading/balance.js 의 formatTruncationNote() — 사유별 reasons 맵과
 #     고정 접두/접미 리터럴("[안내] " / " 조회가 중단되어 일부 보유 종목이 위 목록에서
 #     누락되었을 수 있습니다. 실제 잔고는 별도로 확인하세요.")
-#   - 검증부: mcp-trading/tests/order.test.js 의 truncation note 관련 테스트들
+#   - 결합 고정부: mcp-trading/tests/order.test.js 의 잘림 노트 테스트가
+#     `assert.match(text, /조회가 중단되어/)`로 이 리터럴을 직접 단언한다. 이 픽스처는
+#     JS 출력을 손으로 베낀 사본이라 그 자체로는 드리프트를 못 잡지만(JS가 바뀌어도
+#     통과), JS 쪽 단언이 리터럴을 고정하므로 결합이 실제로 깨진다.
 # formatTruncationNote()의 reasons 맵이나 고정 리터럴을 바꾸면 이 픽스처들과
 # is_balance_truncated()의 매칭 대상 문자열(backend/scheduler.py의
-# _BALANCE_TRUNCATION_MARKER/_BALANCE_TRUNCATION_SUFFIX) 양쪽을 함께 검토해야 합니다.
+# _BALANCE_TRUNCATION_MARKER)을 함께 검토해야 합니다.
 TRUNCATION_NOTES_BY_REASON = {
     "max_pages": "\n\n[안내] 페이지 상한(20회)에 도달하여 조회가 중단되어 일부 보유 종목이 위 목록에서 누락되었을 수 있습니다. 실제 잔고는 별도로 확인하세요.",
     "time_budget": "\n\n[안내] 조회 시간 예산을 초과하여 조회가 중단되어 일부 보유 종목이 위 목록에서 누락되었을 수 있습니다. 실제 잔고는 별도로 확인하세요.",
@@ -237,8 +240,6 @@ class TestBalanceTruncationDetection(unittest.TestCase):
         self.assertTrue(is_balance_truncated(balance_text))
         stocks = extract_stocks_from_balance(balance_text)
         self.assertEqual(stocks, ["삼성전자"])
-        self.assertNotIn("[안내]", stocks)
-        self.assertTrue(all("[안내]" not in s for s in stocks))
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 from unittest.mock import MagicMock
 from ..main import app
 from ..redis_state import RedisSchedulerState
+from .test_balance_parser import TRUNCATION_NOTES_BY_REASON
 
 
 class FakeWatchlistRepo:
@@ -998,15 +999,14 @@ def test_start_scheduler_registers_catalyst_calendar_job(monkeypatch):
     assert "catalyst_calendar" in job_ids
 
 
-# mcp-trading/balance.js의 formatTruncationNote()가 truncated="max_pages"일 때
-# 실제로 만드는 문구(reasons.max_pages + 고정 접미사)를 그대로 재현한 것입니다.
-# (이슈 #136) 이 문구가 [보유 종목 리스트] 뒤에 그대로 붙어 오는 것이 스케줄러가
-# 실제로 받는 balance_text 형태입니다.
+# mcp-trading/balance.js의 잘림 안내 문구는 test_balance_parser.py가 이미 사유별로
+# 재현해 두었으므로(TRUNCATION_NOTES_BY_REASON), 여기서 다시 베끼지 않고 재사용한다.
+# 같은 JS 리터럴이 Python 두 곳에 복사되면 한쪽만 갱신되는 드리프트가 생긴다(이슈 #136).
+# 이 문구가 [보유 종목 리스트] 뒤에 그대로 붙어 오는 것이 스케줄러가 받는 형태다.
 TRUNCATED_BALANCE_TEXT = (
     "[보유 종목 리스트]\n"
-    "- 삼성전자 (005930): 10주\n\n"
-    "[안내] 페이지 상한(20회)에 도달하여 조회가 중단되어 일부 보유 종목이 위 목록에서"
-    " 누락되었을 수 있습니다. 실제 잔고는 별도로 확인하세요."
+    "- 삼성전자 (005930): 10주"
+    + TRUNCATION_NOTES_BY_REASON["max_pages"]
 )
 
 
@@ -1068,9 +1068,12 @@ async def test_monitor_market_task_no_warning_when_balance_not_truncated(monkeyp
     async def fake_redis_state():
         yield state
 
+    monitored_stocks = []
+
     async def mock_run_mcp_tool(params, name, args):
         if name == "get_balance":
             return "[보유 종목 리스트]\n- 삼성전자 (005930): 10주"
+        monitored_stocks.append(args["stock_name"])
         return "news"
 
     async def mock_check_significance(stock, current, last, *, source, provider):
@@ -1089,6 +1092,7 @@ async def test_monitor_market_task_no_warning_when_balance_not_truncated(monkeyp
         await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
 
     assert "잔고 연속조회가 잘려" not in caplog.text
+    assert monitored_stocks == ["삼성전자"]  # 정상 경로를 끝까지 지났음을 함께 고정
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -996,3 +996,137 @@ def test_start_scheduler_registers_catalyst_calendar_job(monkeypatch):
 
     job_ids = [kwargs["id"] for _args, kwargs in added_jobs]
     assert "catalyst_calendar" in job_ids
+
+
+# mcp-trading/balance.js의 formatTruncationNote()가 truncated="max_pages"일 때
+# 실제로 만드는 문구(reasons.max_pages + 고정 접미사)를 그대로 재현한 것입니다.
+# (이슈 #136) 이 문구가 [보유 종목 리스트] 뒤에 그대로 붙어 오는 것이 스케줄러가
+# 실제로 받는 balance_text 형태입니다.
+TRUNCATED_BALANCE_TEXT = (
+    "[보유 종목 리스트]\n"
+    "- 삼성전자 (005930): 10주\n\n"
+    "[안내] 페이지 상한(20회)에 도달하여 조회가 중단되어 일부 보유 종목이 위 목록에서"
+    " 누락되었을 수 있습니다. 실제 잔고는 별도로 확인하세요."
+)
+
+
+@pytest.mark.asyncio
+async def test_monitor_market_task_logs_warning_when_balance_truncated(monkeypatch, caplog):
+    """잔고 연속조회가 잘리면 스케줄러가 경고 로그를 남깁니다 (이슈 #136).
+
+    이 테스트가 잡는 mutation: _monitor_market_task에서 is_balance_truncated() 호출과
+    logger.warning()을 통째로 빠뜨리거나, 조건을 뒤집는(예: `if not is_balance_truncated(...)`)
+    변경. origin/main에는 이 경고 자체가 없으므로 origin/main 기준으로는 반드시 실패한다.
+    """
+    import logging
+    from .. import scheduler as scheduler_module
+    from ..scheduler import SignalSource, monitor_market_task
+
+    state = RedisSchedulerState(FakeRedis())
+
+    @asynccontextmanager
+    async def fake_redis_state():
+        yield state
+
+    async def mock_run_mcp_tool(params, name, args):
+        if name == "get_balance":
+            return TRUNCATED_BALANCE_TEXT
+        return "news"
+
+    async def mock_check_significance(stock, current, last, *, source, provider):
+        return False
+
+    monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
+    monkeypatch.setattr(
+        "backend.scheduler.SIGNAL_SOURCES",
+        [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
+    )
+    monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
+    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", MagicMock(return_value=asyncio.Future()))
+
+    with caplog.at_level(logging.WARNING, logger=scheduler_module.logger.name):
+        await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
+
+    assert "잔고 연속조회가 잘려" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_monitor_market_task_no_warning_when_balance_not_truncated(monkeypatch, caplog):
+    """정상(잘리지 않은) 잔고 응답에서는 매 10분 주기마다 경고가 울리지 않습니다 (이슈 #136).
+
+    이 테스트가 잡는 mutation: is_balance_truncated()가 항상 True를 반환하도록 뒤집히거나,
+    logger.warning()이 조건 없이 항상 호출되는 회귀("늑대가 왔다" 오탐/알림 피로).
+    """
+    import logging
+    from .. import scheduler as scheduler_module
+    from ..scheduler import SignalSource, monitor_market_task
+
+    state = RedisSchedulerState(FakeRedis())
+
+    @asynccontextmanager
+    async def fake_redis_state():
+        yield state
+
+    async def mock_run_mcp_tool(params, name, args):
+        if name == "get_balance":
+            return "[보유 종목 리스트]\n- 삼성전자 (005930): 10주"
+        return "news"
+
+    async def mock_check_significance(stock, current, last, *, source, provider):
+        return False
+
+    monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
+    monkeypatch.setattr(
+        "backend.scheduler.SIGNAL_SOURCES",
+        [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
+    )
+    monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
+    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", MagicMock(return_value=asyncio.Future()))
+
+    with caplog.at_level(logging.WARNING, logger=scheduler_module.logger.name):
+        await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
+
+    assert "잔고 연속조회가 잘려" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_monitor_market_task_still_watches_stocks_returned_despite_truncation(monkeypatch):
+    """잔고 연속조회가 잘려도, 잘리기 전에 이미 확보한 보유 종목은 계속 감시합니다 (이슈 #136).
+
+    잘림은 감시를 "성능 저하(degrade)"시켜야지 "중단(disable)"시켜서는 안 된다는
+    수용 기준을 고정한다. 이 테스트가 잡는 mutation: 잘림 감지 시 owned_stocks를
+    비우거나 stocks_to_monitor 조립을 통째로 건너뛰는 회귀.
+    """
+    from ..scheduler import SignalSource, monitor_market_task
+
+    state = RedisSchedulerState(FakeRedis())
+
+    @asynccontextmanager
+    async def fake_redis_state():
+        yield state
+
+    monitored_stocks = []
+
+    async def mock_run_mcp_tool(params, name, args):
+        if name == "get_balance":
+            return TRUNCATED_BALANCE_TEXT
+        monitored_stocks.append(args["stock_name"])
+        return "news"
+
+    async def mock_check_significance(stock, current, last, *, source, provider):
+        return False
+
+    monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
+    monkeypatch.setattr(
+        "backend.scheduler.SIGNAL_SOURCES",
+        [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
+    )
+    monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
+    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", MagicMock(return_value=asyncio.Future()))
+
+    await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
+
+    assert monitored_stocks == ["삼성전자"]

--- a/mcp-trading/balance.js
+++ b/mcp-trading/balance.js
@@ -226,6 +226,10 @@ function calculateAccountReturnRate(summary, holdings) {
 // 잘림 안내 문구. 주의: "- "로 시작하면 backend/scheduler.py의 extract_stocks_from_balance()가
 // [보유 종목 리스트] 섹션의 "- "로 시작하는 줄을 종목명으로 오인식한다. 이 문구는 반드시
 // "- " 없이, [보유 종목 리스트] 섹션이 끝난 뒤 별도 문단으로만 붙여야 한다.
+//
+// 또한 backend/scheduler.py의 is_balance_truncated()가 아래 "조회가 중단되어" 리터럴을
+// 문자열 매칭해 잘림을 감지한다. 이 문구를 바꾸면 backend 감지가 조용히 무력화되므로,
+// 같은 파일 tests/order.test.js의 잘림 노트 테스트가 이 리터럴을 직접 단언해 고정한다.
 function formatTruncationNote(truncated, pages) {
   if (!truncated) return "";
   const reasons = {

--- a/mcp-trading/tests/order.test.js
+++ b/mcp-trading/tests/order.test.js
@@ -526,6 +526,10 @@ test("formatBalanceReport's truncation note stays outside the holdings section s
   );
 
   assert.match(text, /\[안내\] 페이지 상한\(20회\)에 도달하여/);
+  // backend/scheduler.py의 is_balance_truncated()가 이 "조회가 중단되어" 리터럴을
+  // 문자열 매칭해 잘림을 감지한다. balance.js 문구를 다듬으면 backend 감지가 조용히
+  // 무력화되므로(양쪽 테스트가 통과한 채 프로덕션만 회귀), 여기서 함께 깨지도록 고정한다.
+  assert.match(text, /조회가 중단되어/);
 
   // Mirror backend/scheduler.py's extract_stocks_from_balance(): everything after
   // "[보유 종목 리스트]", split into lines, keep only lines starting with "- ".
@@ -557,6 +561,7 @@ test("formatBalanceReport's no_cursor, error, and repeated_cursor truncation not
     );
 
     assert.match(text, /\[안내\]/);
+    assert.match(text, /조회가 중단되어/);
 
     // Mirror backend/scheduler.py's extract_stocks_from_balance(): everything after
     // "[보유 종목 리스트]", split into lines, keep only lines starting with "- ".


### PR DESCRIPTION
Closes #136

## 문제

`get_balance`의 연속조회가 상한에 걸려 잘리면 그 사실이 반환 텍스트에는 표시되지만, **스케줄러는 이를 읽지 않습니다.**

```python
balance_text = await run_mcp_tool(TRADING_MCP_PARAMS, "get_balance", {})
owned_stocks = extract_stocks_from_balance(balance_text)
```

`extract_stocks_from_balance()`는 `[보유 종목 리스트]` 이후의 `- ` 시작 줄만 파싱하므로 `[안내]` 잘림 문구를 무시합니다. 이건 의도된 설계입니다 — 그 문구가 `- `로 시작하면 종목명으로 오인식되기 때문입니다.

결과적으로 `owned_stocks`가 불완전해도 감시 대상 합산이 아무 경고 없이 진행됩니다. 페이지 상한(20)이나 시간 예산(15초)을 넘긴 계좌는 일부 보유 종목이 10분 주기 뉴스·공시 감시에서 계속 제외되고, 운영자가 알아챌 방법이 없습니다.

#121이 지목한 "누락 사실이 알려지지 않는다"는 `/balance`와 모닝 브리핑에서는 #131로 해소됐지만 스케줄러 경로에는 그대로 남아 있었습니다.

## 변경

**검출을 파서 안이 아니라 호출부에 두었습니다.** `is_balance_truncated()`를 파서 옆에 별도 술어로 추가하고 `_monitor_market_task`에서 한 번 호출합니다.

`extract_stocks_from_balance`는 호출자가 하나뿐이지만 기존 테스트 10건이 `list[str]` 계약을 고정하고 있습니다. 잘림까지 함께 반환하도록 넓히면 파싱과 무관한 관심사(표면화) 때문에 모든 호출자와 테스트가 새 형태를 풀어야 합니다. 두 함수를 각각 단일 목적으로 두고 독립적으로 테스트하는 편이 낫다고 봤습니다.

**사유별 문구가 아니라 고정 리터럴로 매칭합니다.**

```js
// mcp-trading/balance.js:239
return `\n\n[안내] ${reason} 조회가 중단되어 일부 보유 종목이 위 목록에서 누락되었을 수 있습니다. ...`;
```

`truncated`는 실제로 다섯 가지입니다 — `max_pages`·`time_budget`·`no_cursor`·`repeated_cursor`·`error`, 그리고 목록에 없는 값의 fallback. `${reason}`만 바뀌고 앞뒤는 고정이므로 `[안내]`와 `조회가 중단되어` 두 조각만 봅니다. 사유 문구("페이지 상한" 등)를 매칭에 넣으면 여섯 번째 사유가 추가될 때마다 이쪽도 함께 고쳐야 합니다.

**두 조각을 AND로 묶은 이유가 있습니다.** `[안내]`는 유일하지 않습니다 — `mcp-trading/index.js:570`이 모의투자 계좌의 실현손익 TR 미지원 안내에 같은 표지를 씁니다. `조회가 중단되어`는 잘림 문구에만 있습니다. 스케줄러가 `get_balance_rlz_pl`을 파싱하지는 않지만, 한쪽만 보면 그 구분이 우연에 기대게 됩니다.

**경계를 넘는 문자열 결합을 테스트로 고정했습니다.** `truncated` 값 자체는 MCP 경계를 넘어오지 않고 텍스트 응답만 넘어오므로 문자열 매칭이 불가피합니다. `backend/tests/test_balance_parser.py`가 `formatTruncationNote()`의 실제 출력을 다섯 사유 + fallback 전부에 대해 그대로 옮겨 담고 각각 `True`가 나오는지 단언합니다. 같은 파일의 기존 관례(`REAL_BALANCE_TEXT`가 `formatBalanceReport()`에 대해 하는 것)를 따랐습니다.

**로그만 남기고 Telegram은 보내지 않습니다.** 잘림이 지속되는 계좌는 10분 주기마다 조건이 성립하므로, 매 주기 알림은 소음입니다. 이슈의 예상 동작도 로그 가시성까지만 요구합니다.

## 검증

231 → 238 passed. 변형 4종 전부 잡혔습니다.

| 변형 | 잡은 테스트 |
| :--- | :--- |
| 검출 자체 없음 (`origin/main`) | 경고 테스트 실패 + `is_balance_truncated` import 실패 |
| suffix 상수를 엉뚱한 값으로 | 사유 6종 전수 테스트, 안내 문구 오인식 테스트, 경고 테스트 |
| 항상 경고 (`if True`) | 잘리지 않은 응답에 경고 없음 테스트 |
| 잘리면 감시 비활성화 (`owned_stocks = []`) | 반환된 종목은 계속 감시하는지 테스트 |

마지막 변형이 중요합니다 — 잘림은 **저하이지 중단이 아니어야** 합니다. 받아온 종목까지 버리면 잘림 검출이 오히려 감시를 더 줄입니다.

## 범위 밖

- `mcp-trading/`은 건드리지 않았습니다. 구조화된 `truncated` 필드를 MCP 경계 너머로 전달하면 문자열 결합이 사라지지만, 그건 응답 스키마 변경이라 별건입니다.
- `README.md`도 건드리지 않았습니다 — 열린 PR 두 건이 같은 파일을 수정 중입니다.
