### PR TITLE
fix: BackendPanel 엔드포인트 상태를 fetch 성공 여부로 판정 (#71)

### DIFF
--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/frontend-react/src/App.tsx
+++ b/frontend-react/src/App.tsx
@@ -23,6 +23,7 @@ export default function App() {
     rawNews,
     rawTrend,
     resources,
+    endpointOk,
     error,
     chatStatus,
     chatMessages,
@@ -56,7 +57,7 @@ export default function App() {
 
         <ErrorDisplay error={error} />
 
-        <BackendPanel resources={resources} loading={resourceLoading} onRefresh={loadResources} />
+        <BackendPanel resources={resources} endpointOk={endpointOk} loading={resourceLoading} onRefresh={loadResources} />
 
         {latest && <StockHeader stock={stock} latest={latest} />}
 

--- a/frontend-react/src/components/BackendPanel.tsx
+++ b/frontend-react/src/components/BackendPanel.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Activity, RefreshCw, Server, WalletCards } from 'lucide-react';
 import type { DashboardResources } from '../types';
-import type { EndpointOk } from '../hooks/useFinUsDashboard';
+import type { EndpointOk, EndpointStatus } from '../hooks/useFinUsDashboard';
 
 interface BackendPanelProps {
   resources: DashboardResources;
@@ -10,14 +10,20 @@ interface BackendPanelProps {
   onRefresh: () => void;
 }
 
+const DOT_CLASS: Record<EndpointStatus, string> = {
+  ok: 'bg-emerald-500',
+  fail: 'bg-rose-500',
+  unknown: 'bg-slate-300',
+};
+
 const BackendPanel: React.FC<BackendPanelProps> = ({ resources, endpointOk, loading, onRefresh }) => {
   const endpoints = [
-    { label: 'Health', ok: endpointOk.health, path: '/health' },
-    { label: 'Balance', ok: endpointOk.balance, path: '/api/v1/trading/balance' },
-    { label: 'Portfolio', ok: endpointOk.portfolio, path: '/api/v1/db/portfolio' },
-    { label: 'Trades', ok: endpointOk.trades, path: '/api/v1/db/trades' },
-    { label: 'Reports', ok: endpointOk.reports, path: '/api/v1/db/reports' },
-    { label: 'Diary', ok: endpointOk.diaries, path: '/api/v1/db/diary' },
+    { label: 'Health', status: endpointOk.health, path: '/health' },
+    { label: 'Balance', status: endpointOk.balance, path: '/api/v1/trading/balance' },
+    { label: 'Portfolio', status: endpointOk.portfolio, path: '/api/v1/db/portfolio' },
+    { label: 'Trades', status: endpointOk.trades, path: '/api/v1/db/trades' },
+    { label: 'Reports', status: endpointOk.reports, path: '/api/v1/db/reports' },
+    { label: 'Diary', status: endpointOk.diaries, path: '/api/v1/db/diary' },
   ];
 
   return (
@@ -55,7 +61,7 @@ const BackendPanel: React.FC<BackendPanelProps> = ({ resources, endpointOk, load
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
           {endpoints.map((endpoint) => (
             <div key={endpoint.path} className="flex items-center gap-2 rounded-lg bg-slate-50 px-3 py-2">
-              <span className={`w-2.5 h-2.5 rounded-full ${endpoint.ok ? 'bg-emerald-500' : 'bg-rose-500'}`} />
+              <span className={`w-2.5 h-2.5 rounded-full ${DOT_CLASS[endpoint.status]}`} />
               <div className="min-w-0">
                 <div className="text-xs font-black text-slate-700">{endpoint.label}</div>
                 <div className="text-[11px] text-slate-400 truncate">{endpoint.path}</div>

--- a/frontend-react/src/components/BackendPanel.tsx
+++ b/frontend-react/src/components/BackendPanel.tsx
@@ -1,21 +1,23 @@
 import React from 'react';
 import { Activity, RefreshCw, Server, WalletCards } from 'lucide-react';
 import type { DashboardResources } from '../types';
+import type { EndpointOk } from '../hooks/useFinUsDashboard';
 
 interface BackendPanelProps {
   resources: DashboardResources;
+  endpointOk: EndpointOk;
   loading: boolean;
   onRefresh: () => void;
 }
 
-const BackendPanel: React.FC<BackendPanelProps> = ({ resources, loading, onRefresh }) => {
+const BackendPanel: React.FC<BackendPanelProps> = ({ resources, endpointOk, loading, onRefresh }) => {
   const endpoints = [
-    { label: 'Health', ok: Boolean(resources.health), path: '/health' },
-    { label: 'Balance', ok: Boolean(resources.balance), path: '/api/v1/trading/balance' },
-    { label: 'Portfolio', ok: resources.portfolio.length >= 0, path: '/api/v1/db/portfolio' },
-    { label: 'Trades', ok: resources.trades.length >= 0, path: '/api/v1/db/trades' },
-    { label: 'Reports', ok: resources.reports.length >= 0, path: '/api/v1/db/reports' },
-    { label: 'Diary', ok: resources.diaries.length >= 0, path: '/api/v1/db/diary' },
+    { label: 'Health', ok: endpointOk.health, path: '/health' },
+    { label: 'Balance', ok: endpointOk.balance, path: '/api/v1/trading/balance' },
+    { label: 'Portfolio', ok: endpointOk.portfolio, path: '/api/v1/db/portfolio' },
+    { label: 'Trades', ok: endpointOk.trades, path: '/api/v1/db/trades' },
+    { label: 'Reports', ok: endpointOk.reports, path: '/api/v1/db/reports' },
+    { label: 'Diary', ok: endpointOk.diaries, path: '/api/v1/db/diary' },
   ];
 
   return (

--- a/frontend-react/src/hooks/useFinUsDashboard.ts
+++ b/frontend-react/src/hooks/useFinUsDashboard.ts
@@ -2,6 +2,24 @@ import { useCallback, useEffect, useRef, useState, type FormEvent } from 'react'
 import { apiErrorMessage, finUsApi } from '../api';
 import type { AnalysisReport, ChatMessage, DashboardResources } from '../types';
 
+export interface EndpointOk {
+  health: boolean;
+  balance: boolean;
+  portfolio: boolean;
+  trades: boolean;
+  reports: boolean;
+  diaries: boolean;
+}
+
+const initialEndpointOk: EndpointOk = {
+  health: false,
+  balance: false,
+  portfolio: false,
+  trades: false,
+  reports: false,
+  diaries: false,
+};
+
 const initialResources: DashboardResources = {
   health: null,
   balance: null,
@@ -34,6 +52,7 @@ export function useFinUsDashboard() {
   const [rawNews, setRawNews] = useState<string[]>([]);
   const [rawTrend, setRawTrend] = useState<string | null>(null);
   const [resources, setResources] = useState<DashboardResources>(initialResources);
+  const [endpointOk, setEndpointOk] = useState<EndpointOk>(initialEndpointOk);
   const [error, setError] = useState('');
   const [chatStatus, setChatStatus] = useState<'connecting' | 'open' | 'closed'>('connecting');
   const [chatMessages, setChatMessages] = useState<ChatMessage[]>([
@@ -67,6 +86,15 @@ export function useFinUsDashboard() {
       trades: trades.status === 'fulfilled' ? trades.value : [],
       reports: reports.status === 'fulfilled' ? reports.value : [],
       diaries: diaries.status === 'fulfilled' ? diaries.value : [],
+    });
+
+    setEndpointOk({
+      health: health.status === 'fulfilled',
+      balance: balance.status === 'fulfilled',
+      portfolio: portfolio.status === 'fulfilled',
+      trades: trades.status === 'fulfilled',
+      reports: reports.status === 'fulfilled',
+      diaries: diaries.status === 'fulfilled',
     });
 
     const failed = [health, balance, portfolio, trades, reports, diaries].some((item) => item.status === 'rejected');
@@ -191,6 +219,7 @@ export function useFinUsDashboard() {
     rawNews,
     rawTrend,
     resources,
+    endpointOk,
     error,
     chatStatus,
     chatMessages,

--- a/frontend-react/src/hooks/useFinUsDashboard.ts
+++ b/frontend-react/src/hooks/useFinUsDashboard.ts
@@ -2,22 +2,24 @@ import { useCallback, useEffect, useRef, useState, type FormEvent } from 'react'
 import { apiErrorMessage, finUsApi } from '../api';
 import type { AnalysisReport, ChatMessage, DashboardResources } from '../types';
 
+export type EndpointStatus = 'unknown' | 'ok' | 'fail';
+
 export interface EndpointOk {
-  health: boolean;
-  balance: boolean;
-  portfolio: boolean;
-  trades: boolean;
-  reports: boolean;
-  diaries: boolean;
+  health: EndpointStatus;
+  balance: EndpointStatus;
+  portfolio: EndpointStatus;
+  trades: EndpointStatus;
+  reports: EndpointStatus;
+  diaries: EndpointStatus;
 }
 
 const initialEndpointOk: EndpointOk = {
-  health: false,
-  balance: false,
-  portfolio: false,
-  trades: false,
-  reports: false,
-  diaries: false,
+  health: 'unknown',
+  balance: 'unknown',
+  portfolio: 'unknown',
+  trades: 'unknown',
+  reports: 'unknown',
+  diaries: 'unknown',
 };
 
 const initialResources: DashboardResources = {
@@ -89,12 +91,12 @@ export function useFinUsDashboard() {
     });
 
     setEndpointOk({
-      health: health.status === 'fulfilled',
-      balance: balance.status === 'fulfilled',
-      portfolio: portfolio.status === 'fulfilled',
-      trades: trades.status === 'fulfilled',
-      reports: reports.status === 'fulfilled',
-      diaries: diaries.status === 'fulfilled',
+      health: health.status === 'fulfilled' ? 'ok' : 'fail',
+      balance: balance.status === 'fulfilled' ? 'ok' : 'fail',
+      portfolio: portfolio.status === 'fulfilled' ? 'ok' : 'fail',
+      trades: trades.status === 'fulfilled' ? 'ok' : 'fail',
+      reports: reports.status === 'fulfilled' ? 'ok' : 'fail',
+      diaries: diaries.status === 'fulfilled' ? 'ok' : 'fail',
     });
 
     const failed = [health, balance, portfolio, trades, reports, diaries].some((item) => item.status === 'rejected');


### PR DESCRIPTION
Closes #71

## 문제
`BackendPanel.tsx`가 `ok: resources.portfolio.length >= 0`로 상태를 판정하는데, `length >= 0`은 빈 배열에서도 항상 true입니다. API 호출이 실패해 `[]`가 할당된 경우에도 초록 점이 떠, 백엔드 장애 시 사용자가 "정상"으로 오인합니다(Portfolio/Trades/Reports/Diary).

## 변경
- `useFinUsDashboard`의 `loadResources`가 `Promise.allSettled` 결과에서 **엔드포인트별 상태**(`endpointOk`)를 보존해 반환합니다.
- 상태는 삼상태 `EndpointStatus`(`'unknown'`|`'ok'`|`'fail'`)입니다. 첫 조회 완료 전에는 `'unknown'`(회색), 완료 후 `'ok'`(초록)/`'fail'`(빨강). boolean이면 로딩 중에 정상 엔드포인트까지 빨간 점으로 뜨는 새 오탐이 생기므로 삼상태로 표현합니다.
- `App.tsx`가 `endpointOk` prop을 연결하고, `BackendPanel`이 `DOT_CLASS`로 점 색을 정합니다.
- `package.json`에 `"typecheck": "tsc --noEmit"` 스크립트를 추가했습니다.

## 검증
CI `frontend-typecheck` job(`npx tsc --noEmit`)으로 타입 검증됩니다. 로컬에서도 `npm run typecheck`로 동일하게 확인할 수 있습니다.

## 범위
frontend 파일만(`App.tsx`, `BackendPanel.tsx`, `useFinUsDashboard.ts`, `package.json`). `DashboardResources` shape·`types.ts` 불변이라 다른 소비자 영향 없음.