### PR TITLE
fix: 도구 없는 provider의 분석 결과를 소비자가 구분할 수 있게 함

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1,14 +1,47 @@
+from sqlalchemy import inspect, text
 from sqlmodel import create_engine, Session, SQLModel
 from .config import DATABASE_URL, DB_ECHO
 
 # SQLite 사용 시 connect_args={"check_same_thread": False}가 필요함
 engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False}, echo=DB_ECHO)
 
+# 스키마 변경 시 여기에 (테이블명, 컬럼명, ALTER 문) 을 추가한다.
+# SQLModel.metadata.create_all()은 없는 테이블은 만들지만 기존 테이블에 컬럼을
+# 추가하지는 않는다 (SQLAlchemy의 문서화된 동작). 이미 배포된 SQLite 파일은
+# create_all만으로는 새 컬럼을 얻지 못하므로, 부팅 시 직접 보강한다.
+_PENDING_COLUMN_MIGRATIONS: tuple[tuple[str, str, str], ...] = (
+    (
+        "agentreport",
+        "tool_verified",
+        # DEFAULT 0: 이 컬럼이 없던 시절에 만들어진 기존 행을 "도구 미검증"으로
+        # 채운다. NULL이나 1로 채우면 지어낸 과거 리포트가 검증된 것처럼 보일 수
+        # 있으므로(#162) 반드시 0(False)이어야 한다.
+        "ALTER TABLE agentreport ADD COLUMN tool_verified BOOLEAN NOT NULL DEFAULT 0",
+    ),
+)
+
+
+def _run_schema_migrations() -> None:
+    """create_all이 다루지 못하는, 기존 테이블에 대한 컬럼 추가를 처리한다."""
+    inspector = inspect(engine)
+    existing_tables = set(inspector.get_table_names())
+    with engine.begin() as conn:
+        for table_name, column_name, alter_sql in _PENDING_COLUMN_MIGRATIONS:
+            if table_name not in existing_tables:
+                # create_all이 이미 최신 스키마로 새로 만들었으므로 손댈 필요 없음
+                continue
+            columns = {col["name"] for col in inspector.get_columns(table_name)}
+            if column_name in columns:
+                continue
+            conn.execute(text(alter_sql))
+
+
 def init_db():
     """
     데이터베이스 테이블을 초기화합니다.
     """
     SQLModel.metadata.create_all(engine)
+    _run_schema_migrations()
 
 def get_session():
     """

--- a/backend/database.py
+++ b/backend/database.py
@@ -34,7 +34,15 @@ def _run_schema_migrations() -> None:
     이유가 아니다 — 그래서 이 경우만 흡수하고, 그 외의 OperationalError(예:
     디스크 권한 문제로 인한 진짜 실패)는 그대로 올려 startup이 조용히 절반만
     마이그레이션된 스키마로 계속되지 않게 한다.
+
+    주의: BOOLEAN NOT NULL DEFAULT 0 구문과 "duplicate column name" 문자열 매칭은
+    SQLite 전용이다. 다른 방언이면 조용히 오동작할 수 있으므로 가드를 둔다.
     """
+    if engine.dialect.name != "sqlite":
+        raise RuntimeError(
+            f"스키마 마이그레이션은 SQLite 전용입니다 (현재: {engine.dialect.name}). "
+            "다른 DB로 옮기려면 alembic을 도입하세요."
+        )
     for table_name, column_name, alter_sql in _PENDING_COLUMN_MIGRATIONS:
         inspector = inspect(engine)
         if table_name not in inspector.get_table_names():
@@ -62,7 +70,11 @@ def init_db():
     """
     데이터베이스 테이블을 초기화합니다.
     """
-    SQLModel.metadata.create_all(engine)
+    try:
+        SQLModel.metadata.create_all(engine)
+    except OperationalError as exc:
+        if "already exists" not in str(exc).lower():
+            raise
     _run_schema_migrations()
 
 def get_session():

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,4 +1,5 @@
 from sqlalchemy import inspect, text
+from sqlalchemy.exc import OperationalError
 from sqlmodel import create_engine, Session, SQLModel
 from .config import DATABASE_URL, DB_ECHO
 
@@ -12,28 +13,49 @@ engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False}, 
 _PENDING_COLUMN_MIGRATIONS: tuple[tuple[str, str, str], ...] = (
     (
         "agentreport",
-        "tool_verified",
-        # DEFAULT 0: 이 컬럼이 없던 시절에 만들어진 기존 행을 "도구 미검증"으로
+        "provider_supports_tools",
+        # DEFAULT 0: 이 컬럼이 없던 시절에 만들어진 기존 행을 "도구 미지원"으로
         # 채운다. NULL이나 1로 채우면 지어낸 과거 리포트가 검증된 것처럼 보일 수
         # 있으므로(#162) 반드시 0(False)이어야 한다.
-        "ALTER TABLE agentreport ADD COLUMN tool_verified BOOLEAN NOT NULL DEFAULT 0",
+        "ALTER TABLE agentreport ADD COLUMN provider_supports_tools BOOLEAN NOT NULL DEFAULT 0",
     ),
 )
 
 
 def _run_schema_migrations() -> None:
-    """create_all이 다루지 못하는, 기존 테이블에 대한 컬럼 추가를 처리한다."""
-    inspector = inspect(engine)
-    existing_tables = set(inspector.get_table_names())
-    with engine.begin() as conn:
-        for table_name, column_name, alter_sql in _PENDING_COLUMN_MIGRATIONS:
-            if table_name not in existing_tables:
-                # create_all이 이미 최신 스키마로 새로 만들었으므로 손댈 필요 없음
-                continue
-            columns = {col["name"] for col in inspector.get_columns(table_name)}
-            if column_name in columns:
-                continue
-            conn.execute(text(alter_sql))
+    """create_all이 다루지 못하는, 기존 테이블에 대한 컬럼 추가를 처리한다.
+
+    check(컬럼 존재 여부 조회)와 act(ALTER TABLE)가 원자적이지 않으므로, 워커가
+    둘 이상이면(현재는 Dockerfile이 --workers 없이 단일 프로세스로 띄우므로
+    해당 없음, 하지만 그 가정이 바뀌는 순간 바로 재현된다) 동시에 여러 프로세스가
+    "컬럼 없음"을 보고 똑같이 ALTER를 시도할 수 있다. 이때 늦게 도착한 쪽은
+    SQLite로부터 "duplicate column name" OperationalError를 받는데, 이는 컬럼이
+    이미 (다른 워커에 의해) 정상적으로 추가됐다는 뜻이므로 startup을 중단시킬
+    이유가 아니다 — 그래서 이 경우만 흡수하고, 그 외의 OperationalError(예:
+    디스크 권한 문제로 인한 진짜 실패)는 그대로 올려 startup이 조용히 절반만
+    마이그레이션된 스키마로 계속되지 않게 한다.
+    """
+    for table_name, column_name, alter_sql in _PENDING_COLUMN_MIGRATIONS:
+        inspector = inspect(engine)
+        if table_name not in inspector.get_table_names():
+            # create_all이 이미 최신 스키마로 새로 만들었으므로 손댈 필요 없음
+            continue
+        columns = {col["name"] for col in inspector.get_columns(table_name)}
+        if column_name in columns:
+            continue
+        try:
+            with engine.begin() as conn:
+                conn.execute(text(alter_sql))
+        except OperationalError as exc:
+            if "duplicate column name" not in str(exc).lower():
+                raise
+            # 다른 워커가 먼저 컬럼을 추가했다는 뜻인지 재확인한다 — 메시지가
+            # 우연히 겹쳤을 뿐 실제로는 컬럼이 없는 상태라면 원래 예외를 올린다.
+            refreshed_columns = {
+                col["name"] for col in inspect(engine).get_columns(table_name)
+            }
+            if column_name not in refreshed_columns:
+                raise
 
 
 def init_db():

--- a/backend/models.py
+++ b/backend/models.py
@@ -39,24 +39,21 @@ class AgentReport(SQLModel, table=True):
     decision: str = Field(description="투자 결정 (BUY/SELL/HOLD)")
     confidence_score: float = Field(description="신뢰도 점수 (0.0~1.0)")
     reason: str = Field(description="투자 결정 근거")
+    # provider 차원의 "능력" 신호 — 실제 도구 호출 관측이 아님 (#162):
+    # - openai/anthropic/ollama: tools 파라미터 없이 모델 직접 호출 → False는 코드로 증명 가능
+    # - nat=True: NAT 멀티에이전트로 라우팅됐다는 뜻이며, 그 안에서 실제 도구가
+    #   실행됐는지는 이 필드가 보장하지 않는다 (NAT ReAct가 도구 없이 답할 수 있는
+    #   문제 #152, raise_on_parsing_failure: false). false negative는 구조적으로
+    #   불가능하지만 false positive는 가능한 비대칭 신호다.
+    # - 실제 도구 호출 이력(ledger)은 #152의 몫이며 이 필드는 대신하지 않는다.
+    # - 이 컬럼이 없던 구버전 행은 database._run_schema_migrations()가
+    #   ALTER TABLE ... DEFAULT 0으로 채운다 — False는 "도구 미지원"과
+    #   "과거 행이라 확인 불가" 둘 다를 의미하며, 절대 True로 소급되지 않는다.
+    # - services.provider_supports_tools()가 provider 자체에서 파생하며,
+    #   호출부가 직접 True/False를 넘기지 않는다.
     provider_supports_tools: bool = Field(
         default=False,
-        description=(
-            "이 리포트를 만든 provider가 도구(MCP/KIS/뉴스)를 호출할 수 있는 경로로 "
-            "구성돼 있는지 여부. services.provider_supports_tools()가 provider 자체에서 "
-            "파생하며 호출부가 직접 True/False를 넘기지 않는다. "
-            "주의: 이것은 provider 차원의 '능력' 신호이지, 이 리포트를 만들 때 실제로 "
-            "도구가 호출됐다는 관측이 아니다. openai/anthropic/ollama는 tools 파라미터 "
-            "없이 모델을 그대로 호출하므로 False는 코드로 증명 가능하다. 반면 nat=True는 "
-            "NAT 멀티에이전트로 라우팅됐다는 뜻일 뿐이며, 그 안에서 실제로 도구가 실행됐는지는 "
-            "이 필드가 보장하지 않는다 — NAT ReAct 에이전트가 도구 없이도 답을 낼 수 있는 "
-            "문제(#152, finus_nat/configs/agents/*.yml 전부 raise_on_parsing_failure: false)가 "
-            "열려 있는 한, false negative는 구조적으로 불가능해도 false positive는 가능하다. "
-            "실제 도구 호출 이력(ledger)은 #152에서 다룰 몫이며 이 필드는 그것을 대신하지 않는다. "
-            "이 컬럼이 없던 스키마에서 만들어진 기존 행은 database._run_schema_migrations()가 "
-            "ALTER TABLE ... DEFAULT 0으로 채운다 — False는 '도구 미지원'과 "
-            "'과거 행이라 확인 불가'를 모두 의미하며, 절대 True로 소급되지 않는다."
-        ),
+        description="provider가 도구(MCP/KIS/뉴스) 호출 경로로 구성돼 있는지 여부 (provider 능력 신호, 실제 호출 관측 아님).",
     )
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="생성 일시")
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -39,6 +39,17 @@ class AgentReport(SQLModel, table=True):
     decision: str = Field(description="투자 결정 (BUY/SELL/HOLD)")
     confidence_score: float = Field(description="신뢰도 점수 (0.0~1.0)")
     reason: str = Field(description="투자 결정 근거")
