### PR TITLE
fix: 미해석 종목코드(name==code) 주문 확인 화면에 경고 표시 (#139)

### DIFF
--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -1024,6 +1024,11 @@ class TelegramCommandHandler:
             f"수량: {order.quantity:,}주",
             f"주문유형: {'시장가' if order.order_type == 'MARKET' else '지정가'}",
         ]
+        if order.stock_name == order.stock_code:
+            lines.append(
+                "⚠️ 종목명을 확인하지 못했습니다. 입력한 코드가 맞는지 다시 확인하세요."
+            )
+
         if order.order_type == "LIMIT":
             amount = order.quantity * order.price
             lines.extend(

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -43,6 +43,11 @@ WATCH_COMMAND_HELP = "사용법: /watch add <종목명> | remove <종목명> | l
 CATALYST_COMMAND_HELP = "사용법: /catalysts <종목명>"
 EARNINGS_COMMAND_HELP = "사용법: /earnings <종목명> [기간]  예: /earnings 삼성전자 2025Q1"
 NATURAL_ORDER_HELP = "자연어 주문을 해석할 수 없습니다. /buy 또는 /sell 형식으로 입력하세요."
+# 미등록 코드는 mcp-trading/stock-master.js가 {code: X, name: X, market: "UNKNOWN"}을
+# echo하므로 종목명 == 종목코드가 곧 미해석 신호다.
+UNRESOLVED_STOCK_WARNING = (
+    "⚠️ 종목명을 확인하지 못했습니다. 입력한 코드가 맞는지 다시 확인하세요."
+)
 # resolve_stock_code 응답 형식: "종목명 (코드, 시장)" — mcp-trading/index.js
 # 종목명에 괄호가 들어가고 닫히지 않는 종목이 있어(예: "KIWOOM 엔비디아미국30년국채혼합액티브(H")
 # 단순 괄호 매칭 대신 코드+쉼표 조합에 앵커한다. 종목명에 쉼표가 들어가는 종목은 없다.
@@ -683,6 +688,9 @@ class TelegramCommandHandler:
                 {"stock_name": stock_name},
             )
             stock_code = self._extract_stock_code(str(resolved))
+            # 사용자가 코드를 직접 입력해도 해석된 종목명을 쓴다. 원문(stock_name)을 그대로
+            # 넣으면 name == code가 되어 정상 종목에도 미해석 경고가 뜬다(#139 리뷰).
+            resolved_name = self._extract_stock_name(str(resolved)) or stock_name
             if stock_code is None:
                 await self._send_text_or_raise("주문 준비 실패: 종목코드를 확인할 수 없습니다.")
                 return
@@ -713,7 +721,7 @@ class TelegramCommandHandler:
 
         order = PendingOrder(
             chat_id=chat_id,
-            stock_name=stock_name,
+            stock_name=resolved_name,
             stock_code=stock_code,
             side=side,
             quantity=quantity,
@@ -865,6 +873,13 @@ class TelegramCommandHandler:
     def _extract_stock_code(self, text: str) -> str | None:
         match = _STOCK_CODE_EXTRACT_RE.search(text)
         return match.group(1) if match else None
+
+    def _extract_stock_name(self, text: str) -> str | None:
+        # resolve_stock_code 응답 "종목명 (코드, 시장)"에서 코드 앵커 앞부분이 종목명이다.
+        match = _STOCK_CODE_EXTRACT_RE.search(text)
+        if match is None:
+            return None
+        return text[: match.start()].strip() or None
 
     def _extract_order_callback_token(self, data: str) -> str | None:
         if data in {ORDER_CONFIRM_CALLBACK, ORDER_CANCEL_CALLBACK}:
@@ -1024,10 +1039,6 @@ class TelegramCommandHandler:
             f"수량: {order.quantity:,}주",
             f"주문유형: {'시장가' if order.order_type == 'MARKET' else '지정가'}",
         ]
-        if order.stock_name == order.stock_code:
-            lines.append(
-                "⚠️ 종목명을 확인하지 못했습니다. 입력한 코드가 맞는지 다시 확인하세요."
-            )
 
         if order.order_type == "LIMIT":
             amount = order.quantity * order.price
@@ -1051,6 +1062,9 @@ class TelegramCommandHandler:
         )
         if balance:
             lines.append(balance)
