### PR TITLE
fix: DART 법인 조회에 우선주·전환주 접미사 정규화 폴백 추가 (#159)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,28 @@ jobs:
       - name: mcp-trading 테스트 실행
         run: npm test
 
+  mcp-dart-test:
+    name: mcp-dart npm test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mcp-dart
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Node 24 설치 (npm 캐시 활성화)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: mcp-dart/package-lock.json
+
+      - name: npm 의존성 설치
+        run: npm ci
+
+      - name: mcp-dart 테스트 실행
+        run: npm test
+
   frontend-typecheck:
     name: Frontend tsc --noEmit
     runs-on: ubuntu-latest

--- a/mcp-dart/corp-resolver.js
+++ b/mcp-dart/corp-resolver.js
@@ -27,8 +27,21 @@ export function cleanText(value) {
  * @returns {string | undefined}
  */
 export function stripPreferredStockSuffix(name) {
-  const base = name.replace(/\d*우B?(\(전환\))?$/, "");
-  return base.length > 0 ? base : undefined;
+  // `\s*`: "CJ제일제당 우"처럼 접미사 앞에 공백이 들어간 KRX 종목명 대응.
+  // `\d*`: "해성산업1우"·"현대차2우B" 같은 신형우선주 회차 번호.
+  const base = name.replace(/\s*\d*우B?(\(전환\))?$/, "").trim();
+  if (base.length === 0 || base === name) return undefined; // 제거된 게 없으면 폴백 불필요
+  return base;
+}
+
+const MAX_LISTED_MATCHES = 5;
+
+function ambiguousMatchError(query, matches) {
+  const names = matches
+    .slice(0, MAX_LISTED_MATCHES)
+    .map((item) => `${item.corp_name}(${item.stock_code}, ${item.corp_code})`)
+    .join(", ");
+  return new Error(`'${query}'가 여러 회사와 일치합니다: ${names}`);
 }
 
 /**
@@ -54,26 +67,14 @@ export function resolveCorp(items, input) {
     if (matches.length === 0) {
       throw new Error(`'${query}'와 정확히 일치하는 DART 상장회사 정보를 찾지 못했습니다.`);
     }
-    if (matches.length > 1) {
-      const names = matches
-        .slice(0, 5)
-        .map((item) => `${item.corp_name}(${item.stock_code}, ${item.corp_code})`)
-        .join(", ");
-      throw new Error(`'${query}'가 여러 회사와 일치합니다: ${names}`);
-    }
+    if (matches.length > 1) throw ambiguousMatchError(query, matches);
     return matches[0];
   }
 
   // 법인명 완전일치 (항상 우선)
   const exactMatches = items.filter((item) => item.corp_name === query);
   if (exactMatches.length === 1) return exactMatches[0];
-  if (exactMatches.length > 1) {
-    const names = exactMatches
-      .slice(0, 5)
-      .map((item) => `${item.corp_name}(${item.stock_code}, ${item.corp_code})`)
-      .join(", ");
-    throw new Error(`'${query}'가 여러 회사와 일치합니다: ${names}`);
-  }
+  if (exactMatches.length > 1) throw ambiguousMatchError(query, exactMatches);
 
   // 완전일치 0건 → 우선주·전환주 접미사 제거 후 폴백
   const baseName = stripPreferredStockSuffix(query);
@@ -82,10 +83,12 @@ export function resolveCorp(items, input) {
     if (fallbackMatches.length === 1) return fallbackMatches[0];
     if (fallbackMatches.length > 1) {
       const names = fallbackMatches
-        .slice(0, 5)
+        .slice(0, MAX_LISTED_MATCHES)
         .map((item) => `${item.corp_name}(${item.stock_code}, ${item.corp_code})`)
         .join(", ");
-      throw new Error(`'${query}'가 여러 회사와 일치합니다: ${names}`);
+      throw new Error(
+        `'${query}'의 기본 법인명 '${baseName}'이 여러 회사와 일치합니다: ${names}`,
+      );
     }
   }
 

--- a/mcp-dart/corp-resolver.js
+++ b/mcp-dart/corp-resolver.js
@@ -1,0 +1,94 @@
+/**
+ * corp-resolver.js
+ *
+ * DART 상장회사 목록(items)에서 주어진 종목명/코드로 법인을 조회합니다.
+ *
+ * 한계: ETF처럼 DART 법인 목록에 아예 없는 종목은 접미사 정규화로도 해결되지 않습니다
+ * (별도 매핑 필요). 이 변경은 우선주·전환주 접미사에 한정됩니다.
+ */
+
+/**
+ * 문자열 앞뒤 공백 및 내부 연속 공백을 정규화합니다.
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function cleanText(value) {
+  return String(value ?? "").replace(/\s+/g, " ").trim();
+}
+
+/**
+ * 우선주·전환주 접미사 패턴을 제거해 기본 법인명을 추출합니다.
+ * 예: "삼성전자우" → "삼성전자", "현대차2우B" → "현대차", "CJ4우(전환)" → "CJ"
+ *
+ * 패턴: 문자열 끝의 `\d*우B?(\(전환\))?` 만 제거합니다 (중간이 아닌 접미사만).
+ * 제거 후 빈 문자열이 되면 undefined를 반환합니다.
+ *
+ * @param {string} name
+ * @returns {string | undefined}
+ */
+export function stripPreferredStockSuffix(name) {
+  const base = name.replace(/\d*우B?(\(전환\))?$/, "");
+  return base.length > 0 ? base : undefined;
+}
+
+/**
+ * DART 상장회사 목록에서 종목명 또는 6자리 종목코드로 법인을 조회합니다.
+ *
+ * 1. 6자리 숫자 코드이면 stock_code로 완전일치 조회합니다.
+ * 2. 이름이면 corp_name 완전일치를 먼저 시도합니다.
+ * 3. 완전일치가 0건이면 우선주/전환주 접미사를 제거한 기본명으로 폴백합니다.
+ *    - 폴백도 0건이면 원래 query로 에러를 던집니다.
+ *    - 폴백이 다중 매칭이면 "여러 회사 일치" 에러를 던집니다.
+ *
+ * @param {Array<{corp_name: string, stock_code: string, corp_code: string}>} items
+ * @param {string} input
+ * @returns {{corp_name: string, stock_code: string, corp_code: string}}
+ */
+export function resolveCorp(items, input) {
+  const query = cleanText(input);
+  if (!query) throw new Error("stock_name 파라미터가 비어 있습니다.");
+
+  // 6자리 종목코드 경로
+  if (/^\d{6}$/.test(query)) {
+    const matches = items.filter((item) => item.stock_code === query);
+    if (matches.length === 0) {
+      throw new Error(`'${query}'와 정확히 일치하는 DART 상장회사 정보를 찾지 못했습니다.`);
+    }
+    if (matches.length > 1) {
+      const names = matches
+        .slice(0, 5)
+        .map((item) => `${item.corp_name}(${item.stock_code}, ${item.corp_code})`)
+        .join(", ");
+      throw new Error(`'${query}'가 여러 회사와 일치합니다: ${names}`);
+    }
+    return matches[0];
+  }
+
+  // 법인명 완전일치 (항상 우선)
+  const exactMatches = items.filter((item) => item.corp_name === query);
+  if (exactMatches.length === 1) return exactMatches[0];
+  if (exactMatches.length > 1) {
+    const names = exactMatches
+      .slice(0, 5)
+      .map((item) => `${item.corp_name}(${item.stock_code}, ${item.corp_code})`)
+      .join(", ");
+    throw new Error(`'${query}'가 여러 회사와 일치합니다: ${names}`);
+  }
+
+  // 완전일치 0건 → 우선주·전환주 접미사 제거 후 폴백
+  const baseName = stripPreferredStockSuffix(query);
+  if (baseName !== undefined) {
+    const fallbackMatches = items.filter((item) => item.corp_name === baseName);
+    if (fallbackMatches.length === 1) return fallbackMatches[0];
+    if (fallbackMatches.length > 1) {
+      const names = fallbackMatches
+        .slice(0, 5)
+        .map((item) => `${item.corp_name}(${item.stock_code}, ${item.corp_code})`)
+        .join(", ");
+      throw new Error(`'${query}'가 여러 회사와 일치합니다: ${names}`);
+    }
+  }
+
+  // 폴백도 실패 → 원래 query로 에러
+  throw new Error(`'${query}'와 정확히 일치하는 DART 상장회사 정보를 찾지 못했습니다.`);
+}

--- a/mcp-dart/index.js
+++ b/mcp-dart/index.js
@@ -7,6 +7,7 @@ import { XMLParser } from "fast-xml-parser";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
+import { cleanText, resolveCorp } from "./corp-resolver.js";
 
 console.log = console.error;
 
@@ -104,10 +105,6 @@ function requireDartApiKey() {
 function asArray(value) {
   if (!value) return [];
   return Array.isArray(value) ? value : [value];
-}
-
-function cleanText(value) {
-  return String(value ?? "").replace(/\s+/g, " ").trim();
 }
 
 function formatDate(date) {
@@ -248,28 +245,6 @@ async function downloadCorpCodes(apiKey) {
 
 async function getCorpCodes(apiKey) {
   return (await readFreshCorpCodeCache()) || (await downloadCorpCodes(apiKey));
-}
-
-function resolveCorp(items, input) {
-  const query = cleanText(input);
-  if (!query) throw new Error("stock_name 파라미터가 비어 있습니다.");
-
-  const matches = /^\d{6}$/.test(query)
-    ? items.filter((item) => item.stock_code === query)
-    : items.filter((item) => item.corp_name === query);
-
-  if (matches.length === 0) {
-    throw new Error(`'${query}'와 정확히 일치하는 DART 상장회사 정보를 찾지 못했습니다.`);
-  }
-  if (matches.length > 1) {
-    const names = matches
-      .slice(0, 5)
-      .map((item) => `${item.corp_name}(${item.stock_code}, ${item.corp_code})`)
-      .join(", ");
-    throw new Error(`'${query}'가 여러 회사와 일치합니다: ${names}`);
-  }
-
-  return matches[0];
 }
 
 async function fetchDisclosureList(apiKey, corp, window) {

--- a/mcp-dart/tests/resolve-corp.test.js
+++ b/mcp-dart/tests/resolve-corp.test.js
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { resolveCorp } from "../corp-resolver.js";
+import { resolveCorp, stripPreferredStockSuffix } from "../corp-resolver.js";
 
 // 합성 items 배열 — 외부 의존성 없이 순수 단위 테스트
 const items = [
@@ -10,6 +10,7 @@ const items = [
   { corp_name: "LG화학", stock_code: "051910", corp_code: "00000004" },
   // 우선주가 실제로 corp_name으로 등록된 경우(완전일치 우선 검증용)
   { corp_name: "삼성전자우", stock_code: "005935", corp_code: "00000005" },
+  { corp_name: "CJ제일제당", stock_code: "097950", corp_code: "00000006" },
 ];
 
 // 우선주·전환주 접미사 정규화 폴백 케이스
@@ -81,4 +82,36 @@ test("삼성전자(접미사 없음) → 완전일치로 반환", () => {
   const result = resolveCorp(items, "삼성전자");
   assert.equal(result.corp_name, "삼성전자");
   assert.equal(result.stock_code, "005930");
+});
+
+// 🔴1: KRX 종목명에 접미사 앞 공백이 있는 경우 ("CJ제일제당 우")
+test("CJ제일제당 우 → 접미사 앞 공백 제거 후 corp_name CJ제일제당 반환", () => {
+  const result = resolveCorp(items, "CJ제일제당 우");
+  assert.equal(result.corp_name, "CJ제일제당");
+  assert.equal(result.stock_code, "097950");
+});
+
+// 🔵2: stripPreferredStockSuffix 경계값 직접 테스트
+test("stripPreferredStockSuffix: 삼성전자우 → 삼성전자", () => {
+  assert.equal(stripPreferredStockSuffix("삼성전자우"), "삼성전자");
+});
+
+test("stripPreferredStockSuffix: 우 → undefined (빈 문자열 방지)", () => {
+  assert.equal(stripPreferredStockSuffix("우"), undefined);
+});
+
+test("stripPreferredStockSuffix: 삼성전자 → undefined (제거된 것 없음)", () => {
+  assert.equal(stripPreferredStockSuffix("삼성전자"), undefined);
+});
+
+// 🟡3: 폴백 다중 매칭 에러에 baseName이 포함됨
+test("폴백 다중 매칭 시 에러 메시지에 기본 법인명이 포함됨", () => {
+  const dupItems = [
+    { corp_name: "CJ", stock_code: "001040", corp_code: "00000001" },
+    { corp_name: "CJ", stock_code: "001041", corp_code: "00000009" },
+  ];
+  assert.throws(
+    () => resolveCorp(dupItems, "CJ4우(전환)"),
+    /기본 법인명 'CJ'/,
+  );
 });

--- a/mcp-dart/tests/resolve-corp.test.js
+++ b/mcp-dart/tests/resolve-corp.test.js
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveCorp } from "../corp-resolver.js";
+
+// 합성 items 배열 — 외부 의존성 없이 순수 단위 테스트
+const items = [
+  { corp_name: "CJ", stock_code: "001040", corp_code: "00000001" },
+  { corp_name: "삼성전자", stock_code: "005930", corp_code: "00000002" },
+  { corp_name: "현대차", stock_code: "005380", corp_code: "00000003" },
+  { corp_name: "LG화학", stock_code: "051910", corp_code: "00000004" },
+  // 우선주가 실제로 corp_name으로 등록된 경우(완전일치 우선 검증용)
+  { corp_name: "삼성전자우", stock_code: "005935", corp_code: "00000005" },
+];
+
+// 우선주·전환주 접미사 정규화 폴백 케이스
+test("CJ4우(전환) → corp_name CJ 항목 반환", () => {
+  const result = resolveCorp(items, "CJ4우(전환)");
+  assert.equal(result.corp_name, "CJ");
+  assert.equal(result.stock_code, "001040");
+});
+
+test("현대차2우B → corp_name 현대차 항목 반환", () => {
+  const result = resolveCorp(items, "현대차2우B");
+  assert.equal(result.corp_name, "현대차");
+  assert.equal(result.stock_code, "005380");
+});
+
+test("LG화학우 → corp_name LG화학 항목 반환", () => {
+  const result = resolveCorp(items, "LG화학우");
+  assert.equal(result.corp_name, "LG화학");
+  assert.equal(result.stock_code, "051910");
+});
+
+// 완전일치가 폴백보다 우선
+test("삼성전자우 → items에 실제로 있으므로 완전일치(삼성전자우) 우선 반환", () => {
+  const result = resolveCorp(items, "삼성전자우");
+  // 폴백(삼성전자)이 아니라 완전일치(삼성전자우)가 반환되어야 함
+  assert.equal(result.corp_name, "삼성전자우");
+  assert.equal(result.stock_code, "005935");
+});
+
+// 6자리 종목코드 경로
+test("005930 → stock_code 경로로 삼성전자 반환", () => {
+  const result = resolveCorp(items, "005930");
+  assert.equal(result.corp_name, "삼성전자");
+  assert.equal(result.stock_code, "005930");
+});
+
+// 접미사 없는 이름이 없으면 throw
+test("없는 법인명은 접미사 제거 후에도 throw", () => {
+  assert.throws(
+    () => resolveCorp(items, "존재하지않는회사우"),
+    (err) => {
+      assert.ok(err.message.includes("존재하지않는회사우"));
+      return true;
+    },
+  );
+});
+
+// 정규화 후에도 없으면 원래 query로 에러
+test("정규화 후에도 없으면 원래 query가 에러 메시지에 포함됨", () => {
+  assert.throws(
+    () => resolveCorp(items, "없는회사4우(전환)"),
+    (err) => {
+      assert.ok(err.message.includes("없는회사4우(전환)"));
+      return true;
+    },
+  );
+});
+
+// 빈 입력은 throw
+test("빈 stock_name은 throw", () => {
+  assert.throws(
+    () => resolveCorp(items, ""),
+    /stock_name 파라미터가 비어 있습니다/,
+  );
+});
+
+// 일반 법인명(접미사 없음)은 완전일치 경로
+test("삼성전자(접미사 없음) → 완전일치로 반환", () => {
+  const result = resolveCorp(items, "삼성전자");
+  assert.equal(result.corp_name, "삼성전자");
+  assert.equal(result.stock_code, "005930");
+});


### PR DESCRIPTION
Closes #159

## 문제
`mcp-dart`의 `resolveCorp`이 법인명 **완전일치**로만 조회해, 종목명에 우선주 수식이 붙는 종목은 DART 조회가 항상 실패했습니다. 예: 종목명 `CJ4우(전환)` vs DART 법인명 `CJ`. `get_disclosure_signal`/`get_earnings_report`가 종목명을 그대로 넘기므로, 보유 종목이 우선주·전환주면 공시 감시가 조용히 아무것도 못 잡습니다.

## 변경 (해결책 B: 접미사 정규화)
- 법인명 **완전일치를 먼저** 시도(기존 동작·6자리 코드 경로 불변).
- 완전일치가 **0건일 때만** 폴백: 끝의 `\d*우B?(\(전환\))?` 접미사를 제거한 기본 법인명으로 재조회. 폴백은 **고유 매칭(1건)일 때만** 반환하고, 다중이면 기존 "여러 회사 일치" 에러, 0건이면 원래 query로 "찾지 못했습니다" 에러.
- 완전일치가 항상 우선이라 정상 법인명은 회귀 없음.
- 테스트 가능하도록 `resolveCorp`·`cleanText`를 부작용 없는 `mcp-dart/corp-resolver.js`로 분리(`index.js`는 import해 위임, 나머지 로직 무변경).

## 한계
ETF처럼 DART 법인 목록에 **아예 없는** 종목은 접미사 정규화로 해결되지 않습니다(별도 매핑 필요). 이 변경은 우선주·전환주 접미사에 한정됩니다.

## 테스트
`mcp-dart/tests/resolve-corp.test.js` 신규 9건 — `CJ4우(전환)`→`CJ`, `현대차2우B`→`현대차`, `LG화학우`→`LG화학`, 완전일치 우선, 6자리 코드 경로, 접미사 제거 후에도 없으면 throw 등. `node --test tests/resolve-corp.test.js` → 9 pass.

## 범위
`mcp-dart/` 3개 파일만(`index.js`, `corp-resolver.js`, `tests/resolve-corp.test.js`).