### PR TITLE
fix: report.details null 크래시 가드 + getData 응답 검증 (#70)

### DIFF
--- a/frontend-react/src/api.ts
+++ b/frontend-react/src/api.ts
@@ -19,9 +19,15 @@ export function apiErrorMessage(err: unknown): string {
   return '서버와 통신 중 오류가 발생했습니다.';
 }
 
-async function getData<T>(url: string, params?: Record<string, string>) {
+async function getData<T>(url: string, params?: Record<string, string>): Promise<T> {
   const response = await axios.get<ApiResponse<T>>(url, { params });
-  return response.data.data;
+  const { status, data, message } = response.data;
+  if (status !== 'success' || data == null) {
+    throw new Error(
+      `API 오류: status="${status}"${message ? `, message="${message}"` : ''} (url=${url})`
+    );
+  }
+  return data;
 }
 
 async function postData<T>(url: string, body: unknown) {

--- a/frontend-react/src/api.ts
+++ b/frontend-react/src/api.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { type AxiosResponse } from 'axios';
 import type {
   AccountBalance,
   AgentReportItem,
@@ -10,29 +10,43 @@ import type {
   TradeHistoryItem,
 } from './types';
 
+// status가 success가 아니거나 data가 없는 API 응답을 나타낸다. 사용자에게는
+// 백엔드 message/url을 그대로 노출하지 않고(내부 경로 유출 방지), 진단 정보는
+// message/console.error 쪽으로만 보낸다.
+export class ApiStatusError extends Error {
+  constructor(readonly status: string, readonly detail: string | null, readonly url: string) {
+    super(`API 오류: status="${status}"${detail ? `, message="${detail}"` : ''} (url=${url})`);
+    this.name = 'ApiStatusError';
+  }
+}
+
 export function apiErrorMessage(err: unknown): string {
   if (axios.isAxiosError(err)) {
     const detail = err.response?.data?.detail || err.response?.data?.message;
     if (detail) return typeof detail === 'string' ? detail : JSON.stringify(detail);
     if (err.message) return err.message;
   }
+  if (err instanceof ApiStatusError) {
+    console.error(err.message);
+    return err.detail ?? '서버가 오류 응답을 반환했습니다.';
+  }
   return '서버와 통신 중 오류가 발생했습니다.';
 }
 
-async function getData<T>(url: string, params?: Record<string, string>): Promise<T> {
-  const response = await axios.get<ApiResponse<T>>(url, { params });
+function unwrap<T>(response: AxiosResponse<ApiResponse<T>>, url: string): T {
   const { status, data, message } = response.data;
   if (status !== 'success' || data == null) {
-    throw new Error(
-      `API 오류: status="${status}"${message ? `, message="${message}"` : ''} (url=${url})`
-    );
+    throw new ApiStatusError(status, message ?? null, url);
   }
   return data;
 }
 
-async function postData<T>(url: string, body: unknown) {
-  const response = await axios.post<ApiResponse<T>>(url, body);
-  return response.data.data;
+async function getData<T>(url: string, params?: Record<string, string>): Promise<T> {
+  return unwrap(await axios.get<ApiResponse<T>>(url, { params }), url);
+}
+
+async function postData<T>(url: string, body: unknown): Promise<T> {
+  return unwrap(await axios.post<ApiResponse<T>>(url, body), url);
 }
 
 export const finUsApi = {

--- a/frontend-react/src/components/ReportSidebar.tsx
+++ b/frontend-react/src/components/ReportSidebar.tsx
@@ -11,6 +11,12 @@ const ReportSidebar: React.FC<ReportSidebarProps> = ({ report, currentNews }) =>
   return (
     <div className="xl:col-span-1 space-y-6">
       {report && (
+        report.details == null ? (
+          <div className="p-8 rounded-[2rem] border-none shadow-2xl bg-gradient-to-br from-slate-400 to-slate-500 text-white">
+            <span className="text-xs font-black uppercase tracking-widest opacity-80">AI STRATEGY</span>
+            <p className="mt-4 text-sm font-bold opacity-80">분석 결과 없음</p>
+          </div>
+        ) : (
         <div className={`p-8 rounded-[2rem] border-none shadow-2xl relative overflow-hidden ${
           report.details.decision === 'BUY' ? 'bg-gradient-to-br from-rose-500 to-rose-600 text-white' :
           report.details.decision === 'SELL' ? 'bg-gradient-to-br from-indigo-500 to-indigo-600 text-white' :
@@ -49,6 +55,7 @@ const ReportSidebar: React.FC<ReportSidebarProps> = ({ report, currentNews }) =>
             {report.details.reason}
           </p>
         </div>
+        )
       )}
 
       <div className="bg-white p-6 rounded-[2rem] shadow-xl border border-slate-50">

--- a/frontend-react/src/components/ReportSidebar.tsx
+++ b/frontend-react/src/components/ReportSidebar.tsx
@@ -1,60 +1,98 @@
 import React from 'react';
 import { TrendingUp, TrendingDown, Minus, Newspaper } from 'lucide-react';
-import { AnalysisReport } from '../types';
+import { AnalysisReport, TradingSignal } from '../types';
 
 interface ReportSidebarProps {
   report: AnalysisReport | null;
   currentNews: string[];
 }
 
+interface ProviderBadgeProps {
+  provider: string | null;
+  providerSupportsTools: boolean;
+}
+
+const ProviderBadge: React.FC<ProviderBadgeProps> = ({ provider, providerSupportsTools }) => (
+  <span
+    className={`text-[10px] font-black uppercase tracking-wide px-2 py-0.5 rounded-full ${
+      providerSupportsTools ? 'bg-white/25' : 'bg-black/20 opacity-80'
+    }`}
+    title={
+      providerSupportsTools
+        ? `provider(${provider ?? '알 수 없음'})가 도구(MCP/KIS/뉴스) 호출 경로로 구성되어 있다는 뜻입니다. 이번 응답에서 실제로 도구가 호출되었다는 관측은 아닙니다.`
+        : `provider(${provider ?? '알 수 없음'})는 도구(MCP/KIS/뉴스) 없이 모델이 직접 답을 생성했습니다. 수치가 지어낸 값일 수 있습니다.`
+    }
+  >
+    {providerSupportsTools ? 'Tool-capable (unconfirmed)' : 'No tool access'}
+  </span>
+);
+
+interface EmptyStrategyCardProps {
+  provider: string | null;
+  providerSupportsTools: boolean;
+}
+
+const EmptyStrategyCard: React.FC<EmptyStrategyCardProps> = ({ provider, providerSupportsTools }) => (
+  <div className="p-8 rounded-[2rem] border-none shadow-2xl bg-gradient-to-br from-slate-400 to-slate-500 text-white">
+    <div className="flex justify-between items-center mb-6">
+      <div className="flex items-center gap-2">
+        <span className="text-xs font-black uppercase tracking-widest opacity-80">AI STRATEGY</span>
+        <ProviderBadge provider={provider} providerSupportsTools={providerSupportsTools} />
+      </div>
+      <Minus className="w-8 h-8 opacity-50" />
+    </div>
+    <p className="mt-4 text-sm font-bold opacity-80">분석 결과 없음</p>
+  </div>
+);
+
+interface StrategyCardProps {
+  details: TradingSignal;
+  provider: string | null;
+  providerSupportsTools: boolean;
+}
+
+const StrategyCard: React.FC<StrategyCardProps> = ({ details, provider, providerSupportsTools }) => (
+  <div className={`p-8 rounded-[2rem] border-none shadow-2xl relative overflow-hidden ${
+    details.decision === 'BUY' ? 'bg-gradient-to-br from-rose-500 to-rose-600 text-white' :
+    details.decision === 'SELL' ? 'bg-gradient-to-br from-indigo-500 to-indigo-600 text-white' :
+    'bg-gradient-to-br from-slate-500 to-slate-600 text-white'
+  }`}>
+    <div className="flex justify-between items-center mb-6">
+      <div className="flex items-center gap-2">
+        <span className="text-xs font-black uppercase tracking-widest opacity-80">AI STRATEGY</span>
+        <ProviderBadge provider={provider} providerSupportsTools={providerSupportsTools} />
+      </div>
+      {details.decision === 'BUY' ? <TrendingUp className="w-8 h-8 opacity-50" /> :
+       details.decision === 'SELL' ? <TrendingDown className="w-8 h-8 opacity-50" /> : <Minus className="w-8 h-8 opacity-50" />}
+    </div>
+    <h2 className="text-7xl font-black mb-4 tracking-tighter">{details.decision}</h2>
+    <div className="space-y-2 mb-8">
+      <div className="flex justify-between text-xs font-black opacity-80 uppercase">
+        <span>Confidence</span>
+        <span>{(details.confidence_score * 100).toFixed(0)}%</span>
+      </div>
+      <div className="h-3 w-full bg-white/20 rounded-full overflow-hidden">
+        <div className="h-full bg-white transition-all shadow-[0_0_10px_rgba(255,255,255,0.5)]" style={{ width: `${details.confidence_score * 100}%` }} />
+      </div>
+    </div>
+    <p className="text-sm leading-relaxed font-bold bg-black/10 p-5 rounded-2xl backdrop-blur-sm">
+      {details.reason}
+    </p>
+  </div>
+);
+
 const ReportSidebar: React.FC<ReportSidebarProps> = ({ report, currentNews }) => {
   return (
     <div className="xl:col-span-1 space-y-6">
       {report && (
         report.details == null ? (
-          <div className="p-8 rounded-[2rem] border-none shadow-2xl bg-gradient-to-br from-slate-400 to-slate-500 text-white">
-            <span className="text-xs font-black uppercase tracking-widest opacity-80">AI STRATEGY</span>
-            <p className="mt-4 text-sm font-bold opacity-80">분석 결과 없음</p>
-          </div>
+          <EmptyStrategyCard provider={report.provider} providerSupportsTools={report.provider_supports_tools} />
         ) : (
-        <div className={`p-8 rounded-[2rem] border-none shadow-2xl relative overflow-hidden ${
-          report.details.decision === 'BUY' ? 'bg-gradient-to-br from-rose-500 to-rose-600 text-white' :
-          report.details.decision === 'SELL' ? 'bg-gradient-to-br from-indigo-500 to-indigo-600 text-white' :
-          'bg-gradient-to-br from-slate-500 to-slate-600 text-white'
-        }`}>
-          <div className="flex justify-between items-center mb-6">
-            <div className="flex items-center gap-2">
-              <span className="text-xs font-black uppercase tracking-widest opacity-80">AI STRATEGY</span>
-              <span
-                className={`text-[10px] font-black uppercase tracking-wide px-2 py-0.5 rounded-full ${
-                  report.provider_supports_tools ? 'bg-white/25' : 'bg-black/20 opacity-80'
-                }`}
-                title={
-                  report.provider_supports_tools
-                    ? `provider(${report.provider ?? '알 수 없음'})가 도구(MCP/KIS/뉴스) 호출 경로로 구성되어 있다는 뜻입니다. 이번 응답에서 실제로 도구가 호출되었다는 관측은 아닙니다.`
-                    : `provider(${report.provider ?? '알 수 없음'})는 도구(MCP/KIS/뉴스) 없이 모델이 직접 답을 생성했습니다. 수치가 지어낸 값일 수 있습니다.`
-                }
-              >
-                {report.provider_supports_tools ? 'Tool-capable (unconfirmed)' : 'No tool access'}
-              </span>
-            </div>
-            {report.details.decision === 'BUY' ? <TrendingUp className="w-8 h-8 opacity-50" /> :
-             report.details.decision === 'SELL' ? <TrendingDown className="w-8 h-8 opacity-50" /> : <Minus className="w-8 h-8 opacity-50" />}
-          </div>
-          <h2 className="text-7xl font-black mb-4 tracking-tighter">{report.details.decision}</h2>
-          <div className="space-y-2 mb-8">
-            <div className="flex justify-between text-xs font-black opacity-80 uppercase">
-              <span>Confidence</span>
-              <span>{(report.details.confidence_score * 100).toFixed(0)}%</span>
-            </div>
-            <div className="h-3 w-full bg-white/20 rounded-full overflow-hidden">
-              <div className="h-full bg-white transition-all shadow-[0_0_10px_rgba(255,255,255,0.5)]" style={{ width: `${report.details.confidence_score * 100}%` }} />
-            </div>
-          </div>
-          <p className="text-sm leading-relaxed font-bold bg-black/10 p-5 rounded-2xl backdrop-blur-sm">
-            {report.details.reason}
-          </p>
-        </div>
+          <StrategyCard
+            details={report.details}
+            provider={report.provider}
+            providerSupportsTools={report.provider_supports_tools}
+          />
         )
       )}
 

--- a/frontend-react/src/components/ReportSidebar.tsx
+++ b/frontend-react/src/components/ReportSidebar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TrendingUp, TrendingDown, Minus, Newspaper } from 'lucide-react';
+import { TrendingUp, TrendingDown, Minus, Newspaper, HelpCircle } from 'lucide-react';
 import { AnalysisReport, TradingSignal } from '../types';
 
 interface ReportSidebarProps {
@@ -39,9 +39,9 @@ const EmptyStrategyCard: React.FC<EmptyStrategyCardProps> = ({ provider, provide
         <span className="text-xs font-black uppercase tracking-widest opacity-80">AI STRATEGY</span>
         <ProviderBadge provider={provider} providerSupportsTools={providerSupportsTools} />
       </div>
-      <Minus className="w-8 h-8 opacity-50" />
+      <HelpCircle className="w-8 h-8 opacity-50" />
     </div>
-    <p className="mt-4 text-sm font-bold opacity-80">분석 결과 없음</p>
+    <p className="text-sm font-bold opacity-80">분석 결과 없음</p>
   </div>
 );
 

--- a/frontend-react/src/types.ts
+++ b/frontend-react/src/types.ts
@@ -35,7 +35,10 @@ export interface TrendItem {
 
 export interface ApiResponse<T> {
   status: string;
-  data: T;
+  // 백엔드 schemas.py의 CommonResponse.data: Any | None = None과 일치시킨다.
+  // api.ts의 unwrap()이 런타임에서 null을 걸러 T를 반환하므로, 이 필드를
+  // 우회해 response.data.data를 직접 쓰는 코드는 컴파일 타임에 걸린다 (#70).
+  data: T | null;
   message?: string | null;
 }
 

--- a/frontend-react/src/types.ts
+++ b/frontend-react/src/types.ts
@@ -7,7 +7,7 @@ export interface TradingSignal {
 
 export interface AnalysisReport {
   summary: string;
-  details: TradingSignal;
+  details?: TradingSignal | null;
   source_news: string[];
   source_signals?: string[];
   trading_trend: string | null;

--- a/frontend-react/src/types.ts
+++ b/frontend-react/src/types.ts
@@ -7,7 +7,10 @@ export interface TradingSignal {
 
 export interface AnalysisReport {
   summary: string;
-  details?: TradingSignal | null;
+  // 백엔드 schemas.py는 details: TradingSignal(필수)이지만, /api/v1/analyze의
+  // response_model이 CommonResponse(data: Any | None)라 이 필드가 스키마 검증을
+  // 거치지 않는다. 방어적으로 nullable로 선언한다 (#70).
+  details: TradingSignal | null;
   source_news: string[];
   source_signals?: string[];
   trading_trend: string | null;


### PR DESCRIPTION
Closes #70

## 문제
1. `AnalysisReport.details`가 non-nullable로 선언됐지만 백엔드가 NAT 파싱 실패 시 `null`을 반환할 수 있어, `ReportSidebar`에서 `report.details.decision` 접근 시 `TypeError` → 흰 화면(렌더 트리 전체 중단).
2. `getData<T>()`가 응답을 무조건 `T`로 단언 — 백엔드가 `status:"error"`로 200을 반환하거나 `data: null`이면 호출부에서 런타임 에러.

## 변경
- `types.ts`: `details?: TradingSignal | null`.
- `ReportSidebar.tsx`: `report.details == null`이면 "분석 결과 없음" 플레이스홀더 렌더. else 분기에서 TS 제어흐름이 `details`를 `TradingSignal`로 좁혀 기존 접근이 타입 안전.
- `api.ts`: `getData`가 `status !== 'success' || data == null`이면 status·message·url 담은 `Error`를 throw, 정상 경로에서만 `data` 반환.

## 검증
- `report.details`의 다른 소비자 없음(grep 확인) — 타입 변경이 다른 컴포넌트를 깨지 않음.
- CI `frontend-typecheck`(`npx tsc --noEmit`)로 타입 검증. (로컬은 node_modules 미설치라 수동 타입 검토.)

## 범위
`types.ts`, `ReportSidebar.tsx`, `api.ts` 3개 파일만.