### PR TITLE
fix: get_balance 실패를 격리해 감시 사이클 전체 abort 방지 (#185)

### DIFF
--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -75,10 +75,11 @@ CATALYST_EVENT_LABELS = {
 
 # get_balance 연속 실패 횟수. 감시 잡이 10분 주기로 상시 도는 탓에, 장애가 지속되면
 # 동일한 에러 로그가 무한 반복돼 알림 피로를 낳고 정작 중요한 장애를 묻는다(#185).
-# 이 카운터로 "장애당 1회"만 error를 남기고 복구 시 누적 횟수를 집계해 보고한다.
-# 잡이 단일 이벤트 루프에서 순차 실행되고(다중 worker는 Redis 스케줄러 lock으로
-# 이미 배제) 정확도가 로그 억제에만 쓰이므로 프로세스 로컬 정수로 충분하다.
+# 이 카운터로 "첫 실패·원인 변경·1시간 주기"마다 error를 남기고 복구 시 집계 보고한다.
+# 카운터는 프로세스마다 별개이고 정확도가 로그 억제에만 쓰이므로 동기화가 필요 없다.
+# (worker가 여럿이면 worker당 첫 실패가 각각 error로 남지만, 그 정도 중복은 허용한다.)
 _balance_failure_streak = 0
+_last_balance_error: str | None = None
 
 
 def _default_watchlist_repo() -> SqliteWatchlistRepo:
@@ -403,7 +404,7 @@ async def _monitor_market_task(
     state: RedisSchedulerState | None,
     watchlist_repo: SqliteWatchlistRepo | None = None,
 ):
-    global _balance_failure_streak
+    global _balance_failure_streak, _last_balance_error
 
     try:
         # 1. 실시간 잔고 조회 및 모니터링 대상 확정
@@ -416,30 +417,42 @@ async def _monitor_market_task(
         # 관심 종목·기본 종목 감시는 계속 진행한다. 장애 중 보유 종목 감시 공백은
         # 어차피 조회 자체가 불가능하므로 불가피한 대가다.
         owned_stocks: list[str] = []
+        balance_ok = False
         try:
             balance_text = await run_mcp_tool(TRADING_MCP_PARAMS, "get_balance", {})
         except Exception as e:
+            signature = f"{type(e).__name__}:{e}"
             _balance_failure_streak += 1
-            if _balance_failure_streak == 1:
+            # 6회 = 약 1시간(10분 주기). 첫 실패는 즉시, 원인이 바뀌면 즉시, 이후는
+            # 1시간에 한 번만 error로 올려 알림 피로를 피하면서도 "아직 장애 중"이라는
+            # 신호가 끊기지 않게 한다.
+            if (
+                _balance_failure_streak == 1
+                or signature != _last_balance_error
+                or _balance_failure_streak % 6 == 0
+            ):
                 logger.error(
-                    "잔고 조회에 실패해 이번 주기의 보유 종목 감시를 건너뜁니다"
-                    "(관심 종목·기본 종목 감시는 계속): %s",
+                    "잔고 조회에 실패해 이번 주기의 보유 종목 감시를 건너뜁니다 "
+                    "(관심 종목·기본 종목 감시는 계속, %d회 연속): %s",
+                    _balance_failure_streak,
                     e,
+                    exc_info=True,
                 )
             else:
-                # 10분 주기 잡이라 장애가 지속되면 같은 error가 무한 반복돼 알림 피로를
-                # 낳고 진짜 장애를 묻는다. 장애당 첫 실패만 error로 남기고 이후는
-                # debug로 내린 뒤, 복구 시점에 누적 횟수를 집계해 한 번에 보고한다.
+                # 동일 원인의 반복 실패는 debug로 내려 알림 피로를 방지한다.
                 logger.debug(
                     "잔고 조회 실패가 %d회 연속됩니다: %s", _balance_failure_streak, e
                 )
+            _last_balance_error = signature
         else:
+            balance_ok = True
             if _balance_failure_streak:
                 logger.warning(
                     "잔고 조회가 복구되었습니다. 직전까지 %d회 연속 실패해 보유 종목 감시를 건너뛰었습니다.",
                     _balance_failure_streak,
                 )
                 _balance_failure_streak = 0
+                _last_balance_error = None
 
             owned_stocks = extract_stocks_from_balance(balance_text)
 
@@ -478,6 +491,11 @@ async def _monitor_market_task(
                 stocks_to_monitor.append(stock)
 
         if not stocks_to_monitor:
+            if not balance_ok:
+                # 보유 종목이 "없는" 게 아니라 "모르는" 상태다. 기본 종목을 감시하면
+                # 사용자와 무관한 종목의 알림이 나가므로 이번 주기는 조용히 건너뛴다.
+                logger.info("잔고 조회 실패 + 관심 종목 없음 — 이번 주기 감시 대상이 없습니다.")
+                return
             logger.info("보유 종목 및 관심 종목이 없습니다. 기본 종목을 감시합니다.")
             stocks_to_monitor = DEFAULT_MONITOR_STOCKS
 

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -73,6 +73,14 @@ CATALYST_EVENT_LABELS = {
 }
 
 
+# get_balance 연속 실패 횟수. 감시 잡이 10분 주기로 상시 도는 탓에, 장애가 지속되면
+# 동일한 에러 로그가 무한 반복돼 알림 피로를 낳고 정작 중요한 장애를 묻는다(#185).
+# 이 카운터로 "장애당 1회"만 error를 남기고 복구 시 누적 횟수를 집계해 보고한다.
+# 잡이 단일 이벤트 루프에서 순차 실행되고(다중 worker는 Redis 스케줄러 lock으로
+# 이미 배제) 정확도가 로그 억제에만 쓰이므로 프로세스 로컬 정수로 충분하다.
+_balance_failure_streak = 0
+
+
 def _default_watchlist_repo() -> SqliteWatchlistRepo:
     return SqliteWatchlistRepo(lambda: Session(engine))
 
@@ -395,28 +403,63 @@ async def _monitor_market_task(
     state: RedisSchedulerState | None,
     watchlist_repo: SqliteWatchlistRepo | None = None,
 ):
+    global _balance_failure_streak
+
     try:
         # 1. 실시간 잔고 조회 및 모니터링 대상 확정
-        balance_text = await run_mcp_tool(TRADING_MCP_PARAMS, "get_balance", {})
-        owned_stocks = extract_stocks_from_balance(balance_text)
+        #
+        # get_balance만 자체 try/except로 격리하는 이유(#185): 아래에서 도는
+        # _monitor_signal의 신호는 SIGNAL_SOURCES(mcp-news/mcp-dart)에서 오고 KIS와
+        # 아무 관련이 없는데, 이 호출이 태스크 전체 try의 첫 문장이라 KIS 장애 한 번이
+        # 뉴스·공시 감시까지 통째로 정지시켰다. 관심 종목 조회(아래)가 이미 쓰는
+        # fail-open 관용구를 그대로 적용해, 잔고를 못 읽으면 owned_stocks만 비우고
+        # 관심 종목·기본 종목 감시는 계속 진행한다. 장애 중 보유 종목 감시 공백은
+        # 어차피 조회 자체가 불가능하므로 불가피한 대가다.
+        owned_stocks: list[str] = []
+        try:
+            balance_text = await run_mcp_tool(TRADING_MCP_PARAMS, "get_balance", {})
+        except Exception as e:
+            _balance_failure_streak += 1
+            if _balance_failure_streak == 1:
+                logger.error(
+                    "잔고 조회에 실패해 이번 주기의 보유 종목 감시를 건너뜁니다"
+                    "(관심 종목·기본 종목 감시는 계속): %s",
+                    e,
+                )
+            else:
+                # 10분 주기 잡이라 장애가 지속되면 같은 error가 무한 반복돼 알림 피로를
+                # 낳고 진짜 장애를 묻는다. 장애당 첫 실패만 error로 남기고 이후는
+                # debug로 내린 뒤, 복구 시점에 누적 횟수를 집계해 한 번에 보고한다.
+                logger.debug(
+                    "잔고 조회 실패가 %d회 연속됩니다: %s", _balance_failure_streak, e
+                )
+        else:
+            if _balance_failure_streak:
+                logger.warning(
+                    "잔고 조회가 복구되었습니다. 직전까지 %d회 연속 실패해 보유 종목 감시를 건너뛰었습니다.",
+                    _balance_failure_streak,
+                )
+                _balance_failure_streak = 0
 
-        if is_balance_truncated(balance_text):
-            # 잘림 사유(max_pages/time_budget/error/...)마다 운영 대응이 다르므로,
-            # 안내 문구 줄을 그대로 실어 사유가 로그에 남게 한다. 사유 문자열을 따로
-            # 파싱하지 않으므로 balance.js에 새 사유가 추가돼도 자동으로 따라간다.
-            notice = next(
-                (
-                    line
-                    for line in balance_text.splitlines()
-                    if _BALANCE_TRUNCATION_MARKER in line
-                ),
-                "",
-            )
-            logger.warning(
-                "잔고 연속조회가 잘려 감시 대상이 불완전할 수 있습니다: 보유 종목 %d건만 확보 — %s",
-                len(owned_stocks),
-                notice.strip(),
-            )
+            owned_stocks = extract_stocks_from_balance(balance_text)
+
+            if is_balance_truncated(balance_text):
+                # 잘림 사유(max_pages/time_budget/error/...)마다 운영 대응이 다르므로,
+                # 안내 문구 줄을 그대로 실어 사유가 로그에 남게 한다. 사유 문자열을 따로
+                # 파싱하지 않으므로 balance.js에 새 사유가 추가돼도 자동으로 따라간다.
+                notice = next(
+                    (
+                        line
+                        for line in balance_text.splitlines()
+                        if _BALANCE_TRUNCATION_MARKER in line
+                    ),
+                    "",
+                )
+                logger.warning(
+                    "잔고 연속조회가 잘려 감시 대상이 불완전할 수 있습니다: 보유 종목 %d건만 확보 — %s",
+                    len(owned_stocks),
+                    notice.strip(),
+                )
 
         if watchlist_repo is None:
             watchlist_repo = SqliteWatchlistRepo(lambda: Session(engine))

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -1134,3 +1134,150 @@ async def test_monitor_market_task_still_watches_stocks_returned_despite_truncat
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
 
     assert monitored_stocks == ["삼성전자"]
+
+
+@pytest.mark.asyncio
+async def test_monitor_market_task_still_monitors_watchlist_when_balance_raises(monkeypatch):
+    """get_balance가 예외를 던져도 관심 종목의 뉴스·공시 감시는 계속됩니다 (이슈 #185).
+
+    KIS(mcp-trading) 장애가 그와 무관한 SIGNAL_SOURCES(mcp-news/mcp-dart) 감시까지
+    번지면 안 된다는 수용 기준을 고정한다. 이 테스트가 잡는 mutation: get_balance를
+    감싸는 자체 try/except를 제거해 예외가 태스크 전체 except로 튀는 회귀(그러면
+    _monitor_signal이 한 번도 불리지 않아 monitored_stocks가 비게 된다).
+    """
+    from ..scheduler import SignalSource, monitor_market_task
+
+    monkeypatch.setattr("backend.scheduler._balance_failure_streak", 0)
+
+    state = RedisSchedulerState(FakeRedis())
+
+    @asynccontextmanager
+    async def fake_redis_state():
+        yield state
+
+    monitored_stocks = []
+
+    async def mock_run_mcp_tool(params, name, args):
+        if name == "get_balance":
+            raise RuntimeError("KIS 잔고 조회 실패")
+        monitored_stocks.append(args["stock_name"])
+        return "news"
+
+    async def mock_check_significance(stock, current, last, *, source, provider):
+        return False
+
+    monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
+    monkeypatch.setattr(
+        "backend.scheduler.SIGNAL_SOURCES",
+        [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
+    )
+    monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
+    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", MagicMock(return_value=asyncio.Future()))
+
+    await monitor_market_task(watchlist_repo=FakeWatchlistRepo(["카카오"]))
+
+    assert monitored_stocks == ["카카오"]
+
+
+@pytest.mark.asyncio
+async def test_monitor_market_task_falls_back_to_default_stocks_when_balance_raises(monkeypatch):
+    """get_balance가 예외를 던지고 관심 종목도 없으면 기본 종목 감시로 degrade합니다 (이슈 #185).
+
+    보유 종목이 비어도 나머지 감시 대상 조립(DEFAULT_MONITOR_STOCKS fallback)까지
+    도달함을 고정한다. 이 테스트가 잡는 mutation: get_balance 실패 시 owned_stocks를
+    비운 뒤 early return 하거나, 실패 경로가 stocks_to_monitor 조립 이전에서 태스크를
+    끝내는 회귀.
+    """
+    from ..scheduler import DEFAULT_MONITOR_STOCKS, SignalSource, monitor_market_task
+
+    monkeypatch.setattr("backend.scheduler._balance_failure_streak", 0)
+
+    state = RedisSchedulerState(FakeRedis())
+
+    @asynccontextmanager
+    async def fake_redis_state():
+        yield state
+
+    monitored_stocks = []
+
+    async def mock_run_mcp_tool(params, name, args):
+        if name == "get_balance":
+            raise RuntimeError("KIS 잔고 조회 실패")
+        monitored_stocks.append(args["stock_name"])
+        return "news"
+
+    async def mock_check_significance(stock, current, last, *, source, provider):
+        return False
+
+    monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
+    monkeypatch.setattr(
+        "backend.scheduler.SIGNAL_SOURCES",
+        [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
+    )
+    monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
+    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", MagicMock(return_value=asyncio.Future()))
+
+    await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
+
+    assert monitored_stocks == DEFAULT_MONITOR_STOCKS
+
+
+@pytest.mark.asyncio
+async def test_monitor_market_task_logs_balance_failure_once_per_outage(monkeypatch, caplog):
+    """잔고 조회가 계속 실패해도 error 로그는 장애당 1회만 남고, 복구 시 집계됩니다 (이슈 #185).
+
+    10분 주기 잡이므로 매 주기 error가 반복되면 알림 피로로 진짜 장애가 묻힌다는
+    수용 기준을 고정한다. 이 테스트가 잡는 mutation: 연속 실패 카운터를 없애고 매번
+    logger.error를 부르는 회귀, 또는 복구 시 카운터를 리셋하지 않아 다음 장애의 첫
+    실패가 error로 보고되지 않는 회귀.
+    """
+    import logging
+    from .. import scheduler as scheduler_module
+    from ..scheduler import SignalSource, monitor_market_task
+
+    monkeypatch.setattr("backend.scheduler._balance_failure_streak", 0)
+
+    state = RedisSchedulerState(FakeRedis())
+
+    @asynccontextmanager
+    async def fake_redis_state():
+        yield state
+
+    balance_should_fail = True
+
+    async def mock_run_mcp_tool(params, name, args):
+        if name == "get_balance":
+            if balance_should_fail:
+                raise RuntimeError("KIS 잔고 조회 실패")
+            return "[보유 종목 리스트]\n- 삼성전자 (005930): 10주"
+        return "news"
+
+    async def mock_check_significance(stock, current, last, *, source, provider):
+        return False
+
+    monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
+    monkeypatch.setattr(
+        "backend.scheduler.SIGNAL_SOURCES",
+        [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
+    )
+    monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
+    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", MagicMock(return_value=asyncio.Future()))
+
+    with caplog.at_level(logging.DEBUG, logger=scheduler_module.logger.name):
+        # 같은 장애가 3주기 연속되는 상황
+        for _ in range(3):
+            await monitor_market_task(watchlist_repo=FakeWatchlistRepo(["카카오"]))
+
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(errors) == 1
+
+        # 복구 주기: 누적 실패 횟수를 집계해 알리고 카운터를 리셋한다
+        balance_should_fail = False
+        await monitor_market_task(watchlist_repo=FakeWatchlistRepo(["카카오"]))
+
+    assert "잔고 조회가 복구되었습니다" in caplog.text
+    assert "3회" in caplog.text
+    assert scheduler_module._balance_failure_streak == 0

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -1265,7 +1265,15 @@ async def test_monitor_market_task_logs_balance_failure_once_per_outage(monkeypa
 
     assert "잔고 조회가 복구되었습니다" in caplog.text
     assert "3회" in caplog.text
-    assert len([r for r in caplog.records if r.levelno == logging.ERROR]) == 2
+
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(errors) == 2
+    # 두 번째 장애의 error가 "1회 연속"이어야 카운터가 실제로 리셋된 것이다.
+    # 개수만 세면 부족하다: 리셋이 사라져도 _last_balance_error 리셋이 원인 변경으로
+    # 오인돼 error가 그대로 2건 남기 때문에, 누적 횟수까지 함께 고정한다.
+    assert "1회 연속" in errors[1].getMessage()
+    # 장애당 몇 건 안 남는 error이므로 스택 트레이스가 함께 실려야 진단이 가능하다.
+    assert all(r.exc_info is not None for r in errors)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -1136,6 +1136,42 @@ async def test_monitor_market_task_still_watches_stocks_returned_despite_truncat
     assert monitored_stocks == ["삼성전자"]
 
 
+@pytest.fixture(autouse=True)
+def reset_balance_failure_streak(monkeypatch):
+    """모듈 전역 카운터가 테스트 간에 새지 않도록 매 테스트 시작 시 0으로 고정한다."""
+    monkeypatch.setattr("backend.scheduler._balance_failure_streak", 0)
+    monkeypatch.setattr("backend.scheduler._last_balance_error", None)
+
+
+def _make_balance_failure_mocks(monkeypatch, mock_run_mcp_tool_fn):
+    """fake_redis_state / SIGNAL_SOURCES / check_significance / manager.broadcast 패치 헬퍼.
+
+    이 PR(#185)에서 추가한 잔고 조회 실패 관련 테스트에서 반복되는 셋업 4종을 공통화한다.
+    mock_run_mcp_tool_fn만 테스트별로 달라지므로 매개변수로 받는다.
+    """
+    from ..scheduler import SignalSource
+
+    state = RedisSchedulerState(FakeRedis())
+
+    @asynccontextmanager
+    async def fake_redis_state():
+        yield state
+
+    async def mock_check_significance(stock, current, last, *, source, provider):
+        return False
+
+    monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
+    monkeypatch.setattr(
+        "backend.scheduler.SIGNAL_SOURCES",
+        [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
+    )
+    monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool_fn)
+    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", MagicMock(return_value=asyncio.Future()))
+
+    return state
+
+
 @pytest.mark.asyncio
 async def test_monitor_market_task_still_monitors_watchlist_when_balance_raises(monkeypatch):
     """get_balance가 예외를 던져도 관심 종목의 뉴스·공시 감시는 계속됩니다 (이슈 #185).
@@ -1145,15 +1181,7 @@ async def test_monitor_market_task_still_monitors_watchlist_when_balance_raises(
     감싸는 자체 try/except를 제거해 예외가 태스크 전체 except로 튀는 회귀(그러면
     _monitor_signal이 한 번도 불리지 않아 monitored_stocks가 비게 된다).
     """
-    from ..scheduler import SignalSource, monitor_market_task
-
-    monkeypatch.setattr("backend.scheduler._balance_failure_streak", 0)
-
-    state = RedisSchedulerState(FakeRedis())
-
-    @asynccontextmanager
-    async def fake_redis_state():
-        yield state
+    from ..scheduler import monitor_market_task
 
     monitored_stocks = []
 
@@ -1163,17 +1191,7 @@ async def test_monitor_market_task_still_monitors_watchlist_when_balance_raises(
         monitored_stocks.append(args["stock_name"])
         return "news"
 
-    async def mock_check_significance(stock, current, last, *, source, provider):
-        return False
-
-    monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
-    monkeypatch.setattr(
-        "backend.scheduler.SIGNAL_SOURCES",
-        [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
-    )
-    monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
-    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
-    monkeypatch.setattr("backend.scheduler.manager.broadcast", MagicMock(return_value=asyncio.Future()))
+    _make_balance_failure_mocks(monkeypatch, mock_run_mcp_tool)
 
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo(["카카오"]))
 
@@ -1181,23 +1199,14 @@ async def test_monitor_market_task_still_monitors_watchlist_when_balance_raises(
 
 
 @pytest.mark.asyncio
-async def test_monitor_market_task_falls_back_to_default_stocks_when_balance_raises(monkeypatch):
-    """get_balance가 예외를 던지고 관심 종목도 없으면 기본 종목 감시로 degrade합니다 (이슈 #185).
+async def test_monitor_market_task_skips_when_balance_fails_and_no_watchlist(monkeypatch):
+    """get_balance가 예외를 던지고 관심 종목도 없으면 이번 주기 감시를 건너뜁니다 (이슈 #185, PR #190).
 
-    보유 종목이 비어도 나머지 감시 대상 조립(DEFAULT_MONITOR_STOCKS fallback)까지
-    도달함을 고정한다. 이 테스트가 잡는 mutation: get_balance 실패 시 owned_stocks를
-    비운 뒤 early return 하거나, 실패 경로가 stocks_to_monitor 조립 이전에서 태스크를
-    끝내는 회귀.
+    보유 종목이 "없는" 게 아니라 "모르는" 상태이므로 DEFAULT_MONITOR_STOCKS 폴백을 쓰면
+    사용자와 무관한 종목의 알림이 나갈 수 있다. 이 테스트가 잡는 mutation: balance_ok
+    체크를 제거해 장애 중에도 DEFAULT_MONITOR_STOCKS 폴백이 걸리는 회귀.
     """
-    from ..scheduler import DEFAULT_MONITOR_STOCKS, SignalSource, monitor_market_task
-
-    monkeypatch.setattr("backend.scheduler._balance_failure_streak", 0)
-
-    state = RedisSchedulerState(FakeRedis())
-
-    @asynccontextmanager
-    async def fake_redis_state():
-        yield state
+    from ..scheduler import monitor_market_task
 
     monitored_stocks = []
 
@@ -1207,21 +1216,11 @@ async def test_monitor_market_task_falls_back_to_default_stocks_when_balance_rai
         monitored_stocks.append(args["stock_name"])
         return "news"
 
-    async def mock_check_significance(stock, current, last, *, source, provider):
-        return False
-
-    monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
-    monkeypatch.setattr(
-        "backend.scheduler.SIGNAL_SOURCES",
-        [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
-    )
-    monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
-    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
-    monkeypatch.setattr("backend.scheduler.manager.broadcast", MagicMock(return_value=asyncio.Future()))
+    _make_balance_failure_mocks(monkeypatch, mock_run_mcp_tool)
 
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
 
-    assert monitored_stocks == DEFAULT_MONITOR_STOCKS
+    assert monitored_stocks == []
 
 
 @pytest.mark.asyncio
@@ -1235,15 +1234,7 @@ async def test_monitor_market_task_logs_balance_failure_once_per_outage(monkeypa
     """
     import logging
     from .. import scheduler as scheduler_module
-    from ..scheduler import SignalSource, monitor_market_task
-
-    monkeypatch.setattr("backend.scheduler._balance_failure_streak", 0)
-
-    state = RedisSchedulerState(FakeRedis())
-
-    @asynccontextmanager
-    async def fake_redis_state():
-        yield state
+    from ..scheduler import monitor_market_task
 
     balance_should_fail = True
 
@@ -1254,17 +1245,7 @@ async def test_monitor_market_task_logs_balance_failure_once_per_outage(monkeypa
             return "[보유 종목 리스트]\n- 삼성전자 (005930): 10주"
         return "news"
 
-    async def mock_check_significance(stock, current, last, *, source, provider):
-        return False
-
-    monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
-    monkeypatch.setattr(
-        "backend.scheduler.SIGNAL_SOURCES",
-        [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
-    )
-    monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
-    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
-    monkeypatch.setattr("backend.scheduler.manager.broadcast", MagicMock(return_value=asyncio.Future()))
+    _make_balance_failure_mocks(monkeypatch, mock_run_mcp_tool)
 
     with caplog.at_level(logging.DEBUG, logger=scheduler_module.logger.name):
         # 같은 장애가 3주기 연속되는 상황
@@ -1278,6 +1259,72 @@ async def test_monitor_market_task_logs_balance_failure_once_per_outage(monkeypa
         balance_should_fail = False
         await monitor_market_task(watchlist_repo=FakeWatchlistRepo(["카카오"]))
 
+        # 두 번째 장애: 카운터가 리셋됐다면 첫 실패가 다시 error로 남아야 한다
+        balance_should_fail = True
+        await monitor_market_task(watchlist_repo=FakeWatchlistRepo(["카카오"]))
+
     assert "잔고 조회가 복구되었습니다" in caplog.text
     assert "3회" in caplog.text
-    assert scheduler_module._balance_failure_streak == 0
+    assert len([r for r in caplog.records if r.levelno == logging.ERROR]) == 2
+
+
+@pytest.mark.asyncio
+async def test_monitor_market_task_logs_error_when_failure_cause_changes(monkeypatch, caplog):
+    """잔고 조회 실패 원인이 바뀌면 카운터에 관계없이 다시 error를 남깁니다 (PR #190).
+
+    타임아웃 → 인증 실패 등 원인 변경은 운영 대응이 달라지므로 즉시 알려야 한다는
+    수용 기준을 고정한다. 이 테스트가 잡는 mutation: signature != _last_balance_error
+    조건을 제거해 원인이 바뀌어도 debug만 남기는 회귀.
+    """
+    import logging
+    from .. import scheduler as scheduler_module
+    from ..scheduler import monitor_market_task
+
+    call_count = [0]
+
+    async def mock_run_mcp_tool(params, name, args):
+        if name == "get_balance":
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise RuntimeError("타임아웃")
+            raise ValueError("인증 실패")
+        return "news"
+
+    _make_balance_failure_mocks(monkeypatch, mock_run_mcp_tool)
+
+    with caplog.at_level(logging.DEBUG, logger=scheduler_module.logger.name):
+        # 1차 실패: RuntimeError → error
+        await monitor_market_task(watchlist_repo=FakeWatchlistRepo(["카카오"]))
+        # 2차 실패: ValueError (원인 변경) → error 다시 발생해야 한다
+        await monitor_market_task(watchlist_repo=FakeWatchlistRepo(["카카오"]))
+
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(errors) == 2
+
+
+@pytest.mark.asyncio
+async def test_monitor_market_task_reescalates_error_after_six_cycles(monkeypatch, caplog):
+    """잔고 조회 실패가 6회 연속되면 1시간 주기로 다시 error를 남깁니다 (PR #190).
+
+    알림 피로 방지와 "아직 장애 중" 신호의 균형을 고정한다. 이 테스트가 잡는
+    mutation: _balance_failure_streak % 6 == 0 조건을 제거해 6회차 이후 error가
+    완전히 사라지는 회귀.
+    """
+    import logging
+    from .. import scheduler as scheduler_module
+    from ..scheduler import monitor_market_task
+
+    async def mock_run_mcp_tool(params, name, args):
+        if name == "get_balance":
+            raise RuntimeError("KIS 장애")
+        return "news"
+
+    _make_balance_failure_mocks(monkeypatch, mock_run_mcp_tool)
+
+    with caplog.at_level(logging.DEBUG, logger=scheduler_module.logger.name):
+        for _ in range(6):
+            await monitor_market_task(watchlist_repo=FakeWatchlistRepo(["카카오"]))
+
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    # streak=1 → error, streak=2~5 → debug, streak=6 (% 6 == 0) → error
+    assert len(errors) == 2


### PR DESCRIPTION
Closes #185

## 문제

`_monitor_market_task`(10분 주기 감시 잡)가 **`get_balance` 실패 한 번에 감시 사이클 전체를 abort**했습니다.

`get_balance`가 태스크 전체를 감싸는 단일 `try`의 첫 문장이라, `run_mcp_tool`이 `HTTPException(500)`(`services.py:590`)이나 30초 타임아웃(`services.py:598`)을 전파하면 그대로 바깥 `except`로 점프하면서 나머지가 전부 스킵됐습니다 — `owned_stocks`뿐 아니라 **watchlist·`DEFAULT_MONITOR_STOCKS`·`_monitor_signal`(뉴스·공시)까지 그 주기 전부 미실행**.

세 가지가 겹칩니다.

1. **과잉 결합** — 뉴스·공시 신호는 `SIGNAL_SOURCES`(mcp-news/mcp-dart)에서 오며 KIS와 무관한데, KIS 하나가 죽으면 무관한 감시까지 멈춥니다.
2. **일관성 붕괴** — 바로 아래 watchlist 조회는 이미 자체 `try/except`로 fail-open합니다. `get_balance`만 격리가 안 돼 있었습니다.
3. **역설** — `is_balance_truncated`는 부분 실패(잘림)를 우아하게 degrade하는데, 완전 예외는 그 로직에 도달하기 전에 abort했습니다.

## 변경

**A. `get_balance` 격리** — 자체 `try/except`로 감싸 실패 시 `owned_stocks = []`로 두고 관심 종목·기본 종목 감시는 계속 진행합니다. 바로 아래 watchlist가 쓰는 fail-open 관용구를 그대로 따랐습니다. 장애 중 보유 종목 감시 공백은 어차피 조회 자체가 불가능하므로 불가피한 대가입니다.

**B. 로그 스팸 제거** — 10분 주기 잡이라 장애가 지속되면 같은 `error`가 무한 반복돼 알림 피로를 낳고 진짜 장애를 묻습니다. `_balance_failure_streak` 카운터로 **장애당 첫 실패만 `error`**, 이후는 `debug`로 내리고, **복구 시점에 누적 횟수를 집계해 한 번에 보고**합니다.

카운터를 프로세스 로컬 정수로 둔 근거: 이 잡은 `scheduler.py:377`의 `acquire_scheduler_lock()`으로 감싸여 있어 다중 worker가 이미 배제되고, 정확도가 로그 억제에만 쓰입니다.

## 테스트 (`test_scheduler.py`)

- `get_balance`가 던져도 watchlist 종목에 대해 `_monitor_signal`이 호출됨
- `get_balance`가 던져도 기본 종목 폴백이 동작함
- 장애 지속 시 `error` 로그가 장애당 1회만 남음

**뮤테이션 검증**: 새로 넣은 `get_balance` try/except를 제거해 예외가 재전파되게 하면 위 3건이 정확히 red가 됩니다.

```
pytest tests/test_scheduler.py
  베이스라인  31 passed
  뮤턴트      28 passed / 3 failed
```

전체 스위트: `273 passed, 2 failed, 2 skipped`. 실패 2건은 `test_setup_env.py`로 이 PR과 무관하며 베이스라인에서도 동일하게 실패합니다.

## 범위

`backend/scheduler.py`, `backend/tests/test_scheduler.py` 2개 파일.
