### PR TITLE
fix: DuplicateOrderError가 예약 항목 대신 만료 시각만 들도록 축소 (#167)

### DIFF
--- a/mcp-trading/order-dedup.js
+++ b/mcp-trading/order-dedup.js
@@ -6,11 +6,29 @@ import path from "node:path";
 export const DEFAULT_ORDER_DEDUP_TTL_MS = 120_000;
 const DEFAULT_ORDER_DEDUP_PATH = path.join(os.tmpdir(), "finus-kis-order-dedup.json");
 
+// 원장 항목에는 request.body.CANO(계좌번호)가 평문으로 들어 있다. message는
+// 깨끗해도 에러 "객체"를 로깅하는 순간(console.error(err)·JSON.stringify(err)·
+// util.inspect(err, {depth: null})) 항목 전체가 그대로 찍히므로, 이 클래스는
+// 항목을 들고 있지 않는다.
+//
+// 항목을 non-enumerable로 숨기는 선택지도 있었지만 받지 않았다. 저장소 전체를
+// 훑어보면 이 에러를 잡는 쪽은 항목의 어느 필드도 읽지 않는다(유일한 `.entry`
+// 참조가 이 대입 자체였다) - 숨겨야 할 만큼의 진단 가치가 애초에 없다.
+// 숨기기만 하면 값은 계속 살아 있어 showHidden 출력·getOwnPropertyNames·커스텀
+// 직렬화로 언제든 다시 새고, LedgerUnreadableError가 같은 파일에서 "내용을
+// 아예 싣지 않는다"는 자세를 이미 세워둔 터라 둘을 어긋나게 둘 이유가 없다.
+//
+// 남기는 것은 만료 시각 하나다. 계좌번호와 무관한 타임스탬프이면서 "차단이
+// 언제 풀리는지"라는 메시지의 '잠시 후'를 실제 값으로 뒷받침한다. 항목이 아니라
+// 이 숫자만 받도록 생성자 자체를 바꿔둔다 - 그래야 원장 내용이 이 클래스로
+// 흘러들어올 경로가 구조적으로 남지 않는다. dedup 키는 일부러 싣지 않는다:
+// sha256이어도 CANO는 10자리 숫자라 나머지 주문 필드를 아는 쪽에는 전수 탐색이
+// 현실적이고, 이 역시 잡는 쪽에서 아무도 쓰지 않는다.
 export class DuplicateOrderError extends Error {
-  constructor(entry) {
+  constructor(expiresAt) {
     super("중복 주문 방지를 위해 동일 주문 재요청을 차단했습니다. 잠시 후 주문 내역을 확인하세요.");
     this.name = "DuplicateOrderError";
-    this.entry = entry;
+    this.expiresAt = expiresAt;
   }
 }
 
@@ -133,7 +151,7 @@ export class OrderDedupStore {
     const ledger = this.#readLedger(now);
     const existing = ledger[key];
     if (existing && Number(existing.expiresAt) > now) {
-      throw new DuplicateOrderError(existing);
+      throw new DuplicateOrderError(Number(existing.expiresAt));
     }
 
     const entry = {

--- a/mcp-trading/order-dedup.js
+++ b/mcp-trading/order-dedup.js
@@ -21,14 +21,20 @@ const DEFAULT_ORDER_DEDUP_PATH = path.join(os.tmpdir(), "finus-kis-order-dedup.j
 // 남기는 것은 만료 시각 하나다. 계좌번호와 무관한 타임스탬프이면서 "차단이
 // 언제 풀리는지"라는 메시지의 '잠시 후'를 실제 값으로 뒷받침한다. 항목이 아니라
 // 이 숫자만 받도록 생성자 자체를 바꿔둔다 - 그래야 원장 내용이 이 클래스로
-// 흘러들어올 경로가 구조적으로 남지 않는다. dedup 키는 일부러 싣지 않는다:
+// 흘러들어올 경로가 구조적으로 남지 않는다. 더 나아가 생성자가 expiresAt을
+// 직접 Number()로 좁혀, 호출부가 실수로 원장 항목을 통째로 넘겨도 내용이 실리지
+// 않도록 보장한다(Number({...}) === NaN). dedup 키는 일부러 싣지 않는다:
 // sha256이어도 CANO는 10자리 숫자라 나머지 주문 필드를 아는 쪽에는 전수 탐색이
 // 현실적이고, 이 역시 잡는 쪽에서 아무도 쓰지 않는다.
 export class DuplicateOrderError extends Error {
+  // expiresAt은 반드시 숫자로 좁힌다. 호출부가 실수로 원장 항목을 넘겨도
+  // Number({...}) === NaN이라 내용이 실리지 않는다 - "원장 내용이 흘러들어올
+  // 경로가 없다"를 호출부 관례가 아니라 이 클래스가 스스로 보장하게 한다.
+  // (원장은 외부 파일이라 expiresAt이 문자열일 수도 있어 어차피 강제가 필요하다.)
   constructor(expiresAt) {
     super("중복 주문 방지를 위해 동일 주문 재요청을 차단했습니다. 잠시 후 주문 내역을 확인하세요.");
     this.name = "DuplicateOrderError";
-    this.expiresAt = expiresAt;
+    this.expiresAt = Number(expiresAt);
   }
 }
 
@@ -150,8 +156,9 @@ export class OrderDedupStore {
     const now = this.now();
     const ledger = this.#readLedger(now);
     const existing = ledger[key];
-    if (existing && Number(existing.expiresAt) > now) {
-      throw new DuplicateOrderError(Number(existing.expiresAt));
+    const expiresAt = Number(existing?.expiresAt);
+    if (existing && expiresAt > now) {
+      throw new DuplicateOrderError(expiresAt);
     }
 
     const entry = {

--- a/mcp-trading/tests/order-dedup.test.js
+++ b/mcp-trading/tests/order-dedup.test.js
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test, { after } from "node:test";
+import util from "node:util";
 import {
   DEFAULT_ORDER_DEDUP_TTL_MS,
   DuplicateOrderError,
@@ -157,6 +158,111 @@ test("OrderDedupStore blocks duplicate reservations across separate instances sh
   assert.throws(
     () => storeB.reserve("same-order", { stockCode: "005930" }),
     DuplicateOrderError,
+  );
+});
+
+const LEAKED_CANO = "1234567890";
+
+// index.js의 placeOrder가 reserve()에 실제로 넘기는 모양 그대로다(pathname·
+// trId·body). CANO가 평문으로 들어가는 것은 이 body이므로, 축약된 페이로드로
+// 검증하면 정작 새는 필드를 지나치게 된다.
+function reserveThenTriggerDuplicate(t) {
+  const filePath = tempLedgerPath(t);
+  const store = new OrderDedupStore({ filePath, ttlMs: 60_000, now: () => 1_000 });
+  const request = {
+    pathname: "/uapi/domestic-stock/v1/trading/order-cash",
+    trId: "VTTC0802U",
+    body: { CANO: LEAKED_CANO, ACNT_PRDT_CD: "01", PDNO: "005930", ORD_QTY: "1" },
+  };
+
+  store.reserve("same-order", request);
+
+  // 원장에 CANO가 평문으로 저장된다는 전제를 함께 고정한다. 이 전제가 깨지면
+  // (예: 호출자가 body를 더 이상 넘기지 않게 되면) 아래 "누출 없음" 단언들이
+  // 전부 공허하게 참이 되어 조용히 검증력을 잃는다.
+  assert.ok(
+    fs.readFileSync(filePath, "utf8").includes(LEAKED_CANO),
+    "이 테스트의 전제(원장 항목에 CANO가 평문으로 저장됨)가 깨졌습니다",
+  );
+
+  let thrown;
+  assert.throws(
+    () => store.reserve("same-order", request),
+    (error) => {
+      thrown = error;
+      return error instanceof DuplicateOrderError;
+    },
+  );
+  return thrown;
+}
+
+// DuplicateOrderError는 예약 항목 전체를 들고 있었고 그 안에 CANO(계좌번호)가
+// 평문으로 있었다. message는 깨끗한데도 에러 "객체"를 로깅하는 순간 계좌번호가
+// 찍혔다. 지금 이 결함이 도달 불가인 것은 우연이다 - 아무도 에러 객체를
+// 로깅하지 않기로 정해서가 아니라 아직 그렇게 한 사람이 없어서다. 게다가 같은
+// 파일의 LedgerUnreadableError는 정반대로 "로깅해도 안전"하게 만들어져 있어,
+// 다음에 에러 로깅을 추가하는 사람이 둘을 같은 것으로 취급하기 쉽다. 그래서
+// LedgerUnreadableError와 같은 수준으로 누출 표면을 테스트로 고정한다.
+//
+// 잡는 뮤테이션: 생성자가 다시 예약 항목을 통째로 싣게 되면(`this.entry =
+// entry`) 실패해야 한다. Object.defineProperty로 non-enumerable하게 숨기기만
+// 하는 절충안도 showHidden 검사에서 걸린다 - 숨긴 값은 여전히 살아 있어
+// 커스텀 직렬화나 getOwnPropertyNames로 언제든 다시 꺼낼 수 있기 때문이다.
+test("DuplicateOrderError never exposes ledger contents (CANO) on any logging surface", (t) => {
+  const thrown = reserveThenTriggerDuplicate(t);
+
+  // console.error(err)는 인자를 util.inspect로 포매팅해 stderr에 쓴다. console.error
+  // 자체를 몽키패치하면 캡처되는 것은 에러 "객체"라 String(arg)가 항상
+  // "DuplicateOrderError: <message>"로만 나와, 항목을 통째로 든 구현에서도
+  // 통과하는 공허한 검사가 된다. 실제로 출력되는 바이트를 봐야 하므로
+  // process.stderr.write를 가로채고 진짜 console.error를 호출한다.
+  const stderrChunks = [];
+  const stderrWrite = t.mock.method(process.stderr, "write", (chunk) => {
+    stderrChunks.push(String(chunk));
+    return true;
+  });
+  console.error(thrown);
+  stderrWrite.mock.restore();
+
+  assert.ok(
+    stderrChunks.join("").includes("DuplicateOrderError"),
+    "stderr 캡처 자체가 동작하지 않았습니다 - 이 검사의 전제가 깨졌습니다",
+  );
+
+  for (const [surface, rendered] of [
+    [".message", thrown.message],
+    [".stack", thrown.stack],
+    ["String(err)", String(thrown)],
+    ["JSON.stringify(err)", JSON.stringify(thrown)],
+    ["util.inspect(err, {depth: null})", util.inspect(thrown, { depth: null })],
+    [
+      "util.inspect(err, {depth: null, showHidden: true})",
+      util.inspect(thrown, { depth: null, showHidden: true }),
+    ],
+    ["console.error(err)", stderrChunks.join("")],
+    ["Object.getOwnPropertyNames(err)", Object.getOwnPropertyNames(thrown).join(",")],
+  ]) {
+    assert.ok(
+      !String(rendered).includes(LEAKED_CANO),
+      `${surface}에 계좌번호가 노출되면 안 됩니다: ${rendered}`,
+    );
+  }
+});
+
+// 항목을 버리되 진단 가치까지 통째로 버리지는 않는다는 계약, 그리고 축소 자체를
+// 고정한다. 잡는 뮤테이션: this.expiresAt을 빼거나 reserve()가 만료 시각 대신
+// 항목을 넘기도록 되돌리면(그러면 expiresAt이 객체가 되고 entry가 되살아난다)
+// 실패해야 한다. 위 누출 테스트는 CANO 문자열만 보므로, 만료 시각이 조용히
+// 사라지는 변경은 이 테스트만 잡는다.
+test("DuplicateOrderError carries only the expiry timestamp, not the ledger entry", (t) => {
+  const thrown = reserveThenTriggerDuplicate(t);
+
+  assert.equal(thrown.expiresAt, 61_000, "now(1_000) + ttlMs(60_000)이어야 합니다");
+  assert.equal(thrown.entry, undefined, "예약 항목을 들고 있으면 안 됩니다");
+  assert.deepEqual(
+    Object.getOwnPropertyNames(thrown).filter((name) => !["message", "stack"].includes(name)),
+    ["name", "expiresAt"],
+    "이름과 만료 시각 외의 필드를 들고 있으면 안 됩니다",
   );
 });
 

--- a/mcp-trading/tests/order-dedup.test.js
+++ b/mcp-trading/tests/order-dedup.test.js
@@ -46,6 +46,25 @@ after(() => {
   }
 });
 
+// 두 에러 클래스에 공통으로 적용하는 누출 표면 헬퍼. stderrCapture는 호출자가
+// 직접 캡처한 stderr/console.error 출력 문자열이다 - DuplicateOrderError 쪽은
+// process.stderr.write를 가로채 실제 바이트를 보고, LedgerUnreadableError 쪽은
+// console.error 목(mock) 호출 인자를 문자열로 이어붙여 넘긴다.
+function assertNoLeakOnAnyLoggingSurface(err, secret, stderrCapture = "") {
+  for (const [surface, rendered] of [
+    [".message", err.message],
+    [".stack", err.stack],
+    ["String(err)", String(err)],
+    ["JSON.stringify(err)", JSON.stringify(err)],
+    ["util.inspect(err, {depth: null})", util.inspect(err, { depth: null })],
+    ["util.inspect(err, {depth: null, showHidden: true})", util.inspect(err, { depth: null, showHidden: true })],
+    ["console.error(err)", stderrCapture],
+    ["Object.getOwnPropertyNames(err)", Object.getOwnPropertyNames(err).join(",")],
+  ]) {
+    assert.ok(!String(rendered).includes(secret), `${surface}에 계좌번호가 노출되면 안 됩니다: ${rendered}`);
+  }
+}
+
 test("createOrderDedupKey normalizes equivalent order arguments", () => {
   const first = createOrderDedupKey({
     accountNo: "1234567801",
@@ -229,24 +248,14 @@ test("DuplicateOrderError never exposes ledger contents (CANO) on any logging su
     "stderr 캡처 자체가 동작하지 않았습니다 - 이 검사의 전제가 깨졌습니다",
   );
 
-  for (const [surface, rendered] of [
-    [".message", thrown.message],
-    [".stack", thrown.stack],
-    ["String(err)", String(thrown)],
-    ["JSON.stringify(err)", JSON.stringify(thrown)],
-    ["util.inspect(err, {depth: null})", util.inspect(thrown, { depth: null })],
-    [
-      "util.inspect(err, {depth: null, showHidden: true})",
-      util.inspect(thrown, { depth: null, showHidden: true }),
-    ],
-    ["console.error(err)", stderrChunks.join("")],
-    ["Object.getOwnPropertyNames(err)", Object.getOwnPropertyNames(thrown).join(",")],
-  ]) {
-    assert.ok(
-      !String(rendered).includes(LEAKED_CANO),
-      `${surface}에 계좌번호가 노출되면 안 됩니다: ${rendered}`,
-    );
-  }
+  assertNoLeakOnAnyLoggingSurface(thrown, LEAKED_CANO, stderrChunks.join(""));
+
+  // 생성자에 원장 항목을 직접 넘겨도 내용이 실리지 않는다 - Number() 강제가
+  // 호출부 관례가 아니라 클래스 자체에 있음을 고정한다.
+  assert.ok(
+    !JSON.stringify(new DuplicateOrderError({ request: { body: { CANO: LEAKED_CANO } } })).includes(LEAKED_CANO),
+    "생성자에 원장 항목을 넘겨도 내용이 실리면 안 됩니다",
+  );
 });
 
 // 항목을 버리되 진단 가치까지 통째로 버리지는 않는다는 계약, 그리고 축소 자체를
@@ -494,19 +503,18 @@ for (const [label, buildPayload] of [
 ]) {
   test(`OrderDedupStore.reserve never leaks ledger contents (CANO) into the thrown error or logs (${label})`, (t) => {
     const filePath = tempLedgerPath(t);
-    const leakedCano = "1234567890";
-    const payload = buildPayload(leakedCano);
+    const payload = buildPayload(LEAKED_CANO);
     fs.writeFileSync(filePath, payload);
 
-    // 이 페이로드가 실제로 V8의 SyntaxError 메시지에 leakedCano를 에코하는지
+    // 이 페이로드가 실제로 V8의 SyntaxError 메시지에 LEAKED_CANO를 에코하는지
     // 먼저 확인한다 - 이 전제가 깨지면(예: 엔진이 바뀌어 더 이상 에코하지
-    // 않으면) 아래 assert.ok(!...)가 항상 참이 되어 테스트가 다시 공허해질
-    // 수 있으므로, 전제 자체를 함께 고정한다.
+    // 않으면) 아래 assertNoLeakOnAnyLoggingSurface의 검사가 항상 참이 되어
+    // 테스트가 다시 공허해질 수 있으므로, 전제 자체를 함께 고정한다.
     let parseEchoesPayload = false;
     try {
       JSON.parse(payload);
     } catch (error) {
-      parseEchoesPayload = error.message.includes(leakedCano);
+      parseEchoesPayload = error.message.includes(LEAKED_CANO);
     }
     assert.ok(
       parseEchoesPayload,
@@ -516,25 +524,17 @@ for (const [label, buildPayload] of [
     const store = new OrderDedupStore({ filePath, ttlMs: 60_000, now: () => 1_000 });
     const consoleError = t.mock.method(console, "error", () => {});
 
+    let thrownError;
     assert.throws(
       () => store.reserve("k", { stockCode: "005930" }),
       (error) => {
-        assert.ok(
-          !error.message.includes(leakedCano),
-          `던지는 메시지에 원장 내용(CANO)이 섞이면 안 됩니다: ${error.message}`,
-        );
+        thrownError = error;
         return true;
       },
     );
 
-    for (const call of consoleError.mock.calls) {
-      for (const arg of call.arguments) {
-        assert.ok(
-          !String(arg).includes(leakedCano),
-          `console.error 로그에 원장 내용(CANO)이 섞이면 안 됩니다: ${arg}`,
-        );
-      }
-    }
+    const stderrCapture = consoleError.mock.calls.flatMap((c) => c.arguments).map(String).join("");
+    assertNoLeakOnAnyLoggingSurface(thrownError, LEAKED_CANO, stderrCapture);
   });
 }
 


### PR DESCRIPTION
Closes #167

## 문제

`mcp-trading/order-dedup.js`의 `DuplicateOrderError`가 `this.entry`에 예약 항목 전체를 들고 있고, 그 안에 `request.body.CANO`(계좌번호)가 평문으로 있습니다. `message`는 깨끗하지만 에러 **객체**를 로깅하는 순간 계좌번호가 찍힙니다 — `console.error(err)` / `JSON.stringify(err)` / `util.inspect(err, {depth: null})`.

현재 도달 불가인 것은 우연입니다. `callTradingTool`의 catch(index.js:602-608)이 `error.message`만 포맷하고 있어 아직 아무도 에러 객체를 로깅하지 않았을 뿐, 그렇게 하지 않기로 정해진 게 아닙니다.

같은 파일의 `LedgerUnreadableError`(PR #166)는 정반대입니다 — 9개 표면에서 누출이 없도록 **의도적으로 내용을 비웠고**, 원본 `error.message`조차 싣지 않습니다. 한 파일에 성질이 반대인 에러 둘이 나란히 있으면, 다음에 에러 로깅을 추가하는 사람이 둘을 같게 취급할 가능성이 높습니다.

## 변경 — 항목 대신 만료 시각만

생성자가 **항목이 아니라 만료 시각을 받도록** 시그니처 자체를 바꿨습니다. 그래야 원장 내용이 이 클래스로 흘러들어올 경로가 구조적으로 남지 않습니다.

```js
export class DuplicateOrderError extends Error {
  constructor(expiresAt) {
    super("중복 주문 방지를 위해 ...");
    this.name = "DuplicateOrderError";
    this.expiresAt = expiresAt;
  }
}
```

**`entry`를 non-enumerable로 숨기는 대안은 받지 않았습니다.** 저장소를 훑어본 결과 이 에러를 잡는 쪽은 항목의 어느 필드도 읽지 않습니다 — 유일한 `.entry` 참조가 대입문 자체였습니다. 숨겨야 할 만큼의 진단 가치가 애초에 없고, 숨기기만 하면 값은 계속 살아 있어 `showHidden` 출력·`getOwnPropertyNames`·커스텀 직렬화로 언제든 다시 샙니다. `LedgerUnreadableError`가 같은 파일에서 이미 "내용을 아예 싣지 않는다"는 자세를 세워둔 터라 둘을 어긋나게 둘 이유가 없습니다.

남긴 `expiresAt`은 계좌번호와 무관한 타임스탬프이면서, 메시지의 "잠시 후"가 실제로 언제인지를 뒷받침합니다.

**dedup 키는 일부러 싣지 않았습니다.** sha256이어도 CANO는 10자리 숫자라 나머지 주문 필드를 아는 쪽에는 전수 탐색이 현실적이고, 이 역시 잡는 쪽에서 아무도 쓰지 않습니다.

## 테스트

`LedgerUnreadableError`가 검증하는 누출 표면 목록을 그대로 따라 `DuplicateOrderError`도 같은 수준으로 고정했습니다 — `JSON.stringify` / `util.inspect(depth:null)` / `console.error(err)` 캡처 / `Object.keys` 등에서 CANO가 나오지 않아야 합니다.

**뮤테이션 검증**: 생성자가 다시 예약 항목을 싣게 하면(`this.entry = ...`) 테스트가 red가 됩니다.

```
node --test tests/order-dedup.test.js
  베이스라인  41 pass
  뮤턴트      40 pass / 1 fail
```

## 범위

`mcp-trading/order-dedup.js`(생성자 + 호출부 1줄), `mcp-trading/tests/order-dedup.test.js` 2개 파일.

