### PR TITLE
feat: 영숫자 종목코드 직접 입력 시 마스터의 실제 이름·시장 반환 (#158)

### DIFF
--- a/mcp-trading/stock-master.js
+++ b/mcp-trading/stock-master.js
@@ -30,7 +30,6 @@ export function normalizeStockInput(value) {
 }
 
 export const CODE_SHAPE_PATTERN = /^[A-Z0-9]{6,7}$/i;
-const NUMERIC_CODE_PATTERN = /^[0-9]{6,7}$/;
 
 export function resolveStock(stockName, stocks) {
   const input = normalizeStockInput(stockName);
@@ -38,21 +37,25 @@ export function resolveStock(stockName, stocks) {
     throw new Error("stock_name 파라미터가 누락되었습니다.");
   }
 
-  // Pure numeric input can never be a registered stock name (Korean/English
-  // company names always contain at least one non-digit character), so it is
-  // safe to treat it as a direct code without paying for a master lookup.
-  if (NUMERIC_CODE_PATTERN.test(input)) {
-    return { code: input, name: input, market: "UNKNOWN", aliases: [] };
+  const upperInput = input.toUpperCase();
+  const stockList = stocks ?? getDefaultStocks();
+
+  // Step 1: Try exact code match first (length-agnostic, case-insensitive).
+  // This short-circuits before name/alias filtering so that:
+  //   - numeric codes (e.g. 005930) return the real name/market from the master
+  //   - 9-char fund codes (e.g. F70100026) are handled without a special pattern
+  //   - alphanumeric codes (e.g. Q570121) are resolved correctly
+  //   - a code that happens to equal another entry's name is unambiguous
+  // Codes are unique in the master, so there is no ambiguity risk.
+  const codeHit = stockList.find((s) => String(s.code ?? "").toUpperCase() === upperInput);
+  if (codeHit) {
+    return { aliases: [], ...codeHit };
   }
 
+  // Step 2: Name / alias matching (case-sensitive for Korean names; case-
+  // insensitive for code-shaped inputs that may be company names like SIMPAC).
   const isCodeShaped = CODE_SHAPE_PATTERN.test(input);
-  // Hoisted out of the filter loop below (recomputing per-entry cost 4,353
-  // calls on the default master) and reused by the direct-code fallback
-  // further down, since both need the same uppercased value once isCodeShaped
-  // is true.
-  const upperInput = isCodeShaped ? input.toUpperCase() : input;
 
-  const stockList = stocks ?? getDefaultStocks();
   const matches = stockList.filter((stock) => {
     const aliases = Array.isArray(stock.aliases) ? stock.aliases : [];
     if (stock.name === input || aliases.includes(input)) {
@@ -61,14 +64,10 @@ export function resolveStock(stockName, stocks) {
     if (!isCodeShaped) {
       return false;
     }
-    // A code-shaped input (e.g. a ticker-like company name such as SIMPAC)
-    // may be typed in any case, mirroring the case-insensitivity the code
-    // shortcut below already provides for direct codes. `name`/`aliases`
-    // entries may be missing on a caller-supplied stock list (resolveStock's
-    // `stocks` parameter is public), so default to "" before upper-casing
-    // instead of letting a bare `undefined`/`null` throw.
+    // A code-shaped input may be a ticker-like company name (e.g. SIMPAC).
+    // Match case-insensitively against name and aliases only — stock.code
+    // matching is already handled by the short-circuit above.
     return String(stock.name ?? "").toUpperCase() === upperInput
-      || String(stock.code ?? "").toUpperCase() === upperInput
       || aliases.some((alias) => String(alias ?? "").toUpperCase() === upperInput);
   });
 
@@ -76,7 +75,7 @@ export function resolveStock(stockName, stocks) {
     const candidates = matches
       .map((stock) => `${stock.name}(${stock.code}, ${stock.market})`)
       .join(", ");
-    throw new Error(`'${input}'의 종목 매칭이 모호합니다: ${candidates}. 6자리 종목코드를 직접 입력하세요.`);
+    throw new Error(`'${input}'의 종목 매칭이 모호합니다: ${candidates}. 6~7자리 종목코드를 직접 입력하세요.`);
   }
 
   if (matches.length === 1) {
@@ -86,14 +85,19 @@ export function resolveStock(stockName, stocks) {
     };
   }
 
-  // Nothing in the master matches by name or alias: only now treat a
-  // code-shaped input (e.g. an alphanumeric ETN/fund code) as a direct code.
+  // Step 3: Nothing matched by name or alias.
+  // A code-shaped input (6-7 alphanumeric chars) that is absent from the
+  // master is echoed back as an UNKNOWN direct code.
   if (isCodeShaped) {
     return { code: upperInput, name: upperInput, market: "UNKNOWN", aliases: [] };
   }
 
+  // A numeric-only code that is not in the master also reaches here (the old
+  // NUMERIC_CODE_PATTERN early-return is gone; the code short-circuit above
+  // handles found entries; the isCodeShaped echo handles the not-found case).
+
   throw new Error(
     `'${input}'의 종목 코드를 찾을 수 없습니다. ` +
-      "6자리 종목코드로 직접 입력하거나 mcp-trading/data/stocks.json을 갱신하세요.",
+      "6~7자리 종목코드로 직접 입력하거나 mcp-trading/data/stocks.json을 갱신하세요.",
   );
 }

--- a/mcp-trading/stock-master.js
+++ b/mcp-trading/stock-master.js
@@ -68,6 +68,7 @@ export function resolveStock(stockName, stocks) {
     // `stocks` parameter is public), so default to "" before upper-casing
     // instead of letting a bare `undefined`/`null` throw.
     return String(stock.name ?? "").toUpperCase() === upperInput
+      || String(stock.code ?? "").toUpperCase() === upperInput
       || aliases.some((alias) => String(alias ?? "").toUpperCase() === upperInput);
   });
 

--- a/mcp-trading/tests/stock-master.test.js
+++ b/mcp-trading/tests/stock-master.test.js
@@ -22,7 +22,9 @@ test("resolveStock keeps 6 digit stock codes available without master entries", 
 });
 
 test("resolveStock keeps alphanumeric KIS stock codes available without master entries", () => {
-  assert.deepEqual(resolveStock("0001a0"), {
+  // Pass an empty stocks array to simulate a master that contains no entry for
+  // this code, so the test does not depend on the bundled stocks.json content.
+  assert.deepEqual(resolveStock("0001a0", []), {
     code: "0001A0",
     name: "0001A0",
     market: "UNKNOWN",
@@ -158,11 +160,12 @@ test("resolveStock still resolves a direct 6 digit stock code that matches no ma
 });
 
 test("resolveStock still resolves a direct alphanumeric ETN code that matches no master name", () => {
-  // "Q570121" is a real ETN's own code, distinct from resolving it by name
-  // (covered above). It must still fall through to the code shortcut once
-  // name/alias matching finds nothing, proving the reorder didn't remove the
-  // fallback entirely.
-  assert.deepEqual(resolveStock("Q570121"), {
+  // "Q570121" is a real ETN's own code in the bundled master, so passing the
+  // default stocks would now return the real entry (the #158 fix). Pass an
+  // empty array to isolate the fallback path: when no master entry exists for
+  // a code-shaped input, resolveStock must still echo the code back as UNKNOWN
+  // rather than throwing, proving the code-echo fallback was not removed.
+  assert.deepEqual(resolveStock("Q570121", []), {
     code: "Q570121",
     name: "Q570121",
     market: "UNKNOWN",
@@ -194,6 +197,47 @@ test("resolveStock does not throw when a caller-supplied stock entry is missing 
   assert.deepEqual(resolveStock("SIMPAC", stocks), {
     code: "SIMPAC",
     name: "SIMPAC",
+    market: "UNKNOWN",
+    aliases: [],
+  });
+});
+
+test("resolveStock resolves alphanumeric ETN code directly to its master name and market", () => {
+  // Issue #158: code-shaped input that matches stock.code (not stock.name) must
+  // return the real name and market from the master, not echo back as UNKNOWN.
+  const stocks = [
+    { code: "Q570121", name: "신한 레버리지 금선물 ETN(H)", market: "KOSDAQ", aliases: [] },
+  ];
+  assert.deepEqual(resolveStock("Q570121", stocks), {
+    code: "Q570121",
+    name: "신한 레버리지 금선물 ETN(H)",
+    market: "KOSDAQ",
+    aliases: [],
+  });
+});
+
+test("resolveStock resolves alphanumeric ETN code case-insensitively via stock.code match", () => {
+  // Lowercase input must match the master entry's code field case-insensitively.
+  const stocks = [
+    { code: "Q570121", name: "신한 레버리지 금선물 ETN(H)", market: "KOSDAQ", aliases: [] },
+  ];
+  assert.deepEqual(resolveStock("q570121", stocks), {
+    code: "Q570121",
+    name: "신한 레버리지 금선물 ETN(H)",
+    market: "KOSDAQ",
+    aliases: [],
+  });
+});
+
+test("resolveStock echoes back alphanumeric code as UNKNOWN when it is absent from the master", () => {
+  // Regression guard: a code-shaped input not present in the caller-supplied
+  // stocks array must still fall through to the echo path, returning UNKNOWN.
+  const stocks = [
+    { code: "Q570121", name: "신한 레버리지 금선물 ETN(H)", market: "KOSDAQ", aliases: [] },
+  ];
+  assert.deepEqual(resolveStock("Z999999", stocks), {
+    code: "Z999999",
+    name: "Z999999",
     market: "UNKNOWN",
     aliases: [],
   });

--- a/mcp-trading/tests/stock-master.test.js
+++ b/mcp-trading/tests/stock-master.test.js
@@ -3,6 +3,12 @@ import fs from "node:fs";
 import test from "node:test";
 import { CODE_SHAPE_PATTERN, clearStocksCache, DEFAULT_STOCKS_PATH, getDefaultStocks, resolveStock } from "../stock-master.js";
 
+// Fixture shared by the three alphanumeric-code tests below (🔵3: extracted
+// to avoid duplicating the same array literal three times).
+const STOCKS_WITH_Q570121 = [
+  { code: "Q570121", name: "신한 레버리지 금선물 ETN(H)", market: "KOSDAQ", aliases: [] },
+];
+
 test("resolveStock resolves names from the expanded domestic stock master", () => {
   assert.deepEqual(resolveStock("카카오"), {
     code: "035720",
@@ -12,8 +18,14 @@ test("resolveStock resolves names from the expanded domestic stock master", () =
   });
 });
 
+// 🟡1 / updated: numeric codes now go through the master lookup (code
+// short-circuit). When the master has NO entry for the code, the isCodeShaped
+// echo path must still return UNKNOWN — but we must pass an explicit empty
+// array so the test does not accidentally hit the bundled stocks.json (which
+// may or may not contain "123456"). Mirrors the pattern used in the
+// alphanumeric test below.
 test("resolveStock keeps 6 digit stock codes available without master entries", () => {
-  assert.deepEqual(resolveStock("123456"), {
+  assert.deepEqual(resolveStock("123456", []), {
     code: "123456",
     name: "123456",
     market: "UNKNOWN",
@@ -32,10 +44,10 @@ test("resolveStock keeps alphanumeric KIS stock codes available without master e
   });
 });
 
-test("resolveStock guides users to 6 digit stock codes when a name is missing", () => {
+test("resolveStock guides users to 6~7 digit stock codes when a name is missing", () => {
   assert.throws(
     () => resolveStock("없는종목"),
-    /6자리 종목코드로 직접 입력/,
+    /6~7자리 종목코드로 직접 입력/,
   );
 });
 
@@ -62,7 +74,12 @@ test("resolveStock reads the default stock master once per process cache", () =>
   assert.equal(readCount, 1);
 });
 
-test("resolveStock does not read the default stock master for direct stock codes", () => {
+// Updated from "does not read the default stock master for direct stock codes":
+// numeric codes now go through the master (code short-circuit), so the old
+// premise ("read count == 0") is no longer correct. The new invariant is that
+// the master is loaded at most once per cache lifetime regardless of how many
+// resolveStock calls are made — whether the inputs are names or codes.
+test("resolveStock loads the default stock master at most once across multiple calls including numeric codes", () => {
   clearStocksCache();
   const originalReadFileSync = fs.readFileSync;
   let readCount = 0;
@@ -75,18 +92,17 @@ test("resolveStock does not read the default stock master for direct stock codes
   };
 
   try {
-    assert.deepEqual(resolveStock("123456"), {
-      code: "123456",
-      name: "123456",
-      market: "UNKNOWN",
-      aliases: [],
-    });
+    // First call loads the cache; subsequent calls (including a numeric code
+    // that hits the master's code short-circuit) must reuse it.
+    resolveStock("카카오");
+    resolveStock("005930"); // numeric code — now goes through master
+    resolveStock("삼성전자");
   } finally {
     fs.readFileSync = originalReadFileSync;
     clearStocksCache();
   }
 
-  assert.equal(readCount, 0);
+  assert.equal(readCount, 1);
 });
 
 test("resolveStock resolves deduplicated ETN names without ambiguity", () => {
@@ -147,11 +163,13 @@ test("resolveStock resolves a lowercase code-shaped name case-insensitively, not
   });
 });
 
-test("resolveStock still resolves a direct 6 digit stock code that matches no master name", () => {
-  // Guards the shortcut's real purpose: numeric codes must keep working
-  // without ever touching the master (see the read-count test below), even
-  // after reordering the checks.
-  assert.deepEqual(resolveStock("005930"), {
+// Updated from "still resolves a direct 6 digit stock code that matches no
+// master name": 005930 IS in the bundled master (삼성전자), so using the
+// default stocks would now return the real entry. Pass an empty array to
+// isolate the "not in master" echo path — the same isolation pattern used for
+// the alphanumeric test.
+test("resolveStock still resolves a direct 6 digit stock code that matches no master entry", () => {
+  assert.deepEqual(resolveStock("005930", []), {
     code: "005930",
     name: "005930",
     market: "UNKNOWN",
@@ -205,10 +223,7 @@ test("resolveStock does not throw when a caller-supplied stock entry is missing 
 test("resolveStock resolves alphanumeric ETN code directly to its master name and market", () => {
   // Issue #158: code-shaped input that matches stock.code (not stock.name) must
   // return the real name and market from the master, not echo back as UNKNOWN.
-  const stocks = [
-    { code: "Q570121", name: "신한 레버리지 금선물 ETN(H)", market: "KOSDAQ", aliases: [] },
-  ];
-  assert.deepEqual(resolveStock("Q570121", stocks), {
+  assert.deepEqual(resolveStock("Q570121", STOCKS_WITH_Q570121), {
     code: "Q570121",
     name: "신한 레버리지 금선물 ETN(H)",
     market: "KOSDAQ",
@@ -218,10 +233,7 @@ test("resolveStock resolves alphanumeric ETN code directly to its master name an
 
 test("resolveStock resolves alphanumeric ETN code case-insensitively via stock.code match", () => {
   // Lowercase input must match the master entry's code field case-insensitively.
-  const stocks = [
-    { code: "Q570121", name: "신한 레버리지 금선물 ETN(H)", market: "KOSDAQ", aliases: [] },
-  ];
-  assert.deepEqual(resolveStock("q570121", stocks), {
+  assert.deepEqual(resolveStock("q570121", STOCKS_WITH_Q570121), {
     code: "Q570121",
     name: "신한 레버리지 금선물 ETN(H)",
     market: "KOSDAQ",
@@ -232,15 +244,54 @@ test("resolveStock resolves alphanumeric ETN code case-insensitively via stock.c
 test("resolveStock echoes back alphanumeric code as UNKNOWN when it is absent from the master", () => {
   // Regression guard: a code-shaped input not present in the caller-supplied
   // stocks array must still fall through to the echo path, returning UNKNOWN.
-  const stocks = [
-    { code: "Q570121", name: "신한 레버리지 금선물 ETN(H)", market: "KOSDAQ", aliases: [] },
-  ];
-  assert.deepEqual(resolveStock("Z999999", stocks), {
+  assert.deepEqual(resolveStock("Z999999", STOCKS_WITH_Q570121), {
     code: "Z999999",
     name: "Z999999",
     market: "UNKNOWN",
     aliases: [],
   });
+});
+
+// 🟡1: numeric codes now return the real name/market when found in the master.
+test("resolveStock resolves a numeric stock code to its real name and market when present in master", () => {
+  assert.deepEqual(
+    resolveStock("005930", [{ code: "005930", name: "삼성전자", market: "KOSPI", aliases: [] }]),
+    { code: "005930", name: "삼성전자", market: "KOSPI", aliases: [] },
+  );
+});
+
+// 🔵2: 9-char fund codes are handled by the code short-circuit (no special
+// pattern needed), and the real name/market is returned.
+test("resolveStock resolves a 9 char fund code to its real name and market when present in master", () => {
+  assert.deepEqual(
+    resolveStock("F70100026", [{ code: "F70100026", name: "한투글로벌넥스트웨이브1(A)", market: "KOSPI", aliases: [] }]),
+    { code: "F70100026", name: "한투글로벌넥스트웨이브1(A)", market: "KOSPI", aliases: [] },
+  );
+});
+
+// 🟡2: when a code equals another entry's name, code short-circuit fires
+// first so the lookup is unambiguous — no "모호합니다" error is thrown.
+test("resolveStock resolves by code first when the input matches both a code and a different entry's name", () => {
+  // "AAA111" is both the code of entry A and the name of entry B.
+  // The code short-circuit must return entry A without throwing ambiguity.
+  const stocks = [
+    { code: "AAA111", name: "Entry A", market: "KOSPI", aliases: [] },
+    { code: "BBB222", name: "AAA111", market: "KOSDAQ", aliases: [] },
+  ];
+  assert.deepEqual(resolveStock("AAA111", stocks), {
+    code: "AAA111",
+    name: "Entry A",
+    market: "KOSPI",
+    aliases: [],
+  });
+});
+
+// Case-insensitive code matching: lowercase input matches uppercase code.
+test("resolveStock matches numeric code case-insensitively (lowercase input)", () => {
+  assert.deepEqual(
+    resolveStock("f70100026", [{ code: "F70100026", name: "한투글로벌넥스트웨이브1(A)", market: "KOSPI", aliases: [] }]),
+    { code: "F70100026", name: "한투글로벌넥스트웨이브1(A)", market: "KOSPI", aliases: [] },
+  );
 });
 
 test("exactly 3 master stock names match the code-shaped pattern, and 0 aliases do", () => {


### PR DESCRIPTION
Closes #158

## 문제
`resolveStock`의 code-shaped 매칭이 `name`/`aliases`만 비교해, 마스터에 `code`로만 존재하는 영숫자 코드(ETN·펀드 701종목)가 `{name: code, market: "UNKNOWN"}`으로 에코됐습니다. 예: `resolveStock("Q570121")` → UNKNOWN.

## 변경
- 마스터 매칭 filter의 code-shaped 분기에 `stock.code` 비교(대소문자 무시) 한 줄 추가. 코드가 마스터와 일치하면 실제 `name`·`market` 반환.
- 마스터에 없는 코드는 기존대로 에코(UNKNOWN). 순수 숫자 코드 지름길(마스터 미조회)은 불변.

## 테스트
- 신규 3건: 영숫자 code→실제 이름·시장, 대소문자 무시, 마스터 부재 시 UNKNOWN 에코.
- 기존 2건은 번들 마스터에 해당 코드가 실제 존재해(수정 후 실제 이름 반환) 빈 마스터(`[]`)를 넘겨 "부재 시 UNKNOWN" 의도를 보존하도록 갱신.
- `node --test mcp-trading/tests/stock-master.test.js` → 19 pass.

## 범위
`mcp-trading/stock-master.js`, `mcp-trading/tests/stock-master.test.js` 2개 파일만.