### PR TITLE
test: kisOrderPost 분리로 주문 제출 플래그 경계 고정

### DIFF
--- a/mcp-trading/index.js
+++ b/mcp-trading/index.js
@@ -16,6 +16,7 @@ import {
   formatWon,
   isPaperTradingKisUrl,
 } from "./formatters.js";
+import { kisOrderPost } from "./kis-client.js";
 import {
   OrderDedupStore,
   createOrderDedupKey,
@@ -208,65 +209,6 @@ function formatOrderTime(value) {
   return `${text.slice(0, 2)}:${text.slice(2, 4)}:${text.slice(4, 6)}`;
 }
 
-async function createKisHashKey(body) {
-  const response = await kisAxios.post(`${KIS_URL}/uapi/hashkey`, body, {
-    headers: {
-      "Content-Type": "application/json",
-      appkey: KIS_API_KEY,
-      appsecret: KIS_API_SECRET,
-    },
-  });
-  const hashKey = response.data?.HASH;
-  if (!hashKey) {
-    throw new Error("KIS hashkey 발급 실패");
-  }
-  return hashKey;
-}
-
-async function kisPost(pathname, trId, body, { useHashKey = false } = {}) {
-  // 이 블록(토큰 발급, 필요 시 해시키 발급)이 던지는 오류는 아래 실제 주문 POST가 아직
-  // 나가기 전에 발생한 것이므로, 주문이 KIS에 제출되지 않았음이 확실하다.
-  let token;
-  let hashKey;
-  try {
-    token = await getAccessToken();
-    if (useHashKey) {
-      hashKey = await createKisHashKey(body);
-    }
-  } catch (error) {
-    error.kisOrderNotSubmitted = true;
-    throw error;
-  }
-
-  const headers = {
-    "Content-Type": "application/json",
-    authorization: `Bearer ${token}`,
-    appkey: KIS_API_KEY,
-    appsecret: KIS_API_SECRET,
-    tr_id: trId,
-    custtype: "P",
-  };
-  if (useHashKey) {
-    headers.hashkey = hashKey;
-  }
-
-  let response;
-  try {
-    response = await kisAxios.post(`${KIS_URL}${pathname}`, body, { headers });
-  } catch (error) {
-    error.kisOrderSubmittedMaybe = true;
-    throw error;
-  }
-
-  const data = response.data;
-  if (data.rt_cd !== "0") {
-    const error = new Error(`KIS API 오류: ${data.msg1 || data.msg_cd || "알 수 없는 오류"}`);
-    error.kisOrderRejected = true;
-    throw error;
-  }
-  return data;
-}
-
 async function getStockQuote(stockName) {
   const stock = resolveStock(stockName);
   const data = await kisGet(
@@ -376,7 +318,17 @@ async function placeOrder(args) {
   const data = await submitOrder({
     dedupStore: orderDedupStore,
     dedupKey,
-    submit: () => kisPost(request.pathname, request.trId, request.body, { useHashKey: true }),
+    submit: () => kisOrderPost({
+      kisAxios,
+      kisUrl: KIS_URL,
+      appKey: KIS_API_KEY,
+      appSecret: KIS_API_SECRET,
+      pathname: request.pathname,
+      trId: request.trId,
+      body: request.body,
+      useHashKey: true,
+      getAccessToken,
+    }),
   });
   return formatOrderResult({
     stockName,

--- a/mcp-trading/kis-client.js
+++ b/mcp-trading/kis-client.js
@@ -1,0 +1,97 @@
+// index.js는 부작용을 가진 서버 진입점이라 여기서 import하지 않는다(balance.js:17,
+// order-submit.js:1-3와 동일한 컨벤션) — 이 파일도 그래서 index.js 밖으로 분리했다.
+//
+// #163: kisPost(주문 제출 HTTP POST)가 export되지 않아 이 함수가 던지는 세 가지 플래그
+// (kisOrderNotSubmitted / kisOrderSubmittedMaybe / kisOrderRejected) — order-submit.js:17의
+// 중복 주문 가드 해제 여부를 좌우하는 그 경계 — 를 고정하는 테스트가 하나도 없었다. 여기로
+// 옮기고 kisAxios 인스턴스를 주입받게 해서, 실제 네트워크 없이 세 갈래 분류를 테스트할 수
+// 있게 한다.
+//
+// getAccessToken(토큰 캐시 포함, index.js)은 kisGet/kisApiGet 조회 경로와도 공유되고 파일
+// 캐시라는 별개 관심사를 안고 있어 여기로 옮기지 않고 함수로 주입받는다 — 이 경계가 실제로
+// 신경 쓰는 것은 "pre-flight가 실패했는가"이지 "왜 실패했는가"가 아니다.
+
+async function createKisHashKey({ kisAxios, kisUrl, appKey, appSecret, body }) {
+  const response = await kisAxios.post(`${kisUrl}/uapi/hashkey`, body, {
+    headers: {
+      "Content-Type": "application/json",
+      appkey: appKey,
+      appsecret: appSecret,
+    },
+  });
+  const hashKey = response.data?.HASH;
+  if (!hashKey) {
+    throw new Error("KIS hashkey 발급 실패");
+  }
+  return hashKey;
+}
+
+// 주문 제출 전용 POST. 호출자는 정확히 하나(index.js의 place_order 경로)이고 플래그를 읽는
+// 곳도 order-submit.js 하나뿐이다. 읽기 전용 도구는 전부 kisGet/kisApiGet을 쓰므로, 다음에
+// 읽기 전용 POST 도구(예: 주문 정정·취소 조회가 아닌 별도 POST)를 추가할 사람이 범용 이름에
+// 이끌려 이 함수를 재사용해 주문 제출 시맨틱(중복 방지 가드 해제 판정)을 그대로 물려받지
+// 않도록 kisOrderPost로 이름 붙였다.
+export async function kisOrderPost({
+  kisAxios,
+  kisUrl,
+  appKey,
+  appSecret,
+  pathname,
+  trId,
+  body,
+  useHashKey = false,
+  getAccessToken,
+}) {
+  // 이 블록(토큰 발급, 필요 시 해시키 발급)이 던지는 오류는 아래 실제 주문 POST가 아직
+  // 나가기 전에 발생한 것이므로, 주문이 KIS에 제출되지 않았음이 확실하다.
+  let token;
+  let hashKey;
+  try {
+    token = await getAccessToken();
+    if (useHashKey) {
+      hashKey = await createKisHashKey({ kisAxios, kisUrl, appKey, appSecret, body });
+    }
+  } catch (error) {
+    // ES 모듈은 항상 strict mode라 원시값(문자열/숫자/null 등)에 프로퍼티를 대입하면
+    // TypeError가 난다. 이 구간의 모든 throw 지점(getAccessToken의 new Error, createKisHashKey의
+    // new Error, axios 에러)은 항상 객체를 던지므로 오늘은 도달 불가능하지만, 바로 아래의
+    // kisOrderSubmittedMaybe 태깅과 대칭을 맞추고 향후 이 블록에 원시값을 던질 수 있는 코드가
+    // 섞여도 "에러를 분류하는" 이 코드 자체가 죽지 않도록 방어적으로 가드한다.
+    if (error && typeof error === "object") {
+      error.kisOrderNotSubmitted = true;
+    }
+    throw error;
+  }
+
+  const headers = {
+    "Content-Type": "application/json",
+    authorization: `Bearer ${token}`,
+    appkey: appKey,
+    appsecret: appSecret,
+    tr_id: trId,
+    custtype: "P",
+  };
+  if (useHashKey) {
+    headers.hashkey = hashKey;
+  }
+
+  let response;
+  try {
+    response = await kisAxios.post(`${kisUrl}${pathname}`, body, { headers });
+  } catch (error) {
+    // 위 pre-flight 블록과 동일한 이유로 가드한다: axios 에러는 항상 객체이므로 오늘은
+    // 도달 불가능하지만, 대칭을 맞춰 둔다.
+    if (error && typeof error === "object") {
+      error.kisOrderSubmittedMaybe = true;
+    }
+    throw error;
+  }
+
+  const data = response.data;
+  if (data.rt_cd !== "0") {
+    const error = new Error(`KIS API 오류: ${data.msg1 || data.msg_cd || "알 수 없는 오류"}`);
+    error.kisOrderRejected = true;
+    throw error;
+  }
+  return data;
+}

--- a/mcp-trading/kis-client.js
+++ b/mcp-trading/kis-client.js
@@ -41,6 +41,10 @@ const KIS_ORDER_POST_REQUIRED_DEPENDENCIES = [
   "pathname",
   "trId",
   "body",
+  // 기본값 false는 "hashkey 없이 주문 POST를 보낸다"는 뜻이라 조용히 틀릴 수 있다.
+  // 누락 시 KIS 거절 -> kisOrderRejected -> 중복 방지 가드 해제 경로를 타므로,
+  // 이 주문 제출 전용 함수에서는 명시 배선을 강제한다(위 주석의 "아홉 개"와도 일치).
+  "useHashKey",
   "getAccessToken",
 ];
 
@@ -65,10 +69,10 @@ export async function kisOrderPost({
   pathname,
   trId,
   body,
-  useHashKey = false,
+  useHashKey,
   getAccessToken,
 }) {
-  requireKisOrderPostDependencies({ kisAxios, kisUrl, appKey, appSecret, pathname, trId, body, getAccessToken });
+  requireKisOrderPostDependencies({ kisAxios, kisUrl, appKey, appSecret, pathname, trId, body, useHashKey, getAccessToken });
 
   // 이 블록(토큰 발급, 필요 시 해시키 발급)이 던지는 오류는 아래 실제 주문 POST가 아직
   // 나가기 전에 발생한 것이므로, 주문이 KIS에 제출되지 않았음이 확실하다.

--- a/mcp-trading/kis-client.js
+++ b/mcp-trading/kis-client.js
@@ -26,6 +26,32 @@ async function createKisHashKey({ kisAxios, kisUrl, appKey, appSecret, body }) {
   return hashKey;
 }
 
+// index.js는 이 아홉 개(kisAxios, kisUrl, appKey, appSecret, pathname, trId, body, useHashKey,
+// getAccessToken)를 명시적으로 배선한다 — 분리 전에는 전부 index.js 모듈 스코프 변수를 암묵적으로
+// 읽었다. 배선을 빠뜨리면(예: getAccessToken 인자를 통째로 빼먹으면) 그 자리에서
+// "getAccessToken is not a function" 같은 일반 TypeError가 나서 어디가 문제인지 알기 어렵고,
+// 실제 프로덕션 배선(index.js의 단일 호출부)을 그대로 재현하는 테스트가 아니면 잡히지도
+// 않는다. 필수 의존성이 비어 있으면 어떤 것이 빠졌는지 이름으로 지목하는 에러를 즉시 던져서,
+// 이 함수를 부르는 어떤 호출부에서든(지금은 index.js 하나지만) 실수를 빨리, 시끄럽게 드러낸다.
+const KIS_ORDER_POST_REQUIRED_DEPENDENCIES = [
+  "kisAxios",
+  "kisUrl",
+  "appKey",
+  "appSecret",
+  "pathname",
+  "trId",
+  "body",
+  "getAccessToken",
+];
+
+function requireKisOrderPostDependencies(deps) {
+  for (const name of KIS_ORDER_POST_REQUIRED_DEPENDENCIES) {
+    if (deps[name] === undefined) {
+      throw new Error(`kisOrderPost: 필수 인자 '${name}'이(가) 주입되지 않았습니다. 호출부의 배선을 확인하세요.`);
+    }
+  }
+}
+
 // 주문 제출 전용 POST. 호출자는 정확히 하나(index.js의 place_order 경로)이고 플래그를 읽는
 // 곳도 order-submit.js 하나뿐이다. 읽기 전용 도구는 전부 kisGet/kisApiGet을 쓰므로, 다음에
 // 읽기 전용 POST 도구(예: 주문 정정·취소 조회가 아닌 별도 POST)를 추가할 사람이 범용 이름에
@@ -42,6 +68,8 @@ export async function kisOrderPost({
   useHashKey = false,
   getAccessToken,
 }) {
+  requireKisOrderPostDependencies({ kisAxios, kisUrl, appKey, appSecret, pathname, trId, body, getAccessToken });
+
   // 이 블록(토큰 발급, 필요 시 해시키 발급)이 던지는 오류는 아래 실제 주문 POST가 아직
   // 나가기 전에 발생한 것이므로, 주문이 KIS에 제출되지 않았음이 확실하다.
   let token;

--- a/mcp-trading/tests/kis-client.test.js
+++ b/mcp-trading/tests/kis-client.test.js
@@ -1,0 +1,206 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { kisOrderPost } from "../kis-client.js";
+
+// #163: kisOrderPost (formerly kisPost, index.js) tags a thrown error with exactly one of
+// three flags depending on where in the call the failure happened. submitOrder()
+// (order-submit.js:17) reads these flags to decide whether the duplicate-order dedup
+// guard is safe to release. A wrong flag here means either a duplicate real order goes
+// through, or a legitimate order stays blocked for the full TTL. Before this file, kisPost
+// was not exported and nothing exercised its production side — only order-submit.js's
+// consumption of pre-tagged errors was tested (order.test.js).
+//
+// Confirmed against origin/main: widening the pre-flight try in the original kisPost so
+// it also wraps the order POST (tagging a genuine post-submission failure as
+// kisOrderNotSubmitted instead of kisOrderSubmittedMaybe) left the full suite green
+// (72/72) — nothing pinned this boundary. These three tests each target one of the three
+// flag-producing branches.
+
+function fakeAxios({ post }) {
+  return { post };
+}
+
+test("kisOrderPost: pre-flight failure (getAccessToken) tags kisOrderNotSubmitted, not kisOrderSubmittedMaybe", async () => {
+  const preFlightError = new Error("Access Token 발급 실패: EGW00133 초당 거래건수를 초과하였습니다.");
+  const getAccessToken = async () => {
+    throw preFlightError;
+  };
+  // The order POST itself must never be reached when pre-flight fails first.
+  const kisAxios = fakeAxios({
+    post: async () => {
+      throw new Error("order POST must not be called when pre-flight fails");
+    },
+  });
+
+  await assert.rejects(
+    () => kisOrderPost({
+      kisAxios,
+      kisUrl: "https://openapivts.koreainvestment.com:29443",
+      appKey: "test-app-key",
+      appSecret: "test-app-secret",
+      pathname: "/uapi/domestic-stock/v1/trading/order-cash",
+      trId: "VTTC0012U",
+      body: {},
+      useHashKey: false,
+      getAccessToken,
+    }),
+    (err) => {
+      assert.equal(err, preFlightError);
+      assert.equal(err.kisOrderNotSubmitted, true);
+      assert.equal(err.kisOrderSubmittedMaybe, undefined);
+      return true;
+    },
+  );
+});
+
+test("kisOrderPost: pre-flight failure (createKisHashKey via the /uapi/hashkey POST) also tags kisOrderNotSubmitted, not kisOrderSubmittedMaybe", async () => {
+  const getAccessToken = async () => "test-token";
+  const kisAxios = fakeAxios({
+    post: async (url) => {
+      if (url.endsWith("/uapi/hashkey")) {
+        throw new Error("connect ETIMEDOUT");
+      }
+      throw new Error("order POST must not be called when hashkey pre-flight fails");
+    },
+  });
+
+  await assert.rejects(
+    () => kisOrderPost({
+      kisAxios,
+      kisUrl: "https://openapivts.koreainvestment.com:29443",
+      appKey: "test-app-key",
+      appSecret: "test-app-secret",
+      pathname: "/uapi/domestic-stock/v1/trading/order-cash",
+      trId: "VTTC0012U",
+      body: {},
+      useHashKey: true,
+      getAccessToken,
+    }),
+    (err) => {
+      assert.equal(err.kisOrderNotSubmitted, true);
+      assert.equal(err.kisOrderSubmittedMaybe, undefined);
+      return true;
+    },
+  );
+});
+
+test("kisOrderPost: order POST throws tags kisOrderSubmittedMaybe, not kisOrderNotSubmitted", async () => {
+  const getAccessToken = async () => "test-token";
+  const submitError = new Error("connect ETIMEDOUT");
+  const kisAxios = fakeAxios({
+    post: async (url) => {
+      // getAccessToken/createKisHashKey are injected/skipped here, so the only POST this
+      // client makes is the order submission itself.
+      throw submitError;
+    },
+  });
+
+  await assert.rejects(
+    () => kisOrderPost({
+      kisAxios,
+      kisUrl: "https://openapivts.koreainvestment.com:29443",
+      appKey: "test-app-key",
+      appSecret: "test-app-secret",
+      pathname: "/uapi/domestic-stock/v1/trading/order-cash",
+      trId: "VTTC0012U",
+      body: {},
+      useHashKey: false,
+      getAccessToken,
+    }),
+    (err) => {
+      assert.equal(err, submitError);
+      assert.equal(err.kisOrderSubmittedMaybe, true);
+      assert.equal(err.kisOrderNotSubmitted, undefined);
+      return true;
+    },
+  );
+});
+
+test('kisOrderPost: rt_cd !== "0" tags kisOrderRejected, and neither of the other two flags', async () => {
+  const getAccessToken = async () => "test-token";
+  const kisAxios = fakeAxios({
+    post: async () => ({
+      data: { rt_cd: "1", msg1: "주문가능금액을 초과하였습니다.", msg_cd: "APBK0952" },
+    }),
+  });
+
+  await assert.rejects(
+    () => kisOrderPost({
+      kisAxios,
+      kisUrl: "https://openapivts.koreainvestment.com:29443",
+      appKey: "test-app-key",
+      appSecret: "test-app-secret",
+      pathname: "/uapi/domestic-stock/v1/trading/order-cash",
+      trId: "VTTC0012U",
+      body: {},
+      useHashKey: false,
+      getAccessToken,
+    }),
+    (err) => {
+      assert.match(err.message, /주문가능금액을 초과하였습니다\./);
+      assert.equal(err.kisOrderRejected, true);
+      assert.equal(err.kisOrderNotSubmitted, undefined);
+      assert.equal(err.kisOrderSubmittedMaybe, undefined);
+      return true;
+    },
+  );
+});
+
+test("kisOrderPost: success (rt_cd === \"0\") returns the KIS response data untagged", async () => {
+  const getAccessToken = async () => "test-token";
+  const responseData = { rt_cd: "0", output: { ODNO: "0000001234" }, msg1: "주문이 완료되었습니다" };
+  const kisAxios = fakeAxios({
+    post: async () => ({ data: responseData }),
+  });
+
+  const data = await kisOrderPost({
+    kisAxios,
+    kisUrl: "https://openapivts.koreainvestment.com:29443",
+    appKey: "test-app-key",
+    appSecret: "test-app-secret",
+    pathname: "/uapi/domestic-stock/v1/trading/order-cash",
+    trId: "VTTC0012U",
+    body: {},
+    useHashKey: false,
+    getAccessToken,
+  });
+
+  assert.deepEqual(data, responseData);
+});
+
+test("kisOrderPost: sends bearer token, appkey/appsecret, tr_id, and hashkey headers to the order pathname built from kisUrl", async () => {
+  const getAccessToken = async () => "captured-token";
+  let hashKeyCall = null;
+  let orderCall = null;
+  const kisAxios = fakeAxios({
+    post: async (url, body, config) => {
+      if (url.endsWith("/uapi/hashkey")) {
+        hashKeyCall = { url, body, config };
+        return { data: { HASH: "captured-hash" } };
+      }
+      orderCall = { url, body, config };
+      return { data: { rt_cd: "0", output: {} } };
+    },
+  });
+
+  await kisOrderPost({
+    kisAxios,
+    kisUrl: "https://openapivts.koreainvestment.com:29443",
+    appKey: "captured-app-key",
+    appSecret: "captured-app-secret",
+    pathname: "/uapi/domestic-stock/v1/trading/order-cash",
+    trId: "VTTC0012U",
+    body: { PDNO: "005930" },
+    useHashKey: true,
+    getAccessToken,
+  });
+
+  assert.equal(hashKeyCall.url, "https://openapivts.koreainvestment.com:29443/uapi/hashkey");
+  assert.equal(orderCall.url, "https://openapivts.koreainvestment.com:29443/uapi/domestic-stock/v1/trading/order-cash");
+  assert.deepEqual(orderCall.body, { PDNO: "005930" });
+  assert.equal(orderCall.config.headers.authorization, "Bearer captured-token");
+  assert.equal(orderCall.config.headers.appkey, "captured-app-key");
+  assert.equal(orderCall.config.headers.appsecret, "captured-app-secret");
+  assert.equal(orderCall.config.headers.tr_id, "VTTC0012U");
+  assert.equal(orderCall.config.headers.hashkey, "captured-hash");
+});

--- a/mcp-trading/tests/kis-client.test.js
+++ b/mcp-trading/tests/kis-client.test.js
@@ -13,8 +13,10 @@ import { kisOrderPost } from "../kis-client.js";
 // Confirmed against origin/main: widening the pre-flight try in the original kisPost so
 // it also wraps the order POST (tagging a genuine post-submission failure as
 // kisOrderNotSubmitted instead of kisOrderSubmittedMaybe) left the full suite green
-// (72/72) — nothing pinned this boundary. These three tests each target one of the three
-// flag-producing branches.
+// (72/72) — nothing pinned this boundary. The tests below pin each of the three
+// flag-producing branches (including the hashkey-response-without-HASH case, which is
+// also a kisOrderNotSubmitted producer), the required-dependency guard added for
+// index.js's wiring, and the typeof-guard on each catch block.
 
 function fakeAxios({ post }) {
   return { post };
@@ -55,11 +57,14 @@ test("kisOrderPost: pre-flight failure (getAccessToken) tags kisOrderNotSubmitte
 
 test("kisOrderPost: pre-flight failure (createKisHashKey via the /uapi/hashkey POST) also tags kisOrderNotSubmitted, not kisOrderSubmittedMaybe", async () => {
   const getAccessToken = async () => "test-token";
+  const hashKeyError = new Error("connect ETIMEDOUT");
+  let orderPostCalled = false;
   const kisAxios = fakeAxios({
     post: async (url) => {
       if (url.endsWith("/uapi/hashkey")) {
-        throw new Error("connect ETIMEDOUT");
+        throw hashKeyError;
       }
+      orderPostCalled = true;
       throw new Error("order POST must not be called when hashkey pre-flight fails");
     },
   });
@@ -77,20 +82,64 @@ test("kisOrderPost: pre-flight failure (createKisHashKey via the /uapi/hashkey P
       getAccessToken,
     }),
     (err) => {
+      assert.equal(err, hashKeyError);
       assert.equal(err.kisOrderNotSubmitted, true);
       assert.equal(err.kisOrderSubmittedMaybe, undefined);
       return true;
     },
   );
+  assert.equal(orderPostCalled, false, "the order POST must never be reached when the hashkey pre-flight fails");
+});
+
+// #163 review follow-up (row 4 of the flag table): createKisHashKey's own guard
+// (`if (!hashKey) throw ...`) is the one pre-flight branch that was still unpinned.
+// Confirmed to redden this test: neutralizing that guard (`if (!hashKey)` -> `if (false)`)
+// in kis-client.js leaves the whole suite green, because nothing else notices that
+// headers.hashkey ends up undefined — the order POST goes out anyway with a malformed
+// header, KIS rejects it, and that misclassifies as kisOrderRejected (which releases the
+// dedup guard), reviving the duplicate-order direction #163 is about.
+test("kisOrderPost: hashkey pre-flight succeeds (200) but the response body has no HASH field tags kisOrderNotSubmitted, not kisOrderSubmittedMaybe, and the order POST is never sent", async () => {
+  const getAccessToken = async () => "test-token";
+  let orderPostCalled = false;
+  const kisAxios = fakeAxios({
+    post: async (url) => {
+      if (url.endsWith("/uapi/hashkey")) {
+        return { data: {} }; // 200 response, but the body carries no HASH field
+      }
+      orderPostCalled = true;
+      throw new Error("order POST must not be called when the hashkey response is malformed");
+    },
+  });
+
+  await assert.rejects(
+    () => kisOrderPost({
+      kisAxios,
+      kisUrl: "https://openapivts.koreainvestment.com:29443",
+      appKey: "test-app-key",
+      appSecret: "test-app-secret",
+      pathname: "/uapi/domestic-stock/v1/trading/order-cash",
+      trId: "VTTC0012U",
+      body: {},
+      useHashKey: true,
+      getAccessToken,
+    }),
+    (err) => {
+      assert.match(err.message, /KIS hashkey 발급 실패/);
+      assert.equal(err.kisOrderNotSubmitted, true);
+      assert.equal(err.kisOrderSubmittedMaybe, undefined);
+      return true;
+    },
+  );
+  assert.equal(orderPostCalled, false, "the order POST must never be reached when the hashkey response has no HASH");
 });
 
 test("kisOrderPost: order POST throws tags kisOrderSubmittedMaybe, not kisOrderNotSubmitted", async () => {
   const getAccessToken = async () => "test-token";
   const submitError = new Error("connect ETIMEDOUT");
   const kisAxios = fakeAxios({
-    post: async (url) => {
-      // getAccessToken/createKisHashKey are injected/skipped here, so the only POST this
-      // client makes is the order submission itself.
+    post: async () => {
+      // useHashKey is false here, so the only POST this client makes is the order
+      // submission itself.
       throw submitError;
     },
   });
@@ -168,16 +217,25 @@ test("kisOrderPost: success (rt_cd === \"0\") returns the KIS response data unta
   assert.deepEqual(data, responseData);
 });
 
-test("kisOrderPost: sends bearer token, appkey/appsecret, tr_id, and hashkey headers to the order pathname built from kisUrl", async () => {
-  const getAccessToken = async () => "captured-token";
+test("kisOrderPost: sends bearer token, appkey/appsecret, tr_id, and hashkey headers to the order pathname built from kisUrl, fetching the token before the hashkey POST before the order POST", async () => {
+  // Call order matters here, not just header content: if the hashkey POST fired before
+  // getAccessToken() (or before whatever pre-flight credential check a real caller does),
+  // it would send placeholder/unready credentials to KIS ahead of schedule.
+  const callOrder = [];
+  const getAccessToken = async () => {
+    callOrder.push("getAccessToken");
+    return "captured-token";
+  };
   let hashKeyCall = null;
   let orderCall = null;
   const kisAxios = fakeAxios({
     post: async (url, body, config) => {
       if (url.endsWith("/uapi/hashkey")) {
+        callOrder.push("hashkey");
         hashKeyCall = { url, body, config };
         return { data: { HASH: "captured-hash" } };
       }
+      callOrder.push("order");
       orderCall = { url, body, config };
       return { data: { rt_cd: "0", output: {} } };
     },
@@ -195,6 +253,7 @@ test("kisOrderPost: sends bearer token, appkey/appsecret, tr_id, and hashkey hea
     getAccessToken,
   });
 
+  assert.deepEqual(callOrder, ["getAccessToken", "hashkey", "order"]);
   assert.equal(hashKeyCall.url, "https://openapivts.koreainvestment.com:29443/uapi/hashkey");
   assert.equal(orderCall.url, "https://openapivts.koreainvestment.com:29443/uapi/domestic-stock/v1/trading/order-cash");
   assert.deepEqual(orderCall.body, { PDNO: "005930" });
@@ -203,4 +262,102 @@ test("kisOrderPost: sends bearer token, appkey/appsecret, tr_id, and hashkey hea
   assert.equal(orderCall.config.headers.appsecret, "captured-app-secret");
   assert.equal(orderCall.config.headers.tr_id, "VTTC0012U");
   assert.equal(orderCall.config.headers.hashkey, "captured-hash");
+});
+
+// #163 review follow-up: kisOrderPost turned nine implicit index.js module-scope reads
+// into nine explicit call-site parameters. A wiring mistake at the one production call
+// site (index.js) — e.g. dropping `getAccessToken` from the object literal — used to
+// surface only as a generic TypeError from deep inside the pre-flight try, which still
+// gets classified kisOrderNotSubmitted (fails closed, safe direction) but gives no hint
+// what actually broke. This guard converts that into a named error identifying exactly
+// which dependency is missing, and protects every future caller, not just index.js's one
+// call site.
+test("kisOrderPost: throws a named error identifying the missing dependency when a required argument is not supplied, before making any HTTP call", async () => {
+  const validArgs = {
+    kisAxios: fakeAxios({ post: async () => { throw new Error("no HTTP call should happen"); } }),
+    kisUrl: "https://openapivts.koreainvestment.com:29443",
+    appKey: "test-app-key",
+    appSecret: "test-app-secret",
+    pathname: "/uapi/domestic-stock/v1/trading/order-cash",
+    trId: "VTTC0012U",
+    body: {},
+    useHashKey: false,
+    getAccessToken: async () => "test-token",
+  };
+
+  for (const missing of ["kisAxios", "kisUrl", "appKey", "appSecret", "pathname", "trId", "body", "getAccessToken"]) {
+    const args = { ...validArgs, [missing]: undefined };
+    await assert.rejects(
+      () => kisOrderPost(args),
+      (err) => {
+        assert.match(err.message, new RegExp(`'${missing}'`));
+        assert.equal(err.kisOrderNotSubmitted, undefined, "the dependency guard must fire before pre-flight, not be classified as a KIS failure");
+        assert.equal(err.kisOrderSubmittedMaybe, undefined);
+        assert.equal(err.kisOrderRejected, undefined);
+        return true;
+      },
+      `omitting '${missing}' should throw a named error mentioning it`,
+    );
+  }
+});
+
+// The typeof-error guard on each catch block (kisOrderNotSubmitted and
+// kisOrderSubmittedMaybe) exists so tagging a caught error never itself throws when the
+// error is a primitive (ES modules are strict mode; assigning a property to a string/
+// number/null throws TypeError). These two tests give that guard coverage: without it
+// (i.e. under an `if (true)` mutation of either guard), a bare-string throw would be
+// replaced by a TypeError from the property assignment itself, and these assertions on
+// the original string would fail.
+test("kisOrderPost: a bare string thrown by getAccessToken propagates unchanged instead of crashing on the tagging assignment", async () => {
+  const getAccessToken = async () => {
+    throw "token service unavailable"; // eslint-disable-line no-throw-literal -- exercising the primitive-error guard
+  };
+  const kisAxios = fakeAxios({
+    post: async () => { throw new Error("no HTTP call should happen"); },
+  });
+
+  await assert.rejects(
+    () => kisOrderPost({
+      kisAxios,
+      kisUrl: "https://openapivts.koreainvestment.com:29443",
+      appKey: "test-app-key",
+      appSecret: "test-app-secret",
+      pathname: "/uapi/domestic-stock/v1/trading/order-cash",
+      trId: "VTTC0012U",
+      body: {},
+      useHashKey: false,
+      getAccessToken,
+    }),
+    (err) => {
+      assert.equal(err, "token service unavailable");
+      return true;
+    },
+  );
+});
+
+test("kisOrderPost: a bare string thrown by the order POST propagates unchanged instead of crashing on the tagging assignment", async () => {
+  const getAccessToken = async () => "test-token";
+  const kisAxios = fakeAxios({
+    post: async () => {
+      throw "socket hang up"; // eslint-disable-line no-throw-literal -- exercising the primitive-error guard
+    },
+  });
+
+  await assert.rejects(
+    () => kisOrderPost({
+      kisAxios,
+      kisUrl: "https://openapivts.koreainvestment.com:29443",
+      appKey: "test-app-key",
+      appSecret: "test-app-secret",
+      pathname: "/uapi/domestic-stock/v1/trading/order-cash",
+      trId: "VTTC0012U",
+      body: {},
+      useHashKey: false,
+      getAccessToken,
+    }),
+    (err) => {
+      assert.equal(err, "socket hang up");
+      return true;
+    },
+  );
 });

--- a/mcp-trading/tests/kis-client.test.js
+++ b/mcp-trading/tests/kis-client.test.js
@@ -285,7 +285,7 @@ test("kisOrderPost: throws a named error identifying the missing dependency when
     getAccessToken: async () => "test-token",
   };
 
-  for (const missing of ["kisAxios", "kisUrl", "appKey", "appSecret", "pathname", "trId", "body", "getAccessToken"]) {
+  for (const missing of ["kisAxios", "kisUrl", "appKey", "appSecret", "pathname", "trId", "body", "useHashKey", "getAccessToken"]) {
     const args = { ...validArgs, [missing]: undefined };
     await assert.rejects(
       () => kisOrderPost(args),

--- a/mcp-trading/tests/order.test.js
+++ b/mcp-trading/tests/order.test.js
@@ -888,7 +888,7 @@ test("createCashOrderRequest builds market order body", () => {
 // separates "did KIS accept the order" from "did we finish recording it" so a ledger
 // write failure can never undo an accepted order.
 //
-// The release() allowlist recognizes three flags kisPost (index.js) can attach to a
+// The release() allowlist recognizes three flags kisOrderPost (kis-client.js) can attach to a
 // thrown error: kisOrderRejected (KIS said rt_cd !== "0" — nothing was submitted),
 // kisOrderNotSubmitted (token/hashkey pre-flight failed before the order POST ever went
 // out — also nothing was submitted), and kisOrderSubmittedMaybe (the order POST itself
@@ -992,7 +992,7 @@ test("submitOrder: releases the dedup guard when KIS rejects the order (rt_cd !=
 
 // Mutation this catches: dropping the `error.kisOrderNotSubmitted === true` allowlist
 // entry added after review of #161. getAccessToken() and createKisHashKey() both run
-// before the order POST in kisPost (index.js); a failure there — expired credentials,
+// before the order POST in kisOrderPost (kis-client.js); a failure there — expired credentials,
 // a rate-limited token endpoint, a cold token cache after a container restart — means
 // the order was never sent. Without this class, that dedup key sits reserved for the
 // full TTL and DuplicateOrderError tells the user to "check the order shortly" for an


### PR DESCRIPTION
Closes #163

## 문제

PR #164가 `kisPost`에 주문 제출 여부를 나타내는 플래그 3종을 세웠습니다. 이 플래그가 `order-submit.js:17`의 release 판정을 좌우하고, 판정이 틀리면 **중복 실주문** 아니면 **정당한 주문 차단**입니다.

경계 자체는 맞았습니다. 다만 이를 고정하는 테스트가 하나도 없었습니다 — `kisPost`는 export되지 않고 어떤 테스트도 실행하지 않습니다. #164가 추가한 9개는 전부 플래그의 **소비**를 검증하고 **생산**은 0개였습니다.

## 재현

`origin/main`에서 사전 단계 try를 주문 POST까지 넓혀, 8초 타임아웃으로 실패한 POST(=제출됐을 수 있음)를 "제출 안 됨 확실"로 오분류하게 만들었습니다. 그러면 가드가 해제되고 재시도가 두 번째 실주문이 됩니다.

```
origin/main + 변형  ->  tests 72  pass 72  fail 0
```

**돈 잃는 버그를 넣은 채로 전부 통과합니다.** 이 브랜치에서는 red입니다.

## 변경

`kisPost`와 주문 전용 헬퍼 `createKisHashKey`를 `mcp-trading/kis-client.js`로 분리하고 **`kisOrderPost`로 개명**했습니다. 호출자가 정확히 하나(주문 경로)이고 플래그를 읽는 곳도 하나인데 이름이 범용이라, 다음에 POST 도구를 추가하는 사람이 주문 의미론을 물려받기 쉬웠습니다. 읽기 도구는 전부 `kisGet`/`kisApiGet`을 씁니다.

`kisAxios`·`kisUrl`·`appKey`·`appSecret`을 주입받아 테스트가 네트워크 없이 돕니다. `getAccessToken`은 `index.js`에 남기고 함수로 주입했습니다 — 토큰 캐시 디스크 I/O가 `kisGet`/`kisApiGet`과 공유되는 별개 관심사이고, 이 경계가 관심 있는 건 사전 단계가 **실패했다는 사실**이지 이유가 아닙니다.

`balance.js:17`이 명시한 저장소 관례를 따랐습니다 — `index.js`는 부작용을 가진 서버 진입점이라 여기서 import하지 않습니다.

**추출은 동작을 바꾸지 않았습니다.** 주석·공백을 제거하고 의도한 개명만 정규화해 `origin/main`과 대조한 결과, 차이는 아래 두 가드뿐입니다.

```js
} catch (error) {
+ if (error && typeof error === "object") {
    error.kisOrderNotSubmitted = true;
+ }
  throw error;
}
```

호출 순서(토큰 → hashkey → 주문 POST), 헤더, 두 URL, `rt_cd` 처리, 반환값 전부 동일합니다. `kisAxios`는 한 번 생성된 같은 객체 참조가 넘어가므로 8초 타임아웃도 그대로입니다.

## 고정한 플래그 표

| 실패 지점 | 플래그 | 분류 |
| :--- | :--- | :--- |
| `requireKisCredentials()` | `kisOrderNotSubmitted` | 제출 안 됨 확실 |
| `Access Token 발급 실패` | `kisOrderNotSubmitted` | 제출 안 됨 확실 |
| `createKisHashKey` axios 실패 | `kisOrderNotSubmitted` | 제출 안 됨 확실 |
| `KIS hashkey 발급 실패` | `kisOrderNotSubmitted` | 제출 안 됨 확실 |
| 주문 POST 실패 (8초 타임아웃 포함) | `kisOrderSubmittedMaybe` | 제출 여부 불명 |
| `rt_cd !== "0"` | `kisOrderRejected` | 제출 안 됨 확실 |
| `markSucceeded` 기록 실패 | 없음 | **제출됨 확실** |

`rt_cd` 검사는 두 try **바깥**에 있어, `response.data`가 undefined일 때의 `TypeError`가 태그 없이 전파됩니다 → `order-submit.js:17`이 가드를 유지합니다(fail-closed).

## 리뷰에서 나온 것

**hashkey 200-without-HASH 행이 안 잠겨 있었습니다.** 리뷰 전에는 `if (!hashKey)` throw를 없애도 78개가 전부 통과했습니다. 그러면 `headers.hashkey`가 `undefined`인 채 **주문 POST가 그대로 나가고**, KIS가 거절하면 `kisOrderRejected`로 분류되어 **가드가 해제**됩니다. 일곱 행 중 유일하게 열려 있던 사전 단계 행이었습니다. 테스트를 추가했고, 변형 시 실제로 주문 POST에 도달하는 것까지 확인했습니다.

**프로덕션 배선이 덮이지 않았습니다.** 추출이 암묵적 모듈 스코프 참조 9개를 명시적 주입 지점으로 바꿨는데, 테스트가 각자 의존성 객체를 넘기다 보니 배선 오타가 보이지 않았습니다. `appKey`에 `KIS_API_SECRET`을 넣어도 78/78이었습니다.

텍스트를 읽어 호출부를 검사하는 대신 `kisOrderPost` 진입부에 필수 의존성 검사를 넣었습니다. 빠진 이름을 지목하는 named error가 나므로 일반 `TypeError`보다 진단이 낫고, 그 한 호출부가 아니라 앞으로의 모든 호출자를 보호합니다.

**호출 순서를 고정했습니다.** 사전 단계 두 줄을 맞바꾸면 `requireKisCredentials()`보다 hashkey POST가 먼저 나가 placeholder 자격증명이 KIS로 갑니다.

## 검증

72 → 82. 변형 전부 red 확인, 옆 테스트 동반 실패 없음.

| 변형 | 잡은 테스트 |
| :--- | :--- |
| 사전 단계 try를 주문 POST까지 확대 | 주문 POST 실패 → `kisOrderSubmittedMaybe` |
| `if (!hashKey)` → `if (false)` | hashkey 누락 행 (실제로 주문 POST 도달) |
| 필수 의존성 검사 제거 | 배선 가드 |
| 사전 단계 태그를 `kisOrderSubmittedMaybe`로 | 사전 단계 2건 |
| `kisOrderRejected` 태그 제거 | `rt_cd` 거절 |
| `typeof` 가드 둘을 `if (true)`로 | 원시값 전파 2건 |
| `appkey: appKey` → `appSecret` | 헤더 구성 |
| `return data` → `return response` | 반환값 |
| 사전 단계 두 줄 순서 교환 | 호출 순서 |

실기동에서 stdout 0바이트를 확인했습니다(MCP JSON-RPC 채널). 로그에 `appkey`·`appsecret`·`authorization`·`CANO` 없음을 확인했습니다.

## 함께 정리한 것

- 원시값 대입 가드를 신규·기존 두 곳 모두에 넣었습니다. 둘 다 현재 도달 불가지만(감싼 구간의 모든 throw 지점이 객체를 만듭니다), 이슈가 지적한 "하나는 가드되고 하나는 아닌" 비대칭이 사라집니다. 부수 효과로 `order.test.js:1113`의 `throw null` 케이스가 프로덕션에서 실제로 만들어질 수 있는 형태가 됐습니다.
- `tests/order.test.js:891,995`의 `kisPost (index.js)` 주석을 고쳤습니다. 이 주석이 소비자 테스트와 생산자를 잇는 유일한 연결이었는데, 추출이 그 연결을 끊으면서 알아챌 기계적 이유도 함께 없앴습니다.