+    tool_verified: bool = Field(
+        default=False,
+        description=(
+            "MCP/KIS/뉴스 등 실제 도구를 호출해 만든 분석인지 여부. "
+            "services.provider_is_tool_backed()가 provider 분기에서 파생하며 호출부가 "
+            "직접 True/False를 넘기지 않는다 (현재는 provider=nat만 True). "
+            "이 컬럼이 없던 스키마에서 만들어진 기존 행은 database._run_schema_migrations()가 "
+            "ALTER TABLE ... DEFAULT 0으로 채운다 — 즉 False는 '도구 미사용'과 "
+            "'과거 행이라 확인 불가'를 모두 의미하며, 절대 True로 소급되지 않는다."
+        ),
+    )
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="생성 일시")
 
 class Diary(SQLModel, table=True):

--- a/backend/models.py
+++ b/backend/models.py
@@ -39,14 +39,22 @@ class AgentReport(SQLModel, table=True):
     decision: str = Field(description="투자 결정 (BUY/SELL/HOLD)")
     confidence_score: float = Field(description="신뢰도 점수 (0.0~1.0)")
     reason: str = Field(description="투자 결정 근거")
-    tool_verified: bool = Field(
+    provider_supports_tools: bool = Field(
         default=False,
         description=(
-            "MCP/KIS/뉴스 등 실제 도구를 호출해 만든 분석인지 여부. "
-            "services.provider_is_tool_backed()가 provider 분기에서 파생하며 호출부가 "
-            "직접 True/False를 넘기지 않는다 (현재는 provider=nat만 True). "
+            "이 리포트를 만든 provider가 도구(MCP/KIS/뉴스)를 호출할 수 있는 경로로 "
+            "구성돼 있는지 여부. services.provider_supports_tools()가 provider 자체에서 "
+            "파생하며 호출부가 직접 True/False를 넘기지 않는다. "
+            "주의: 이것은 provider 차원의 '능력' 신호이지, 이 리포트를 만들 때 실제로 "
+            "도구가 호출됐다는 관측이 아니다. openai/anthropic/ollama는 tools 파라미터 "
+            "없이 모델을 그대로 호출하므로 False는 코드로 증명 가능하다. 반면 nat=True는 "
+            "NAT 멀티에이전트로 라우팅됐다는 뜻일 뿐이며, 그 안에서 실제로 도구가 실행됐는지는 "
+            "이 필드가 보장하지 않는다 — NAT ReAct 에이전트가 도구 없이도 답을 낼 수 있는 "
+            "문제(#152, finus_nat/configs/agents/*.yml 전부 raise_on_parsing_failure: false)가 "
+            "열려 있는 한, false negative는 구조적으로 불가능해도 false positive는 가능하다. "
+            "실제 도구 호출 이력(ledger)은 #152에서 다룰 몫이며 이 필드는 그것을 대신하지 않는다. "
             "이 컬럼이 없던 스키마에서 만들어진 기존 행은 database._run_schema_migrations()가 "
-            "ALTER TABLE ... DEFAULT 0으로 채운다 — 즉 False는 '도구 미사용'과 "
+            "ALTER TABLE ... DEFAULT 0으로 채운다 — False는 '도구 미지원'과 "
             "'과거 행이라 확인 불가'를 모두 의미하며, 절대 True로 소급되지 않는다."
         ),
     )

--- a/backend/schema_docs.md
+++ b/backend/schema_docs.md
@@ -33,6 +33,7 @@ erDiagram
         string decision "투자 결정 (BUY/SELL/HOLD)"
         float confidence_score "신뢰도 점수"
         string reason "투자 결정 근거"
+        boolean provider_supports_tools "provider가 도구 호출 가능 경로인지 (실제 호출 관측 아님, #162)"
         datetime created_at "생성 일시"
     }
     Diary {

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -17,6 +17,13 @@ class AnalysisReport(BaseModel):
     urgency: Literal["low", "normal", "high", "critical"] = "normal"
     urgency_reason: str | None = None
     telegram_alert: bool = False
+    # #162: LLM 원문 JSON에는 없는 필드. services.perform_stock_analysis가
+    # analysis_from_nat_text 호출 이후 provider_supports_tools()로 파생한 값을
+    # 덮어써 채운다. 기본값(None/False)은 이 스키마가 (드물게) LLM 응답 파싱
+    # 경로에서 직접 쓰일 때를 위한 안전값일 뿐, /api/v1/analyze 응답에서는 항상
+    # perform_stock_analysis가 실제 provider 값으로 덮어쓴다.
+    provider: str | None = None
+    provider_supports_tools: bool = False
 
 
 class CommonResponse(BaseModel):

--- a/backend/services.py
+++ b/backend/services.py
@@ -251,6 +251,7 @@ async def perform_stock_analysis(
             decision=details.get("decision", "HOLD"),
             confidence_score=details.get("confidence_score", 0.0),
             reason=details.get("reason", ""),
+            tool_verified=provider_is_tool_backed(key),
         )
         session.add(report)
         session.commit()
@@ -679,3 +680,22 @@ async def llm_chat(
     if provider_key == "ollama":
         return await _llm_ollama_chat(user_msg)
     return await _llm_nat_chat(user_msg, conversation_id=conversation_id)
+
+
+# llm_chat의 분기와 함께 유지한다: 실제로 MCP/KIS/뉴스 도구를 호출하는 provider만 여기
+# 나열한다. _llm_openai_chat/_llm_anthropic_chat/_llm_ollama_chat은 tools 파라미터 없이
+# 모델을 그대로 호출하므로 도구 근거가 없다 (#162). nat만 NAT 멀티에이전트를 거쳐
+# 실제 시장 데이터를 조회한다. 새 provider가 도구를 갖추게 되면 이 집합 한 곳만 갱신하면
+# provider_is_tool_backed()를 쓰는 모든 호출부(AgentReport.tool_verified 등)에 반영된다.
+_TOOL_BACKED_PROVIDERS: frozenset[str] = frozenset({"nat"})
+
+
+def provider_is_tool_backed(
+    provider_key: Literal["openai", "anthropic", "nat", "ollama"],
+) -> bool:
+    """provider_key가 실제 도구(MCP/KIS/뉴스)를 호출해 응답을 생성하는지 여부.
+
+    AgentReport.tool_verified는 항상 이 함수로 파생시킨다 — 호출부가 True/False를
+    손으로 넘기면 언젠가 어긋난다.
+    """
+    return provider_key in _TOOL_BACKED_PROVIDERS

--- a/backend/services.py
+++ b/backend/services.py
@@ -239,6 +239,12 @@ async def perform_stock_analysis(
     raw = await llm_chat(key, user_msg, conversation_id=nat_cid)
     data = analysis_from_nat_text(str(raw), stock)
 
+    # #162: 이 값을 API 응답(data)과 DB 저장(report) 양쪽에 동일하게 붙인다 —
+    # 소비자가 provider 문자열만 보고 도구 사용 여부를 스스로 추론하지 않게 한다.
+    supports_tools = provider_supports_tools(key)
+    data["provider"] = key
+    data["provider_supports_tools"] = supports_tools
+
     # 분석 리포트를 데이터베이스에 자동으로 저장
     try:
         details = data.get("details", {})
@@ -251,7 +257,7 @@ async def perform_stock_analysis(
             decision=details.get("decision", "HOLD"),
             confidence_score=details.get("confidence_score", 0.0),
             reason=details.get("reason", ""),
-            tool_verified=provider_is_tool_backed(key),
+            provider_supports_tools=supports_tools,
         )
         session.add(report)
         session.commit()
@@ -682,20 +688,28 @@ async def llm_chat(
     return await _llm_nat_chat(user_msg, conversation_id=conversation_id)
 
 
-# llm_chat의 분기와 함께 유지한다: 실제로 MCP/KIS/뉴스 도구를 호출하는 provider만 여기
-# 나열한다. _llm_openai_chat/_llm_anthropic_chat/_llm_ollama_chat은 tools 파라미터 없이
-# 모델을 그대로 호출하므로 도구 근거가 없다 (#162). nat만 NAT 멀티에이전트를 거쳐
-# 실제 시장 데이터를 조회한다. 새 provider가 도구를 갖추게 되면 이 집합 한 곳만 갱신하면
-# provider_is_tool_backed()를 쓰는 모든 호출부(AgentReport.tool_verified 등)에 반영된다.
-_TOOL_BACKED_PROVIDERS: frozenset[str] = frozenset({"nat"})
+# llm_chat의 분기와 함께 유지한다: NAT처럼 도구(MCP/KIS/뉴스)를 호출할 수 있는 경로로
+# 라우팅되는 provider만 여기 나열한다. _llm_openai_chat/_llm_anthropic_chat/
+# _llm_ollama_chat은 tools 파라미터 없이 모델을 그대로 호출하므로, 이 셋에 대해
+# False라는 것은 코드로 증명 가능하다 (#162). 반대로 "nat"은 NAT 멀티에이전트로
+# 라우팅된다는 provider 차원의 능력만 의미할 뿐, 그 호출에서 실제로 도구가 실행됐다는
+# 관측이 아니다 — NAT ReAct 에이전트가 도구 없이도 답을 낼 수 있는 문제(#152, 여섯
+# finus_nat/configs/agents/*.yml 모두 raise_on_parsing_failure: false)가 열려 있는
+# 한, 이 필드는 false negative는 구조적으로 불가능해도 false positive는 가능한
+# 비대칭적인 신호다. 실제 도구 호출 이력(ledger)은 #152의 몫이며 여기서 만들지 않는다.
+# 새 provider가 도구를 갖추게 되면 이 집합 한 곳만 갱신하면 provider_supports_tools()를
+# 쓰는 모든 호출부(AgentReport.provider_supports_tools 등)에 반영된다.
+_TOOL_CAPABLE_PROVIDERS: frozenset[str] = frozenset({"nat"})
 
 
-def provider_is_tool_backed(
+def provider_supports_tools(
     provider_key: Literal["openai", "anthropic", "nat", "ollama"],
 ) -> bool:
-    """provider_key가 실제 도구(MCP/KIS/뉴스)를 호출해 응답을 생성하는지 여부.
+    """provider_key가 도구(MCP/KIS/뉴스)를 호출할 수 있는 경로로 라우팅되는지 여부.
 
-    AgentReport.tool_verified는 항상 이 함수로 파생시킨다 — 호출부가 True/False를
-    손으로 넘기면 언젠가 어긋난다.
+    이것은 provider 자체에서 파생한 "능력" 신호다 — 이번 호출에서 실제로 도구가
+    호출됐다는 관측이 아니다 (#152 참고). AgentReport.provider_supports_tools와
+    /api/v1/analyze 응답의 provider_supports_tools는 항상 이 함수로 파생시킨다 —
+    호출부가 True/False를 손으로 넘기면 언젠가 어긋난다.
     """
-    return provider_key in _TOOL_BACKED_PROVIDERS
+    return provider_key in _TOOL_CAPABLE_PROVIDERS

--- a/backend/services.py
+++ b/backend/services.py
@@ -25,6 +25,12 @@ from .models import AgentReport
 logger = logging.getLogger(__name__)
 _NAT_RESPONSE_LOG_PREVIEW_CHARS = 800
 
+# LLM 출력이 절대 정할 수 없는, 서버가 provider에서만 파생하는 필드.
+# analysis_from_nat_text가 모델의 raw JSON을 그대로 AnalysisReport에 넘기면
+# 악의적이거나 비정상적인 LLM 출력이 이 값들을 주입할 수 있으므로 파싱 단계에서
+# 걷어낸다. 실제 값은 perform_stock_analysis가 provider_supports_tools()로 채운다.
+_DERIVED_PROVENANCE_FIELDS = frozenset({"provider", "provider_supports_tools"})
+
 # 입력이 이미 종목코드 형태인지 판정하는 범위. mcp-trading/stock-master.js의
 # resolveStock() 지름길(6~7자 영숫자를 그대로 코드로 인정)과 상한을 맞춘다.
 # KIS 국내 종목코드는 6자리 숫자(005930)만이 아니다. 코스닥 스팩·리츠 등 약 18%가
@@ -614,7 +620,9 @@ def analysis_from_nat_text(raw: str, stock: str) -> dict[str, Any]:
     text = (raw or "").strip()
     for data in _json_objects_from_text(text):
         try:
-            report = AnalysisReport(**data)
+            report = AnalysisReport(
+                **{k: v for k, v in data.items() if k not in _DERIVED_PROVENANCE_FIELDS}
+            )
             dumped = report.model_dump()
             if dumped.get("source_signals") is None:
                 dumped["source_signals"] = dumped.get("source_news", [])

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -210,3 +210,80 @@ async def test_analyze_stock_saves_report(client: TestClient, session: Session, 
     assert reports[0].decision == "BUY"
     assert reports[0].confidence_score == 0.85
     assert reports[0].stock_code == "005930"
+    # /api/v1/analyze의 기본 provider(openai)는 tools 없이 모델을 그대로 호출하므로
+    # (#162) 저장되는 리포트는 도구 검증되지 않은 것으로 표시되어야 한다.
+    assert reports[0].tool_verified is False
+
+
+@pytest.mark.asyncio
+async def test_analyze_stock_via_nat_marks_report_tool_verified(client: TestClient, session: Session, monkeypatch):
+    """provider=nat 경로는 실제 도구(MCP/KIS/뉴스)를 거치므로 tool_verified=True로
+    저장되어야 한다. #162 수용 기준: provider=nat 경로의 동작은 불변이어야 한다.
+    """
+    async def mock_llm_chat(*args, **kwargs):
+        return "mocked raw response"
+
+    def mock_analysis_from_nat_text(raw_text, stock):
+        return {
+            "summary": f"Summary for {stock}",
+            "details": {
+                "decision": "HOLD",
+                "confidence_score": 0.5,
+                "reason": "no strong signal",
+            },
+        }
+
+    async def mock_run_mcp_tool(*args, **kwargs):
+        return "삼성전자 (005930, KOSPI)"
+
+    monkeypatch.setattr("backend.services.llm_chat", mock_llm_chat)
+    monkeypatch.setattr("backend.services.analysis_from_nat_text", mock_analysis_from_nat_text)
+    monkeypatch.setattr("backend.services.run_mcp_tool", mock_run_mcp_tool)
+
+    response = client.get("/api/v1/analyze?stock=삼성전자&provider=nat")
+    assert response.status_code == 200
+
+    reports = session.query(AgentReport).all()
+    assert len(reports) == 1
+    assert reports[0].provider == "nat"
+    assert reports[0].tool_verified is True
+
+
+@pytest.mark.asyncio
+async def test_db_reports_round_trips_tool_verified_field(client: TestClient, session: Session, monkeypatch):
+    """GET /api/v1/db/reports 응답 JSON에 tool_verified 필드가 실제 값 그대로
+    포함되어야 한다. AgentReport에 필드를 추가했지만 API 응답 스키마에서 빠뜨리면
+    이 테스트가 깨진다.
+    """
+    async def mock_llm_chat(*args, **kwargs):
+        return "mocked raw response"
+
+    def mock_analysis_from_nat_text(raw_text, stock):
+        return {
+            "summary": f"Summary for {stock}",
+            "details": {
+                "decision": "SELL",
+                "confidence_score": 0.3,
+                "reason": "약세 신호",
+            },
+        }
+
+    async def mock_run_mcp_tool(*args, **kwargs):
+        return "삼성전자 (005930, KOSPI)"
+
+    monkeypatch.setattr("backend.services.llm_chat", mock_llm_chat)
+    monkeypatch.setattr("backend.services.analysis_from_nat_text", mock_analysis_from_nat_text)
+    monkeypatch.setattr("backend.services.run_mcp_tool", mock_run_mcp_tool)
+
+    # openai(기본값, 도구 미사용)와 nat(도구 사용) 둘 다 저장
+    assert client.get("/api/v1/analyze?stock=삼성전자").status_code == 200
+    assert client.get("/api/v1/analyze?stock=삼성전자&provider=nat").status_code == 200
+
+    response = client.get("/api/v1/db/reports")
+    assert response.status_code == 200
+    reports = response.json()["data"]
+    assert len(reports) == 2
+
+    by_provider = {r["provider"]: r for r in reports}
+    assert by_provider["openai"]["tool_verified"] is False
+    assert by_provider["nat"]["tool_verified"] is True

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -202,6 +202,12 @@ async def test_analyze_stock_saves_report(client: TestClient, session: Session, 
     response = client.get("/api/v1/analyze?stock=삼성전자")
     assert response.status_code == 200
     assert response.json()["status"] == "success"
+    payload = response.json()["data"]
+    # /api/v1/analyze 응답 payload 자체에도 provider/provider_supports_tools가
+    # 실려야 한다 (#162 HIGH2) - AnalysisReport만 반환하고 저장된 값을 붙이지
+    # 않으면 이 두 줄이 깨진다.
+    assert payload["provider"] == "openai"
+    assert payload["provider_supports_tools"] is False
 
     # Verify DB save
     reports = session.query(AgentReport).all()
@@ -211,14 +217,18 @@ async def test_analyze_stock_saves_report(client: TestClient, session: Session, 
     assert reports[0].confidence_score == 0.85
     assert reports[0].stock_code == "005930"
     # /api/v1/analyze의 기본 provider(openai)는 tools 없이 모델을 그대로 호출하므로
-    # (#162) 저장되는 리포트는 도구 검증되지 않은 것으로 표시되어야 한다.
-    assert reports[0].tool_verified is False
+    # (#162) 저장되는 리포트는 도구를 쓸 수 없는 provider로 표시되어야 한다.
+    assert reports[0].provider_supports_tools is False
 
 
 @pytest.mark.asyncio
-async def test_analyze_stock_via_nat_marks_report_tool_verified(client: TestClient, session: Session, monkeypatch):
-    """provider=nat 경로는 실제 도구(MCP/KIS/뉴스)를 거치므로 tool_verified=True로
-    저장되어야 한다. #162 수용 기준: provider=nat 경로의 동작은 불변이어야 한다.
+async def test_analyze_stock_via_nat_marks_report_tool_supporting(client: TestClient, session: Session, monkeypatch):
+    """provider=nat 경로는 도구를 호출할 수 있는 경로로 라우팅되므로
+    provider_supports_tools=True로 저장되고 응답 payload에도 실려야 한다.
+    (#162 수용 기준: provider=nat 경로의 동작은 불변이어야 한다.) True는 이번
+    호출에서 실제로 도구가 호출됐다는 관측이 아니라 provider 능력 신호일 뿐이다
+    (#152가 열려 있는 한 그렇다) - 그래도 provider=nat이면 반드시 True로
+    기록되어야 한다는 점은 이 테스트가 고정한다.
     """
     async def mock_llm_chat(*args, **kwargs):
         return "mocked raw response"
@@ -242,18 +252,21 @@ async def test_analyze_stock_via_nat_marks_report_tool_verified(client: TestClie
 
     response = client.get("/api/v1/analyze?stock=삼성전자&provider=nat")
     assert response.status_code == 200
+    payload = response.json()["data"]
+    assert payload["provider"] == "nat"
+    assert payload["provider_supports_tools"] is True
 
     reports = session.query(AgentReport).all()
     assert len(reports) == 1
     assert reports[0].provider == "nat"
-    assert reports[0].tool_verified is True
+    assert reports[0].provider_supports_tools is True
 
 
 @pytest.mark.asyncio
-async def test_db_reports_round_trips_tool_verified_field(client: TestClient, session: Session, monkeypatch):
-    """GET /api/v1/db/reports 응답 JSON에 tool_verified 필드가 실제 값 그대로
-    포함되어야 한다. AgentReport에 필드를 추가했지만 API 응답 스키마에서 빠뜨리면
-    이 테스트가 깨진다.
+async def test_db_reports_round_trips_provider_supports_tools_field(client: TestClient, session: Session, monkeypatch):
+    """GET /api/v1/db/reports 응답 JSON에 provider_supports_tools 필드가 실제 값
+    그대로 포함되어야 한다. AgentReport에 필드를 추가했지만 API 응답 스키마에서
+    빠뜨리면 이 테스트가 깨진다.
     """
     async def mock_llm_chat(*args, **kwargs):
         return "mocked raw response"
@@ -275,7 +288,7 @@ async def test_db_reports_round_trips_tool_verified_field(client: TestClient, se
     monkeypatch.setattr("backend.services.analysis_from_nat_text", mock_analysis_from_nat_text)
     monkeypatch.setattr("backend.services.run_mcp_tool", mock_run_mcp_tool)
 
-    # openai(기본값, 도구 미사용)와 nat(도구 사용) 둘 다 저장
+    # openai(기본값, 도구 미지원)와 nat(도구 경로) 둘 다 저장
     assert client.get("/api/v1/analyze?stock=삼성전자").status_code == 200
     assert client.get("/api/v1/analyze?stock=삼성전자&provider=nat").status_code == 200
 
@@ -285,5 +298,5 @@ async def test_db_reports_round_trips_tool_verified_field(client: TestClient, se
     assert len(reports) == 2
 
     by_provider = {r["provider"]: r for r in reports}
-    assert by_provider["openai"]["tool_verified"] is False
-    assert by_provider["nat"]["tool_verified"] is True
+    assert by_provider["openai"]["provider_supports_tools"] is False
+    assert by_provider["nat"]["provider_supports_tools"] is True

--- a/backend/tests/test_schema_migrations.py
+++ b/backend/tests/test_schema_migrations.py
@@ -1,0 +1,134 @@
+"""#162: SQLModel의 create_all()은 새 테이블은 만들지만 이미 존재하는 테이블에
+컬럼을 추가하지 않는다 (SQLAlchemy 문서화된 동작, alembic 없는 이 repo에서는
+database._run_schema_migrations()가 그 간극을 메운다). 여기서는 실제로 컬럼이
+없는 "구버전" SQLite 파일을 직접 만든 뒤 새 코드가 그 파일에 대해 무엇을 하는지
+검증한다 — 새로 만든 빈 DB만으로는 이 회귀를 잡을 수 없다.
+"""
+import sqlite3
+
+from sqlalchemy import Column, DateTime, Float, Integer, MetaData, String, Table, create_engine
+
+from backend import database
+
+
+def _create_old_schema_agentreport(db_path: str) -> None:
+    """tool_verified 컬럼이 없던 시절(이 브랜치 이전 models.py)의 agentreport
+    테이블을 그대로 재현한다 — created_at을 포함한 다른 컬럼은 이번 변경으로
+    새로 생긴 것이 아니므로 그대로 둔다.
+    """
+    old_metadata = MetaData()
+    Table(
+        "agentreport",
+        old_metadata,
+        Column("id", Integer, primary_key=True),
+        Column("stock_code", String),
+        Column("stock_name", String),
+        Column("provider", String),
+        Column("summary", String),
+        Column("decision", String),
+        Column("confidence_score", Float),
+        Column("reason", String),
+        Column("created_at", DateTime),
+    )
+    old_engine = create_engine(f"sqlite:///{db_path}")
+    old_metadata.create_all(old_engine)
+    with old_engine.begin() as conn:
+        conn.exec_driver_sql(
+            "INSERT INTO agentreport "
+            "(stock_code, stock_name, provider, summary, decision, confidence_score, reason, created_at) "
+            "VALUES ('005930', '삼성전자', 'openai', '요약', 'BUY', 0.9, '지어낸 근거', "
+            "'2026-01-01 00:00:00')"
+        )
+    old_engine.dispose()
+
+
+def test_create_all_does_not_add_column_to_existing_table(tmp_path):
+    """전제 확인: create_all만으로는 기존 agentreport 테이블에 tool_verified가
+    생기지 않는다. 이 전제가 깨지면(SQLAlchemy 동작이 바뀌면) 아래 마이그레이션
+    로직 자체가 불필요해지므로 먼저 명시적으로 확인한다.
+    """
+    db_path = tmp_path / "old_only_create_all.db"
+    _create_old_schema_agentreport(str(db_path))
+
+    from sqlmodel import SQLModel
+
+    probe_engine = create_engine(f"sqlite:///{db_path}")
+    SQLModel.metadata.create_all(probe_engine)  # backend.models의 실제 모델 정의 사용
+    probe_engine.dispose()
+
+    conn = sqlite3.connect(str(db_path))
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(agentreport)")}
+    conn.close()
+    assert "tool_verified" not in columns
+
+
+def test_init_db_adds_missing_column_to_old_schema_db(tmp_path, monkeypatch):
+    """database.init_db()를 구버전 DB 파일에 대해 실행하면 tool_verified 컬럼이
+    NOT NULL DEFAULT 0으로 추가되어야 한다. 마이그레이션 SQL을 지우거나 컬럼명을
+    틀리면 이 테스트가 깨진다.
+    """
+    db_path = tmp_path / "old_schema.db"
+    _create_old_schema_agentreport(str(db_path))
+
+    test_engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+    monkeypatch.setattr(database, "engine", test_engine)
+
+    database.init_db()
+
+    conn = sqlite3.connect(str(db_path))
+    cols = {row[1]: row for row in conn.execute("PRAGMA table_info(agentreport)")}
+    conn.close()
+    assert "tool_verified" in cols
+    _, name, col_type, notnull, default, _pk = cols["tool_verified"]
+    assert col_type.upper() in ("BOOLEAN", "BOOL")
+    assert notnull == 1
+
+
+def test_pre_existing_row_does_not_read_as_tool_verified(tmp_path, monkeypatch):
+    """마이그레이션이 채우는 기본값은 반드시 False(0)여야 한다. 구버전 DB에 이미
+    저장돼 있던, 도구 없이 지어낸 리포트가 마이그레이션 한 번으로 "검증됨"으로
+    둔갑하면 #162가 지적한 결함보다 더 나쁜 상태가 된다. 기본값을 1이나 NULL로
+    바꾸면 이 테스트가 깨진다.
+    """
+    db_path = tmp_path / "old_schema_row.db"
+    _create_old_schema_agentreport(str(db_path))
+
+    test_engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+    monkeypatch.setattr(database, "engine", test_engine)
+
+    database.init_db()
+
+    from sqlmodel import Session, select
+
+    from backend.models import AgentReport
+
+    with Session(test_engine) as session:
+        rows = session.exec(select(AgentReport)).all()
+        assert len(rows) == 1
+        assert rows[0].stock_name == "삼성전자"
+        assert rows[0].tool_verified is False
+
+    # ORM 계층을 우회해 raw SQLite 값도 직접 확인 (0이어야 하며 NULL이 아니어야 함)
+    conn = sqlite3.connect(str(db_path))
+    raw_value = conn.execute("SELECT tool_verified FROM agentreport").fetchone()[0]
+    conn.close()
+    assert raw_value == 0
+
+
+def test_init_db_is_idempotent_on_already_migrated_db(tmp_path, monkeypatch):
+    """init_db()를 두 번 호출해도(재기동 시나리오) 이미 컬럼이 있으면 ALTER TABLE을
+    다시 시도해 예외를 던지지 않아야 한다.
+    """
+    db_path = tmp_path / "already_migrated.db"
+    _create_old_schema_agentreport(str(db_path))
+
+    test_engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+    monkeypatch.setattr(database, "engine", test_engine)
+
+    database.init_db()
+    database.init_db()  # 두 번째 호출에서 예외가 나면 테스트 실패
+
+    conn = sqlite3.connect(str(db_path))
+    columns = [row[1] for row in conn.execute("PRAGMA table_info(agentreport)")]
+    conn.close()
+    assert columns.count("tool_verified") == 1

--- a/backend/tests/test_schema_migrations.py
+++ b/backend/tests/test_schema_migrations.py
@@ -196,3 +196,50 @@ def test_init_db_concurrent_migration_does_not_abort_startup(tmp_path, monkeypat
     conn.close()
     assert columns.count("provider_supports_tools") == 1
     assert row_count == 1  # 기존 행이 중복 삽입되지 않았는지도 함께 확인
+
+
+def test_init_db_concurrent_on_empty_db_does_not_abort_startup(tmp_path, monkeypatch):
+    """🟡2: 빈 DB(사전 스키마 없음)에서 여러 워커가 동시에 init_db()를 호출해도
+    startup이 abort되지 않아야 한다.
+
+    test_init_db_concurrent_migration_does_not_abort_startup는 구버전 스키마가
+    이미 존재하는 경우(ALTER TABLE 경합)를 검증한다. 이 테스트는 그것과 달리
+    _create_old_schema_agentreport()로 사전 스키마를 만들지 않고, 완전히 빈 DB에서
+    create_all() 자체가 "table already exists" 경합을 일으키는 경로를 고정한다.
+    수정 전에는 init_db()의 create_all()이 OperationalError를 흡수하지 않아
+    늦게 도착한 워커가 startup을 abort시킬 수 있었다.
+    """
+    db_path = tmp_path / "empty_concurrent.db"
+    # 빈 DB: 사전 스키마 생성 없이 바로 동시 호출
+    test_engine = create_engine(
+        f"sqlite:///{db_path}",
+        connect_args={"check_same_thread": False, "timeout": 30},
+    )
+    monkeypatch.setattr(database, "engine", test_engine)
+
+    errors: list[BaseException] = []
+    errors_lock = threading.Lock()
+    thread_count = 6
+    barrier = threading.Barrier(thread_count)
+
+    def worker() -> None:
+        barrier.wait()
+        try:
+            database.init_db()
+        except BaseException as exc:  # noqa: BLE001 - 테스트가 모든 실패를 관찰해야 함
+            with errors_lock:
+                errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(thread_count)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == [], f"빈 DB에서 동시 init_db()가 예외를 던졌다: {errors!r}"
+
+    import sqlite3
+    conn = sqlite3.connect(str(db_path))
+    columns = [row[1] for row in conn.execute("PRAGMA table_info(agentreport)")]
+    conn.close()
+    assert "provider_supports_tools" in columns

--- a/backend/tests/test_schema_migrations.py
+++ b/backend/tests/test_schema_migrations.py
@@ -5,6 +5,7 @@ database._run_schema_migrations()가 그 간극을 메운다). 여기서는 실�
 검증한다 — 새로 만든 빈 DB만으로는 이 회귀를 잡을 수 없다.
 """
 import sqlite3
+import threading
 
 from sqlalchemy import Column, DateTime, Float, Integer, MetaData, String, Table, create_engine
 
@@ -12,10 +13,23 @@ from backend import database
 
 
 def _create_old_schema_agentreport(db_path: str) -> None:
-    """tool_verified 컬럼이 없던 시절(이 브랜치 이전 models.py)의 agentreport
-    테이블을 그대로 재현한다 — created_at을 포함한 다른 컬럼은 이번 변경으로
-    새로 생긴 것이 아니므로 그대로 둔다.
+    """provider_supports_tools 컬럼이 없던 시절(이 브랜치 이전 models.py)의
+    agentreport 테이블을 그대로 재현한다 — created_at을 포함한 다른 컬럼은 이번
+    변경으로 새로 생긴 것이 아니므로 그대로 둔다.
+
+    다른 테이블(Portfolio, TradeHistory, Diary 등)은 실제 배포 환경처럼 이미
+    최신 스키마로 존재한다고 가정하고 먼저 만들어 둔다 — 이 브랜치가 건드린 건
+    agentreport 하나뿐이므로 나머지가 구버전일 이유가 없고, 만약 여기서 만들지
+    않으면 동시성 테스트(test_init_db_concurrent_migration_does_not_abort_startup)
+    에서 create_all() 자체가 agentreport 외의 테이블을 놓고 별개의
+    "table already exists" 경합을 일으켜 우리가 실제로 검증하려는
+    ALTER TABLE 경합(MEDIUM3)과 뒤섞인다.
     """
+    from sqlmodel import SQLModel
+
+    setup_engine = create_engine(f"sqlite:///{db_path}")
+    SQLModel.metadata.create_all(setup_engine)  # 최신 스키마로 다른 테이블들 생성
+
     old_metadata = MetaData()
     Table(
         "agentreport",
@@ -30,22 +44,23 @@ def _create_old_schema_agentreport(db_path: str) -> None:
         Column("reason", String),
         Column("created_at", DateTime),
     )
-    old_engine = create_engine(f"sqlite:///{db_path}")
-    old_metadata.create_all(old_engine)
-    with old_engine.begin() as conn:
+    with setup_engine.begin() as conn:
+        conn.exec_driver_sql("DROP TABLE agentreport")  # 최신 스키마로 만들어진 것을 버리고
+    old_metadata.create_all(setup_engine)  # 구버전 agentreport로 다시 만든다
+    with setup_engine.begin() as conn:
         conn.exec_driver_sql(
             "INSERT INTO agentreport "
             "(stock_code, stock_name, provider, summary, decision, confidence_score, reason, created_at) "
             "VALUES ('005930', '삼성전자', 'openai', '요약', 'BUY', 0.9, '지어낸 근거', "
             "'2026-01-01 00:00:00')"
         )
-    old_engine.dispose()
+    setup_engine.dispose()
 
 
 def test_create_all_does_not_add_column_to_existing_table(tmp_path):
-    """전제 확인: create_all만으로는 기존 agentreport 테이블에 tool_verified가
-    생기지 않는다. 이 전제가 깨지면(SQLAlchemy 동작이 바뀌면) 아래 마이그레이션
-    로직 자체가 불필요해지므로 먼저 명시적으로 확인한다.
+    """전제 확인: create_all만으로는 기존 agentreport 테이블에
+    provider_supports_tools가 생기지 않는다. 이 전제가 깨지면(SQLAlchemy 동작이
+    바뀌면) 아래 마이그레이션 로직 자체가 불필요해지므로 먼저 명시적으로 확인한다.
     """
     db_path = tmp_path / "old_only_create_all.db"
     _create_old_schema_agentreport(str(db_path))
@@ -59,13 +74,13 @@ def test_create_all_does_not_add_column_to_existing_table(tmp_path):
     conn = sqlite3.connect(str(db_path))
     columns = {row[1] for row in conn.execute("PRAGMA table_info(agentreport)")}
     conn.close()
-    assert "tool_verified" not in columns
+    assert "provider_supports_tools" not in columns
 
 
 def test_init_db_adds_missing_column_to_old_schema_db(tmp_path, monkeypatch):
-    """database.init_db()를 구버전 DB 파일에 대해 실행하면 tool_verified 컬럼이
-    NOT NULL DEFAULT 0으로 추가되어야 한다. 마이그레이션 SQL을 지우거나 컬럼명을
-    틀리면 이 테스트가 깨진다.
+    """database.init_db()를 구버전 DB 파일에 대해 실행하면 provider_supports_tools
+    컬럼이 NOT NULL DEFAULT 0으로 추가되어야 한다. 마이그레이션 SQL을 지우거나
+    컬럼명을 틀리면 이 테스트가 깨진다.
     """
     db_path = tmp_path / "old_schema.db"
     _create_old_schema_agentreport(str(db_path))
@@ -78,15 +93,15 @@ def test_init_db_adds_missing_column_to_old_schema_db(tmp_path, monkeypatch):
     conn = sqlite3.connect(str(db_path))
     cols = {row[1]: row for row in conn.execute("PRAGMA table_info(agentreport)")}
     conn.close()
-    assert "tool_verified" in cols
-    _, name, col_type, notnull, default, _pk = cols["tool_verified"]
+    assert "provider_supports_tools" in cols
+    _, name, col_type, notnull, default, _pk = cols["provider_supports_tools"]
     assert col_type.upper() in ("BOOLEAN", "BOOL")
     assert notnull == 1
 
 
-def test_pre_existing_row_does_not_read_as_tool_verified(tmp_path, monkeypatch):
+def test_pre_existing_row_does_not_read_as_provider_supports_tools(tmp_path, monkeypatch):
     """마이그레이션이 채우는 기본값은 반드시 False(0)여야 한다. 구버전 DB에 이미
-    저장돼 있던, 도구 없이 지어낸 리포트가 마이그레이션 한 번으로 "검증됨"으로
+    저장돼 있던, 도구 없이 지어낸 리포트가 마이그레이션 한 번으로 "도구 지원"으로
     둔갑하면 #162가 지적한 결함보다 더 나쁜 상태가 된다. 기본값을 1이나 NULL로
     바꾸면 이 테스트가 깨진다.
     """
@@ -106,11 +121,11 @@ def test_pre_existing_row_does_not_read_as_tool_verified(tmp_path, monkeypatch):
         rows = session.exec(select(AgentReport)).all()
         assert len(rows) == 1
         assert rows[0].stock_name == "삼성전자"
-        assert rows[0].tool_verified is False
+        assert rows[0].provider_supports_tools is False
 
     # ORM 계층을 우회해 raw SQLite 값도 직접 확인 (0이어야 하며 NULL이 아니어야 함)
     conn = sqlite3.connect(str(db_path))
-    raw_value = conn.execute("SELECT tool_verified FROM agentreport").fetchone()[0]
+    raw_value = conn.execute("SELECT provider_supports_tools FROM agentreport").fetchone()[0]
     conn.close()
     assert raw_value == 0
 
@@ -131,4 +146,53 @@ def test_init_db_is_idempotent_on_already_migrated_db(tmp_path, monkeypatch):
     conn = sqlite3.connect(str(db_path))
     columns = [row[1] for row in conn.execute("PRAGMA table_info(agentreport)")]
     conn.close()
-    assert columns.count("tool_verified") == 1
+    assert columns.count("provider_supports_tools") == 1
+
+
+def test_init_db_concurrent_migration_does_not_abort_startup(tmp_path, monkeypatch):
+    """MEDIUM3: check(컬럼 존재 확인)와 act(ALTER TABLE)가 원자적이지 않으므로,
+    여러 워커가 동시에 init_db()를 호출하면(현재는 Dockerfile이 --workers 없이
+    단일 프로세스라 해당 없지만, 그 가정이 바뀌면 바로 재현된다) 컬럼을 먼저 추가한
+    쪽을 제외한 나머지가 'duplicate column name' OperationalError로 lifespan을
+    타고 올라가 startup 자체를 abort시킬 수 있다. 재현: 구버전 DB 하나에 스레드
+    여러 개가 동시에 init_db()를 호출한다 — 수정 전에는 재현 환경에서 6개 중
+    5개가 예외를 던졌다.
+    """
+    db_path = tmp_path / "concurrent_migration.db"
+    _create_old_schema_agentreport(str(db_path))
+
+    # timeout(=busy_timeout)을 넉넉히 줘서 "database is locked"으로 인한 재현
+    # 불안정성을 줄인다 - 우리가 잡으려는 것은 락 경합이 아니라 duplicate column race다.
+    test_engine = create_engine(
+        f"sqlite:///{db_path}",
+        connect_args={"check_same_thread": False, "timeout": 30},
+    )
+    monkeypatch.setattr(database, "engine", test_engine)
+
+    errors: list[BaseException] = []
+    errors_lock = threading.Lock()
+    thread_count = 6
+    barrier = threading.Barrier(thread_count)
+
+    def worker() -> None:
+        barrier.wait()
+        try:
+            database.init_db()
+        except BaseException as exc:  # noqa: BLE001 - 테스트가 모든 실패를 관찰해야 함
+            with errors_lock:
+                errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(thread_count)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == [], f"init_db()가 동시 호출에서 예외를 던졌다: {errors!r}"
+
+    conn = sqlite3.connect(str(db_path))
+    columns = [row[1] for row in conn.execute("PRAGMA table_info(agentreport)")]
+    row_count = conn.execute("SELECT COUNT(*) FROM agentreport").fetchone()[0]
+    conn.close()
+    assert columns.count("provider_supports_tools") == 1
+    assert row_count == 1  # 기존 행이 중복 삽입되지 않았는지도 함께 확인

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -1,4 +1,6 @@
+import inspect
 import logging
+import typing
 from datetime import date
 from urllib.parse import quote
 from types import SimpleNamespace
@@ -143,23 +145,94 @@ async def test_perform_stock_analysis_includes_trigger_signal(monkeypatch):
     assert '"source_signals"' in prompts[0][1]
 
 
-def test_provider_is_tool_backed_matches_llm_chat_dispatch():
-    """provider_is_tool_backed()는 llm_chat의 provider 분기와 반드시 일치해야 한다.
-    (#162) tools 없이 모델을 그대로 호출하는 openai/anthropic/ollama는 False,
-    실제 MCP/KIS/뉴스를 거치는 nat만 True. 새 provider가 도구를 갖추게 되면 이
-    테스트도 갱신해야 한다는 신호가 된다.
+@pytest.mark.asyncio
+async def test_provider_supports_tools_matches_llm_chat_dispatch(monkeypatch):
+    """provider_supports_tools()가 llm_chat의 실제 라우팅과 어긋나지 않는지 확인한다.
+
+    이전 버전은 provider_is_tool_backed의 출력을 하드코딩된 기대값 4개와만
+    비교했다 - llm_chat 자체의 라우팅이 깨져도(예: openai를 실수로 _llm_nat_chat에
+    연결해도) 통과했다. 여기서는 각 provider_key로 실제 services.llm_chat()을
+    호출해 내부적으로 어떤 _llm_*_chat 구현이 실행됐는지 관측하고, 그 관측치와
+    provider_supports_tools()의 답을 대조한다.
+
+    typing.get_args로 llm_chat의 provider_key Literal을 그대로 열거하므로,
+    다섯 번째 provider가 Literal과 dispatch에는 추가됐는데 tool_dispatch_targets에는
+    반영되지 않으면 KeyError로 실패한다 - 하드코딩된 목록이 아니라 실제 시그니처를
+    따라간다.
     """
-    assert services.provider_is_tool_backed("openai") is False
-    assert services.provider_is_tool_backed("anthropic") is False
-    assert services.provider_is_tool_backed("ollama") is False
-    assert services.provider_is_tool_backed("nat") is True
+    invoked: list[str] = []
+
+    async def fake_openai(user_msg):
+        invoked.append("openai")
+        return "ok"
+
+    async def fake_anthropic(user_msg):
+        invoked.append("anthropic")
+        return "ok"
+
+    async def fake_ollama(user_msg):
+        invoked.append("ollama")
+        return "ok"
+
+    async def fake_nat(user_msg, *, conversation_id=None):
+        invoked.append("nat")
+        return "ok"
+
+    monkeypatch.setattr(services, "_llm_openai_chat", fake_openai)
+    monkeypatch.setattr(services, "_llm_anthropic_chat", fake_anthropic)
+    monkeypatch.setattr(services, "_llm_ollama_chat", fake_ollama)
+    monkeypatch.setattr(services, "_llm_nat_chat", fake_nat)
+
+    annotation = inspect.signature(services.llm_chat).parameters["provider_key"].annotation
+    provider_keys = typing.get_args(annotation)
+    assert provider_keys, "llm_chat의 provider_key가 Literal이 아니게 되면 이 전제부터 깨진다"
+
+    # llm_chat이 실제로 도구를 쓰는 핸들러로 보내는 내부 구현 이름.
+    # provider_key 자체가 아니라 "어디로 라우팅됐는가"로 판정한다.
+    tool_dispatch_targets = {"nat"}
+
+    for key in provider_keys:
+        invoked.clear()
+        await services.llm_chat(key, "테스트")
+        assert len(invoked) == 1, f"{key}가 정확히 하나의 _llm_*_chat 구현으로 라우팅되어야 한다"
+        dispatched_to = invoked[0]
+        expected = dispatched_to in tool_dispatch_targets
+        assert services.provider_supports_tools(key) is expected, (
+            f"provider_key={key!r}가 실제로는 {dispatched_to!r}로 라우팅되는데 "
+            f"provider_supports_tools({key!r})={services.provider_supports_tools(key)}은 "
+            f"{expected}와 어긋난다"
+        )
 
 
 @pytest.mark.asyncio
 async def test_perform_stock_analysis_marks_toolless_provider_report_unverified(monkeypatch):
     """도구 없이 호출되는 provider(openai/anthropic/ollama)로 만든 AgentReport는
-    tool_verified=False로 저장되어야 한다. provider_is_tool_backed가 항상 True를
-    반환하도록 뒤집으면(또는 perform_stock_analysis가 이 값을 무시하면) 이 테스트가
+    provider_supports_tools=False로 저장되고, API 응답 payload에도 같은 값이
+    실려야 한다. provider_supports_tools가 항상 True를 반환하도록 뒤집으면(또는
+    perform_stock_analysis가 이 값을 무시하면) 이 테스트가 깨진다.
+    """
+    async def fake_llm_chat(provider, prompt, *, conversation_id=None):
+        return "plain analysis"
+
+    async def fake_run_mcp_tool(params, tool_name, arguments):
+        return "삼성전자 (005930, KOSPI)"
+
+    monkeypatch.setattr(services, "llm_chat", fake_llm_chat)
+    monkeypatch.setattr(services, "run_mcp_tool", fake_run_mcp_tool)
+
+    session = FakeSession()
+    result = await services.perform_stock_analysis("삼성전자", "openai", session)
+
+    assert session.report.provider_supports_tools is False
+    assert result["provider"] == "openai"
+    assert result["provider_supports_tools"] is False
+
+
+@pytest.mark.asyncio
+async def test_perform_stock_analysis_marks_nat_report_tool_supporting(monkeypatch):
+    """provider=nat으로 만든 AgentReport는 provider_supports_tools=True로 저장되고,
+    API 응답 payload에도 같은 값이 실려야 한다. (#162 수용 기준: provider=nat
+    경로의 동작은 불변). _TOOL_CAPABLE_PROVIDERS에서 "nat"이 빠지면 이 테스트가
     깨진다.
     """
     async def fake_llm_chat(provider, prompt, *, conversation_id=None):
@@ -172,30 +245,11 @@ async def test_perform_stock_analysis_marks_toolless_provider_report_unverified(
     monkeypatch.setattr(services, "run_mcp_tool", fake_run_mcp_tool)
 
     session = FakeSession()
-    await services.perform_stock_analysis("삼성전자", "openai", session)
+    result = await services.perform_stock_analysis("삼성전자", "nat", session)
 
-    assert session.report.tool_verified is False
-
-
-@pytest.mark.asyncio
-async def test_perform_stock_analysis_marks_nat_report_tool_verified(monkeypatch):
-    """provider=nat으로 만든 AgentReport는 tool_verified=True로 저장되어야 한다.
-    (#162 수용 기준: provider=nat 경로의 동작은 불변). _TOOL_BACKED_PROVIDERS에서
-    "nat"이 빠지면 이 테스트가 깨진다.
-    """
-    async def fake_llm_chat(provider, prompt, *, conversation_id=None):
-        return "plain analysis"
-
-    async def fake_run_mcp_tool(params, tool_name, arguments):
-        return "삼성전자 (005930, KOSPI)"
-
-    monkeypatch.setattr(services, "llm_chat", fake_llm_chat)
-    monkeypatch.setattr(services, "run_mcp_tool", fake_run_mcp_tool)
-
-    session = FakeSession()
-    await services.perform_stock_analysis("삼성전자", "nat", session)
-
-    assert session.report.tool_verified is True
+    assert session.report.provider_supports_tools is True
+    assert result["provider"] == "nat"
+    assert result["provider_supports_tools"] is True
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -143,6 +143,61 @@ async def test_perform_stock_analysis_includes_trigger_signal(monkeypatch):
     assert '"source_signals"' in prompts[0][1]
 
 
+def test_provider_is_tool_backed_matches_llm_chat_dispatch():
+    """provider_is_tool_backed()는 llm_chat의 provider 분기와 반드시 일치해야 한다.
+    (#162) tools 없이 모델을 그대로 호출하는 openai/anthropic/ollama는 False,
+    실제 MCP/KIS/뉴스를 거치는 nat만 True. 새 provider가 도구를 갖추게 되면 이
+    테스트도 갱신해야 한다는 신호가 된다.
+    """
+    assert services.provider_is_tool_backed("openai") is False
+    assert services.provider_is_tool_backed("anthropic") is False
+    assert services.provider_is_tool_backed("ollama") is False
+    assert services.provider_is_tool_backed("nat") is True
+
+
+@pytest.mark.asyncio
+async def test_perform_stock_analysis_marks_toolless_provider_report_unverified(monkeypatch):
+    """도구 없이 호출되는 provider(openai/anthropic/ollama)로 만든 AgentReport는
+    tool_verified=False로 저장되어야 한다. provider_is_tool_backed가 항상 True를
+    반환하도록 뒤집으면(또는 perform_stock_analysis가 이 값을 무시하면) 이 테스트가
+    깨진다.
+    """
+    async def fake_llm_chat(provider, prompt, *, conversation_id=None):
+        return "plain analysis"
+
+    async def fake_run_mcp_tool(params, tool_name, arguments):
+        return "삼성전자 (005930, KOSPI)"
+
+    monkeypatch.setattr(services, "llm_chat", fake_llm_chat)
+    monkeypatch.setattr(services, "run_mcp_tool", fake_run_mcp_tool)
+
+    session = FakeSession()
+    await services.perform_stock_analysis("삼성전자", "openai", session)
+
+    assert session.report.tool_verified is False
+
+
+@pytest.mark.asyncio
+async def test_perform_stock_analysis_marks_nat_report_tool_verified(monkeypatch):
+    """provider=nat으로 만든 AgentReport는 tool_verified=True로 저장되어야 한다.
+    (#162 수용 기준: provider=nat 경로의 동작은 불변). _TOOL_BACKED_PROVIDERS에서
+    "nat"이 빠지면 이 테스트가 깨진다.
+    """
+    async def fake_llm_chat(provider, prompt, *, conversation_id=None):
+        return "plain analysis"
+
+    async def fake_run_mcp_tool(params, tool_name, arguments):
+        return "삼성전자 (005930, KOSPI)"
+
+    monkeypatch.setattr(services, "llm_chat", fake_llm_chat)
+    monkeypatch.setattr(services, "run_mcp_tool", fake_run_mcp_tool)
+
+    session = FakeSession()
+    await services.perform_stock_analysis("삼성전자", "nat", session)
+
+    assert session.report.tool_verified is True
+
+
 @pytest.mark.asyncio
 async def test_perform_stock_analysis_resolves_stock_code_via_mcp(monkeypatch):
     async def fake_llm_chat(provider, prompt, *, conversation_id=None):

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -157,7 +157,8 @@ async def test_provider_supports_tools_matches_llm_chat_dispatch(monkeypatch):
 
     typing.get_args로 llm_chat의 provider_key Literal을 그대로 열거하므로,
     다섯 번째 provider가 Literal과 dispatch에는 추가됐는데 tool_dispatch_targets에는
-    반영되지 않으면 KeyError로 실패한다 - 하드코딩된 목록이 아니라 실제 시그니처를
+    반영되지 않으면 provider_supports_tools()의 반환값과 expected가 어긋나
+    마지막 assert에서 실패한다 - 하드코딩된 목록이 아니라 실제 시그니처를
     따라간다.
     """
     invoked: list[str] = []
@@ -202,6 +203,32 @@ async def test_provider_supports_tools_matches_llm_chat_dispatch(monkeypatch):
             f"provider_supports_tools({key!r})={services.provider_supports_tools(key)}은 "
             f"{expected}와 어긋난다"
         )
+
+
+@pytest.mark.asyncio
+async def test_toolless_providers_pass_no_tools_to_the_model(monkeypatch):
+    """provider_supports_tools()가 False인 provider는 실제로 tools 없이 모델을 호출해야 한다."""
+    captured = {}
+
+    class FakeCompletions:
+        async def create(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+            )
+
+    monkeypatch.setattr(
+        services,
+        "AsyncOpenAI",
+        lambda api_key: SimpleNamespace(
+            chat=SimpleNamespace(completions=FakeCompletions())
+        ),
+    )
+    monkeypatch.setattr(services, "OPENAI_API_KEY", "test-key")
+    await services._llm_openai_chat("hi")
+    assert "tools" not in captured, (
+        "openai가 tools를 넘기면 provider_supports_tools(False)가 거짓이 된다"
+    )
 
 
 @pytest.mark.asyncio

--- a/frontend-react/src/components/RecordsPanel.tsx
+++ b/frontend-react/src/components/RecordsPanel.tsx
@@ -79,7 +79,23 @@ const RecordsPanel: React.FC<RecordsPanelProps> = ({ resources, loading, onSubmi
             <div key={item.id ?? `${item.stock_name}-${item.created_at}`} className="rounded-lg bg-slate-50 p-4">
               <div className="flex justify-between gap-3">
                 <div className="font-black text-slate-800">{item.stock_name}</div>
-                <span className="text-xs font-black text-slate-500">{item.decision}</span>
+                <div className="flex items-center gap-2">
+                  <span
+                    className={`text-[10px] font-black uppercase px-2 py-0.5 rounded-full ${
+                      item.provider_supports_tools
+                        ? 'bg-emerald-100 text-emerald-700'
+                        : 'bg-slate-200 text-slate-500'
+                    }`}
+                    title={
+                      item.provider_supports_tools
+                        ? `provider(${item.provider})가 도구 호출 경로로 구성되어 있음 — 실제 호출 여부는 확인되지 않았습니다.`
+                        : `provider(${item.provider})는 도구 없이 생성된 리포트입니다.`
+                    }
+                  >
+                    {item.provider_supports_tools ? 'TOOL-CAPABLE' : 'NO TOOLS'}
+                  </span>
+                  <span className="text-xs font-black text-slate-500">{item.decision}</span>
+                </div>
               </div>
               <p className="mt-2 line-clamp-3 text-xs leading-relaxed text-slate-500">{item.summary}</p>
             </div>

--- a/frontend-react/src/components/RecordsPanel.tsx
+++ b/frontend-react/src/components/RecordsPanel.tsx
@@ -75,31 +75,41 @@ const RecordsPanel: React.FC<RecordsPanelProps> = ({ resources, loading, onSubmi
         </div>
         <div className="space-y-3 max-h-72 overflow-auto">
           {resources.reports.length === 0 && <p className="text-sm text-slate-400">저장된 리포트가 없습니다.</p>}
-          {resources.reports.map((item) => (
-            <div key={item.id ?? `${item.stock_name}-${item.created_at}`} className="rounded-lg bg-slate-50 p-4">
-              <div className="flex justify-between gap-3">
-                <div className="font-black text-slate-800">{item.stock_name}</div>
-                <div className="flex items-center gap-2">
-                  <span
-                    className={`text-[10px] font-black uppercase px-2 py-0.5 rounded-full ${
-                      item.provider_supports_tools
-                        ? 'bg-emerald-100 text-emerald-700'
-                        : 'bg-slate-200 text-slate-500'
-                    }`}
-                    title={
-                      item.provider_supports_tools
-                        ? `provider(${item.provider})가 도구 호출 경로로 구성되어 있음 — 실제 호출 여부는 확인되지 않았습니다.`
-                        : `provider(${item.provider})는 도구 없이 생성된 리포트입니다.`
-                    }
-                  >
-                    {item.provider_supports_tools ? 'TOOL-CAPABLE' : 'NO TOOLS'}
-                  </span>
-                  <span className="text-xs font-black text-slate-500">{item.decision}</span>
+          {resources.reports.map((item) => {
+            // provider_supports_tools=False && provider==='nat'은 이 컬럼이 추가되기 전에
+            // 저장된 legacy 행을 의미한다. 새 코드는 nat이면 반드시 True를 쓰므로,
+            // nat && !supports_tools 조합은 legacy 과거 행에서만 나온다.
+            const providerLabel = item.provider ?? '알 수 없음';
+            const legacyUnknown = !item.provider_supports_tools && item.provider === 'nat';
+            const badgeLabel = item.provider_supports_tools
+              ? 'TOOL-CAPABLE'
+              : legacyUnknown ? 'UNKNOWN' : 'NO TOOLS';
+            const badgeTitle = item.provider_supports_tools
+              ? `provider(${providerLabel})가 도구 호출 경로로 구성되어 있음 — 실제 호출 여부는 확인되지 않았습니다.`
+              : legacyUnknown
+                ? `이 컬럼이 추가되기 전에 저장된 리포트입니다. 도구 사용 여부를 확인할 수 없습니다.`
+                : `provider(${providerLabel})는 도구 없이 생성된 리포트입니다.`;
+            const badgeClass = item.provider_supports_tools
+              ? 'bg-emerald-100 text-emerald-700'
+              : legacyUnknown ? 'bg-amber-100 text-amber-600' : 'bg-slate-200 text-slate-500';
+            return (
+              <div key={item.id ?? `${item.stock_name}-${item.created_at}`} className="rounded-lg bg-slate-50 p-4">
+                <div className="flex justify-between gap-3">
+                  <div className="font-black text-slate-800">{item.stock_name}</div>
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={`text-[10px] font-black uppercase px-2 py-0.5 rounded-full ${badgeClass}`}
+                      title={badgeTitle}
+                    >
+                      {badgeLabel}
+                    </span>
+                    <span className="text-xs font-black text-slate-500">{item.decision}</span>
+                  </div>
                 </div>
+                <p className="mt-2 line-clamp-3 text-xs leading-relaxed text-slate-500">{item.summary}</p>
               </div>
-              <p className="mt-2 line-clamp-3 text-xs leading-relaxed text-slate-500">{item.summary}</p>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </div>
 

--- a/frontend-react/src/components/ReportSidebar.tsx
+++ b/frontend-react/src/components/ReportSidebar.tsx
@@ -25,8 +25,8 @@ const ReportSidebar: React.FC<ReportSidebarProps> = ({ report, currentNews }) =>
                 }`}
                 title={
                   report.provider_supports_tools
-                    ? `provider(${report.provider})가 도구(MCP/KIS/뉴스) 호출 경로로 구성되어 있다는 뜻입니다. 이번 응답에서 실제로 도구가 호출되었다는 관측은 아닙니다.`
-                    : `provider(${report.provider})는 도구(MCP/KIS/뉴스) 없이 모델이 직접 답을 생성했습니다. 수치가 지어낸 값일 수 있습니다.`
+                    ? `provider(${report.provider ?? '알 수 없음'})가 도구(MCP/KIS/뉴스) 호출 경로로 구성되어 있다는 뜻입니다. 이번 응답에서 실제로 도구가 호출되었다는 관측은 아닙니다.`
+                    : `provider(${report.provider ?? '알 수 없음'})는 도구(MCP/KIS/뉴스) 없이 모델이 직접 답을 생성했습니다. 수치가 지어낸 값일 수 있습니다.`
                 }
               >
                 {report.provider_supports_tools ? 'Tool-capable (unconfirmed)' : 'No tool access'}

--- a/frontend-react/src/components/ReportSidebar.tsx
+++ b/frontend-react/src/components/ReportSidebar.tsx
@@ -17,7 +17,21 @@ const ReportSidebar: React.FC<ReportSidebarProps> = ({ report, currentNews }) =>
           'bg-gradient-to-br from-slate-500 to-slate-600 text-white'
         }`}>
           <div className="flex justify-between items-center mb-6">
-            <span className="text-xs font-black uppercase tracking-widest opacity-80">AI STRATEGY</span>
+            <div className="flex items-center gap-2">
+              <span className="text-xs font-black uppercase tracking-widest opacity-80">AI STRATEGY</span>
+              <span
+                className={`text-[10px] font-black uppercase tracking-wide px-2 py-0.5 rounded-full ${
+                  report.provider_supports_tools ? 'bg-white/25' : 'bg-black/20 opacity-80'
+                }`}
+                title={
+                  report.provider_supports_tools
+                    ? `provider(${report.provider})가 도구(MCP/KIS/뉴스) 호출 경로로 구성되어 있다는 뜻입니다. 이번 응답에서 실제로 도구가 호출되었다는 관측은 아닙니다.`
+                    : `provider(${report.provider})는 도구(MCP/KIS/뉴스) 없이 모델이 직접 답을 생성했습니다. 수치가 지어낸 값일 수 있습니다.`
+                }
+              >
+                {report.provider_supports_tools ? 'Tool-capable (unconfirmed)' : 'No tool access'}
+              </span>
+            </div>
             {report.details.decision === 'BUY' ? <TrendingUp className="w-8 h-8 opacity-50" /> :
              report.details.decision === 'SELL' ? <TrendingDown className="w-8 h-8 opacity-50" /> : <Minus className="w-8 h-8 opacity-50" />}
           </div>

--- a/frontend-react/src/types.ts
+++ b/frontend-react/src/types.ts
@@ -14,7 +14,8 @@ export interface AnalysisReport {
   // provider가 도구(MCP/KIS/뉴스)를 호출할 수 있는 경로로 구성돼 있는지 여부.
   // provider 자체에서 파생된 "능력" 신호일 뿐, 이 응답에서 실제로 도구가
   // 호출됐다는 관측은 아니다 (백엔드 #152 참고).
-  provider: string;
+  // 백엔드 schemas.py의 provider: str | None = None과 일치시킨다.
+  provider: string | null;
   provider_supports_tools: boolean;
 }
 
@@ -64,7 +65,9 @@ export interface AgentReportItem {
   id?: number;
   stock_code: string;
   stock_name: string;
-  provider: string;
+  // 백엔드 models.py의 provider: str과 실제 API 직렬화 상 null 가능성에 맞춰
+  // string | null로 선언한다. UI 보간 시 ?? 폴백을 사용한다.
+  provider: string | null;
   summary: string;
   decision: string;
   confidence_score: number;

--- a/frontend-react/src/types.ts
+++ b/frontend-react/src/types.ts
@@ -11,6 +11,11 @@ export interface AnalysisReport {
   source_news: string[];
   source_signals?: string[];
   trading_trend: string | null;
+  // provider가 도구(MCP/KIS/뉴스)를 호출할 수 있는 경로로 구성돼 있는지 여부.
+  // provider 자체에서 파생된 "능력" 신호일 뿐, 이 응답에서 실제로 도구가
+  // 호출됐다는 관측은 아니다 (백엔드 #152 참고).
+  provider: string;
+  provider_supports_tools: boolean;
 }
 
 export interface TrendItem {
@@ -64,6 +69,10 @@ export interface AgentReportItem {
   decision: string;
   confidence_score: number;
   reason: string;
+  // provider가 도구(MCP/KIS/뉴스)를 호출할 수 있는 경로로 구성돼 있는지 여부.
+  // provider 자체에서 파생된 "능력" 신호일 뿐, 이 리포트에서 실제로 도구가
+  // 호출됐다는 관측은 아니다 (백엔드 #152 참고).
+  provider_supports_tools: boolean;
   created_at: string;
 }
 


### PR DESCRIPTION
#162의 **1단계(옵션 C)** 입니다. 이슈가 A/B/C/D를 놓고 제품 판단을 요구했고, C를 먼저 하고 A는 별도로 하기로 정했습니다. **도구 없는 provider의 프롬프트 축소(A)는 이 PR에 없습니다.**

## 문제

`GET /api/v1/analyze`의 기본값이 `provider="openai"`입니다. `_llm_openai_chat`은 `tools` 파라미터 없이 호출합니다 — MCP도, KIS도, 뉴스도 붙어 있지 않습니다. 모델은 종목명만 받고 `decision`(BUY/SELL/HOLD)·`confidence_score`·`reason`·`summary`를 스스로 만들어냅니다.

그 결과가 `AgentReport`로 저장되고 `/api/v1/db/reports`로 재생됩니다. 저장된 뒤에는 도구를 써서 만든 리포트와 **구분되지 않습니다.** `anthropic`·`ollama`도 같은 구조이고, API에는 인증이 없습니다.

## 필드 이름을 정직하게 잡았습니다

처음에는 `tool_verified`로 만들었는데, 리뷰에서 **그 이름이 코드가 보증할 수 없는 것을 주장한다**는 지적을 받고 `provider_supports_tools`로 바꿨습니다.

값은 provider 이름에서 파생됩니다 — `llm_chat`이 어느 `_llm_*_chat`으로 라우팅하는지라는 정적 사실이지, 도구가 실제로 호출됐다는 관측이 아닙니다. 이 구분이 중요한 이유는 **#152가 아직 열려 있기** 때문입니다. 그 이슈의 논지가 NAT의 도구 사용 강제 장치 세 겹이 모두 무력화됐다는 것이고, 여섯 에이전트 YAML 전부 `raise_on_parsing_failure: false`를 달고 있습니다. 그리고 `scheduler.py`가 자동 분석마다 `nat`을 넘기므로 프로덕션 행 대부분이 이 값을 받습니다.

오류의 방향을 봐야 합니다.

- `openai`·`anthropic`·`ollama` → `False`는 **증명 가능합니다.** 그 함수들이 `tools`를 넘기지 않습니다.
- `nat` → `True`는 **경로만 확인한 것입니다.** 위양성이 구조적으로 가능합니다.

`tool_verified`라는 이름이었다면 지어낸 NAT 결과를 "검증됨"으로 세탁했을 것입니다. 실제 도구 호출 원장은 #152의 몫이고, 모델 docstring과 `services.py` 주석이 이 구분과 #152를 명시합니다.

## 소비자가 볼 수 있게 했습니다

이슈의 옵션 C가 "`AgentReport`에 필드를 넣고 **API 응답과 대시보드에 드러냅니다**"라고 적고 있는데, 처음 구현은 저장만 하고 절반을 빠뜨렸습니다. 리뷰가 짚었습니다 — `/api/v1/analyze`는 `AnalysisReport` 스키마를 돌려주므로 live 응답에 필드가 없었고, `RecordsPanel.tsx`는 필드를 이미 실어 주는 엔드포인트를 읽으면서 그냥 버리고 있었습니다.

- `perform_stock_analysis`가 값을 한 번 계산해 **반환 dict와 `AgentReport` 행 양쪽에** 찍습니다. 두 엔드포인트의 값이 어긋날 수 없습니다.
- `AnalysisReport` 스키마에 `provider`·`provider_supports_tools` 추가 (OpenAPI 문서화용, 실제 값은 LLM JSON이 아니라 사후에 채웁니다)
- `ReportSidebar.tsx` — 결정 옆에 `Tool-capable (unconfirmed)` / `No tool access` 배지
- `RecordsPanel.tsx` — 저장된 리포트마다 `TOOL-CAPABLE` / `NO TOOLS` 배지

배지 문구가 "capability, 관측 아님"을 그대로 말합니다. tooltip에 그 구분을 풀어 적었습니다.

## 마이그레이션

alembic이 없고 스키마가 `create_all`에서 나오는데, **`create_all`은 기존 테이블을 ALTER하지 않습니다.** 배포된 모든 SQLite 파일에 컬럼이 없습니다. 이 전제를 먼저 실측으로 확인한 뒤(옛 스키마 테이블을 만들고 `create_all`을 돌려 컬럼이 안 생기는 것을 봄), `init_db()`에 `_run_schema_migrations()`를 넣었습니다.

**기존 행은 `0`, 즉 "도구 없음"으로 읽힙니다.** `DEFAULT 1`이나 NULL-as-true였다면 지금 버그보다 나빴을 것입니다 — 지어낸 과거 기록을 검증된 것으로 세탁하는 셈입니다. 리뷰어가 저장소 픽스처가 아니라 직접 만든 옛 스키마 DB로 재확인했습니다.

**동시성 안전화.** inspect 후 ALTER는 check-then-act입니다. 리뷰에서 스레드 6개로 `init_db()`를 동시에 부르면 **5개가 `duplicate column name`으로 기동을 중단**시키는 것이 재현됐습니다. 현재 배포는 uvicorn 워커 하나라 도달하지 않지만 `--workers`를 붙이는 순간 실전이 됩니다. `OperationalError`를 잡아 duplicate column만 삼키고 재확인 후 통과시킵니다. 그 외는 다시 던집니다.

권한 실패 시에는 **시끄럽게 죽습니다.** chmod-444 파일에서 `OperationalError`가 `init_db()` 밖으로 전파되고 트랜잭션이 롤백됩니다. ORM이 있다고 믿는 스키마로 계속 도는 것보다 낫습니다.

## 파생을 손으로 세우지 않습니다

`_TOOL_CAPABLE_PROVIDERS = frozenset({"nat"})`와 `provider_supports_tools(key)`를 `llm_chat`의 provider 분기 바로 옆에 뒀습니다. `perform_stock_analysis`가 이미 계산해 둔 `key`를 그대로 씁니다. 호출부마다 손으로 넘기는 불리언은 반드시 어긋납니다.

**동기화 테스트가 처음에는 가짜였습니다.** 리터럴 불리언 네 개를 단언할 뿐 `llm_chat`을 import하지도 호출하지도 않았습니다. 리뷰어가 `openai`를 `_llm_nat_chat`으로 라우팅하도록 분기를 바꿔 집합과 분기를 실제로 어긋나게 만들었는데 **테스트가 통과했습니다.**

이제 `llm_chat`의 `provider_key` Literal을 `typing.get_args()`로 열거하고, 네 `_llm_*_chat`을 monkeypatch해 **실제로 어느 것이 호출되는지 관측**한 뒤 그 결과와 대조합니다. 같은 변형에 red가 됩니다.

## 검증

231 → 241 passed. 변형 5종 전부 red 확인.

| 변형 | 잡은 테스트 |
| :--- | :--- |
| `_TOOL_CAPABLE_PROVIDERS`를 빈 집합으로 | 4건 |
| 마이그레이션 `DEFAULT 0` → `DEFAULT 1` | 기존 행 테스트 1건 |
| 위 둘 동시 | 5건 |
| 마이그레이션 try/except 제거 | 동시성 테스트 (6스레드 중 5개 실패) |
| `llm_chat`에서 openai를 nat으로 라우팅 | 동기화 테스트 |

`frontend-react`는 `tsc --noEmit` 통과, `vite build` 성공을 확인했습니다.

## 범위 밖

- **A단계** — `perform_stock_analysis`의 프롬프트는 여전히 모든 provider에게 `decision`·`confidence_score`를 요구합니다. 이 PR은 그 사실을 보이게 만들 뿐이고, 축소는 후속입니다.
- **아직 표시되지 않는 표면 2곳** — `frontend/Assets/Scripts/DashboardUiController.cs`와 `backend/telegram_notifier.py`도 결정과 신뢰도를 그대로 출력합니다. Unity와 Telegram은 이번 범위에 넣지 않았습니다.
- SQLite 전용 ALTER의 엔진 가드. 다른 엔진은 현재 도달 불가입니다(`psycopg2`·`pymysql`이 lockfile에 없음). 다만 이건 강제가 아니라 우연입니다.