+
+        if order.stock_name == order.stock_code:
+            lines.append(UNRESOLVED_STOCK_WARNING)
 
         lines.extend(
             [

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -1039,7 +1039,6 @@ class TelegramCommandHandler:
             f"수량: {order.quantity:,}주",
             f"주문유형: {'시장가' if order.order_type == 'MARKET' else '지정가'}",
         ]
-
         if order.order_type == "LIMIT":
             amount = order.quantity * order.price
             lines.extend(

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -1329,6 +1329,46 @@ async def test_cancel_without_pending_order_replies():
     assert notifier.messages[-1] == "취소할 대기 주문이 없습니다."
 
 
+def test_format_order_prompt_shows_warning_when_stock_name_equals_stock_code():
+    """미해석 코드(name == code)일 때 확인 메시지에 경고 문구가 포함된다."""
+    from backend.trading_orders import PendingOrder
+
+    handler = TelegramCommandHandler(notifier=FakeNotifier())
+    order = PendingOrder(
+        chat_id="123",
+        stock_code="123456",
+        stock_name="123456",
+        side="BUY",
+        quantity=10,
+        price=0,
+        order_type="MARKET",
+        callback_token="tok",
+        created_at=datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+    message = handler._format_order_prompt(order, "", "")
+    assert "⚠️ 종목명을 확인하지 못했습니다. 입력한 코드가 맞는지 다시 확인하세요." in message
+
+
+def test_format_order_prompt_no_warning_when_stock_name_differs_from_stock_code():
+    """정상 종목(name != code)일 때 경고 문구가 없다."""
+    from backend.trading_orders import PendingOrder
+
+    handler = TelegramCommandHandler(notifier=FakeNotifier())
+    order = PendingOrder(
+        chat_id="123",
+        stock_code="005930",
+        stock_name="삼성전자",
+        side="BUY",
+        quantity=10,
+        price=0,
+        order_type="MARKET",
+        callback_token="tok",
+        created_at=datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+    message = handler._format_order_prompt(order, "", "")
+    assert "⚠️ 종목명을 확인하지 못했습니다." not in message
+
+
 @pytest.mark.asyncio
 async def test_confirm_executes_gateway_and_records_trade():
     async def mcp_runner(server_params, tool_name, arguments):

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -18,6 +18,7 @@ from backend.telegram_commands import (
     TELEGRAM_MESSAGE_LIMIT,
     TELEGRAM_TRUNCATION_SUFFIX,
     TREND_COMMAND_HELP,
+    UNRESOLVED_STOCK_WARNING,
     TelegramCommandHandler,
     TelegramCommandPoller,
 )
@@ -1329,44 +1330,63 @@ async def test_cancel_without_pending_order_replies():
     assert notifier.messages[-1] == "취소할 대기 주문이 없습니다."
 
 
-def test_format_order_prompt_shows_warning_when_stock_name_equals_stock_code():
-    """미해석 코드(name == code)일 때 확인 메시지에 경고 문구가 포함된다."""
-    from backend.trading_orders import PendingOrder
+@pytest.mark.asyncio
+async def test_buy_with_stock_code_resolves_name_and_shows_no_warning():
+    """코드를 직접 입력해도 해석된 종목명을 쓰므로 미해석 경고가 없다."""
 
-    handler = TelegramCommandHandler(notifier=FakeNotifier())
-    order = PendingOrder(
-        chat_id="123",
-        stock_code="123456",
-        stock_name="123456",
-        side="BUY",
-        quantity=10,
-        price=0,
-        order_type="MARKET",
-        callback_token="tok",
-        created_at=datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    async def mcp_runner(server_params, tool_name, arguments):
+        if tool_name == "resolve_stock_code":
+            return "삼성전자 (005930, KOSPI)"
+        if tool_name == "get_stock_quote":
+            return "현재가: 74,500원"
+        if tool_name == "get_balance":
+            return "주문가능금액: 1,000,000원"
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
     )
-    message = handler._format_order_prompt(order, "", "")
-    assert "⚠️ 종목명을 확인하지 못했습니다. 입력한 코드가 맞는지 다시 확인하세요." in message
 
-
-def test_format_order_prompt_no_warning_when_stock_name_differs_from_stock_code():
-    """정상 종목(name != code)일 때 경고 문구가 없다."""
-    from backend.trading_orders import PendingOrder
-
-    handler = TelegramCommandHandler(notifier=FakeNotifier())
-    order = PendingOrder(
-        chat_id="123",
-        stock_code="005930",
-        stock_name="삼성전자",
-        side="BUY",
-        quantity=10,
-        price=0,
-        order_type="MARKET",
-        callback_token="tok",
-        created_at=datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "/buy 005930 10"}}
     )
-    message = handler._format_order_prompt(order, "", "")
-    assert "⚠️ 종목명을 확인하지 못했습니다." not in message
+
+    assert handler.pending_orders["123"].stock_name == "삼성전자"
+    assert handler.pending_orders["123"].stock_code == "005930"
+    assert "삼성전자 매수 주문 확인" in notifier.messages[-1]
+    assert UNRESOLVED_STOCK_WARNING not in notifier.messages[-1]
+
+
+@pytest.mark.asyncio
+async def test_buy_with_unregistered_code_shows_unresolved_warning():
+    """미등록 코드는 이름=코드로 echo되므로 미해석 경고가 붙는다."""
+
+    async def mcp_runner(server_params, tool_name, arguments):
+        if tool_name == "resolve_stock_code":
+            return "123456 (123456, UNKNOWN)"
+        if tool_name == "get_stock_quote":
+            return "현재가: 0원"
+        if tool_name == "get_balance":
+            return "주문가능금액: 1,000,000원"
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "/buy 123456 10"}}
+    )
+
+    assert handler.pending_orders["123"].stock_name == "123456"
+    assert handler.pending_orders["123"].stock_code == "123456"
+    assert UNRESOLVED_STOCK_WARNING in notifier.messages[-1]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #139

## 문제
종목마스터에 없는 코드를 입력하면 `resolveStock`이 `{name: code, market: "UNKNOWN"}`을 반환합니다(의도된 설계). 그 결과 텔레그램 주문 확인 화면이 `123456 매수 주문 확인 / 종목코드: 123456`처럼 **종목명을 대조할 정보 없이** 표시돼, 오타로 실재하는 다른 종목 코드를 입력해도 현재가만 보고 `/confirm`으로 엉뚱한 종목을 체결할 수 있습니다.

## 변경
- `_format_order_prompt`에서 `order.stock_name == order.stock_code`(미해석 신호)일 때 확인 메시지에 `⚠️ 종목명을 확인하지 못했습니다...` 경고 줄을 추가합니다. 마스터에서 해석된 종목은 이름≠코드(삼성전자≠005930)라 오탐이 없습니다.

## 테스트
- 미해석 코드에서 경고 포함 / 정상 종목에서 경고 부재 단언. `pytest test_telegram_commands.py` → 100 passed.

## 범위
`backend/telegram_commands.py`, `backend/tests/test_telegram_commands.py` 2개 파일만.