### PR TITLE
refactor: EndpointOk를 EndpointStatuses로 개명해 types.ts로 이동 (#180)

### DIFF
--- a/frontend-react/src/App.tsx
+++ b/frontend-react/src/App.tsx
@@ -23,7 +23,7 @@ export default function App() {
     rawNews,
     rawTrend,
     resources,
-    endpointOk,
+    endpointStatuses,
     error,
     chatStatus,
     chatMessages,
@@ -57,7 +57,7 @@ export default function App() {
 
         <ErrorDisplay error={error} />
 
-        <BackendPanel resources={resources} endpointOk={endpointOk} loading={resourceLoading} onRefresh={loadResources} />
+        <BackendPanel resources={resources} endpointStatuses={endpointStatuses} loading={resourceLoading} onRefresh={loadResources} />
 
         {latest && <StockHeader stock={stock} latest={latest} />}
 

--- a/frontend-react/src/components/BackendPanel.test.tsx
+++ b/frontend-react/src/components/BackendPanel.test.tsx
@@ -1,8 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import BackendPanel from './BackendPanel';
-import type { DashboardResources } from '../types';
-import type { EndpointOk, EndpointStatus } from '../hooks/useFinUsDashboard';
+import type { DashboardResources, EndpointStatus, EndpointStatuses } from '../types';
 
 // 렌더링 매핑 가드: 훅이 판정한 EndpointStatus가 화면의 상태 점에 그대로 반영되는지 본다.
 // 판정 로직 자체의 #71 회귀 가드는 useFinUsDashboard.test.tsx가 담당한다.
@@ -19,7 +18,7 @@ const baseResources: DashboardResources = {
   diaries: [],
 };
 
-const allOk: EndpointOk = {
+const allOk: EndpointStatuses = {
   health: 'ok',
   balance: 'ok',
   portfolio: 'ok',
@@ -44,7 +43,7 @@ describe('BackendPanel', () => {
       render(
         <BackendPanel
           resources={baseResources}
-          endpointOk={{ ...allOk, portfolio: status }}
+          endpointStatuses={{ ...allOk, portfolio: status }}
           loading={false}
           onRefresh={vi.fn()}
         />,
@@ -61,7 +60,7 @@ describe('BackendPanel', () => {
     render(
       <BackendPanel
         resources={baseResources}
-        endpointOk={{ ...allOk, portfolio: 'fail', trades: 'unknown' }}
+        endpointStatuses={{ ...allOk, portfolio: 'fail', trades: 'unknown' }}
         loading={false}
         onRefresh={vi.fn()}
       />,

--- a/frontend-react/src/components/BackendPanel.test.tsx
+++ b/frontend-react/src/components/BackendPanel.test.tsx
@@ -49,7 +49,7 @@ describe('BackendPanel', () => {
         />,
       );
 
-      const dot = screen.getByLabelText(`Portfolio ${statusLabel}`);
+      const dot = screen.getByRole('img', { name: `Portfolio ${statusLabel}` });
       expect(dot).toHaveAttribute('data-status', status);
       expect(dot).toHaveClass(expected);
       forbidden.forEach((cls) => expect(dot).not.toHaveClass(cls));
@@ -66,8 +66,8 @@ describe('BackendPanel', () => {
       />,
     );
 
-    expect(screen.getByLabelText(/^Portfolio /)).toHaveAttribute('data-status', 'fail');
-    expect(screen.getByLabelText(/^Trades /)).toHaveAttribute('data-status', 'unknown');
-    expect(screen.getByLabelText(/^Health /)).toHaveAttribute('data-status', 'ok');
+    expect(screen.getByRole('img', { name: /^Portfolio / })).toHaveAttribute('data-status', 'fail');
+    expect(screen.getByRole('img', { name: /^Trades / })).toHaveAttribute('data-status', 'unknown');
+    expect(screen.getByRole('img', { name: /^Health / })).toHaveAttribute('data-status', 'ok');
   });
 });

--- a/frontend-react/src/components/BackendPanel.tsx
+++ b/frontend-react/src/components/BackendPanel.tsx
@@ -23,6 +23,10 @@ const STATUS_LABEL: Record<EndpointStatus, string> = {
   unknown: '확인 중',
 };
 
+// 상태 점에 role="img"를 쓰는 이유: role="status"는 암묵적 aria-live="polite"를 동반해
+// 엔드포인트 6개마다 라이브 리전이 생긴다. 이 점은 변경 공지가 아니라 현재 상태 지표이므로
+// role="img"가 의미에 맞다. 회귀 가드는 BackendPanel.test.tsx의 getByRole('img', ...) 참조.
+
 const BackendPanel: React.FC<BackendPanelProps> = ({ resources, endpointStatuses, loading, onRefresh }) => {
   const endpoints = [
     { label: 'Health', status: endpointStatuses.health, path: '/health' },
@@ -68,14 +72,6 @@ const BackendPanel: React.FC<BackendPanelProps> = ({ resources, endpointStatuses
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
           {endpoints.map((endpoint) => (
             <div key={endpoint.path} className="flex items-center gap-2 rounded-lg bg-slate-50 px-3 py-2">
-              {/*
-                role="status"는 암묵적으로 aria-live="polite"를 동반해, 엔드포인트마다
-                별도의 라이브 리전을 만든다. 엔드포인트가 6개면 라이브 리전도 6개가 되어
-                새로고침 한 번에 스크린리더가 상태를 6번 연달아 읽는다. 이 점은 "방금
-                바뀌었다고 알리는 공지"가 아니라 "지금 상태를 나타내는 지표"이므로
-                role="img"가 의미에 맞고, 접근 가능한 이름은 아래 aria-label이 그대로
-                제공한다.
-              */}
               <span
                 role="img"
                 aria-label={`${endpoint.label} ${STATUS_LABEL[endpoint.status]}`}

--- a/frontend-react/src/components/BackendPanel.tsx
+++ b/frontend-react/src/components/BackendPanel.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { Activity, RefreshCw, Server, WalletCards } from 'lucide-react';
-import type { DashboardResources } from '../types';
-import type { EndpointOk, EndpointStatus } from '../hooks/useFinUsDashboard';
+import type { DashboardResources, EndpointStatus, EndpointStatuses } from '../types';
 
 interface BackendPanelProps {
   resources: DashboardResources;
-  endpointOk: EndpointOk;
+  endpointStatuses: EndpointStatuses;
   loading: boolean;
   onRefresh: () => void;
 }
@@ -24,14 +23,14 @@ const STATUS_LABEL: Record<EndpointStatus, string> = {
   unknown: '확인 중',
 };
 
-const BackendPanel: React.FC<BackendPanelProps> = ({ resources, endpointOk, loading, onRefresh }) => {
+const BackendPanel: React.FC<BackendPanelProps> = ({ resources, endpointStatuses, loading, onRefresh }) => {
   const endpoints = [
-    { label: 'Health', status: endpointOk.health, path: '/health' },
-    { label: 'Balance', status: endpointOk.balance, path: '/api/v1/trading/balance' },
-    { label: 'Portfolio', status: endpointOk.portfolio, path: '/api/v1/db/portfolio' },
-    { label: 'Trades', status: endpointOk.trades, path: '/api/v1/db/trades' },
-    { label: 'Reports', status: endpointOk.reports, path: '/api/v1/db/reports' },
-    { label: 'Diary', status: endpointOk.diaries, path: '/api/v1/db/diary' },
+    { label: 'Health', status: endpointStatuses.health, path: '/health' },
+    { label: 'Balance', status: endpointStatuses.balance, path: '/api/v1/trading/balance' },
+    { label: 'Portfolio', status: endpointStatuses.portfolio, path: '/api/v1/db/portfolio' },
+    { label: 'Trades', status: endpointStatuses.trades, path: '/api/v1/db/trades' },
+    { label: 'Reports', status: endpointStatuses.reports, path: '/api/v1/db/reports' },
+    { label: 'Diary', status: endpointStatuses.diaries, path: '/api/v1/db/diary' },
   ];
 
   return (
@@ -69,8 +68,16 @@ const BackendPanel: React.FC<BackendPanelProps> = ({ resources, endpointOk, load
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
           {endpoints.map((endpoint) => (
             <div key={endpoint.path} className="flex items-center gap-2 rounded-lg bg-slate-50 px-3 py-2">
+              {/*
+                role="status"는 암묵적으로 aria-live="polite"를 동반해, 엔드포인트마다
+                별도의 라이브 리전을 만든다. 엔드포인트가 6개면 라이브 리전도 6개가 되어
+                새로고침 한 번에 스크린리더가 상태를 6번 연달아 읽는다. 이 점은 "방금
+                바뀌었다고 알리는 공지"가 아니라 "지금 상태를 나타내는 지표"이므로
+                role="img"가 의미에 맞고, 접근 가능한 이름은 아래 aria-label이 그대로
+                제공한다.
+              */}
               <span
-                role="status"
+                role="img"
                 aria-label={`${endpoint.label} ${STATUS_LABEL[endpoint.status]}`}
                 data-status={endpoint.status}
                 className={`w-2.5 h-2.5 rounded-full ${DOT_CLASS[endpoint.status]}`}

--- a/frontend-react/src/hooks/useFinUsDashboard.test.tsx
+++ b/frontend-react/src/hooks/useFinUsDashboard.test.tsx
@@ -63,12 +63,12 @@ describe('useFinUsDashboard - 엔드포인트 상태 판정', () => {
 
     const { result } = renderHook(() => useFinUsDashboard());
 
-    await waitFor(() => expect(result.current.endpointOk.portfolio).toBe('fail'));
+    await waitFor(() => expect(result.current.endpointStatuses.portfolio).toBe('fail'));
     // 거부됐는데 빈 배열 — 이 조합이 정확히 #71의 조건이다.
     expect(result.current.resources.portfolio).toEqual([]);
     // 성공한 다른 엔드포인트는 영향을 받지 않는다.
-    expect(result.current.endpointOk.trades).toBe('ok');
-    expect(result.current.endpointOk.health).toBe('ok');
+    expect(result.current.endpointStatuses.trades).toBe('ok');
+    expect(result.current.endpointStatuses.health).toBe('ok');
   });
 
   it('#71: 배열 계열 엔드포인트 전부가 거부되면 모두 fail로 판정한다', async () => {
@@ -79,10 +79,10 @@ describe('useFinUsDashboard - 엔드포인트 상태 판정', () => {
 
     const { result } = renderHook(() => useFinUsDashboard());
 
-    await waitFor(() => expect(result.current.endpointOk.portfolio).toBe('fail'));
-    expect(result.current.endpointOk.trades).toBe('fail');
-    expect(result.current.endpointOk.reports).toBe('fail');
-    expect(result.current.endpointOk.diaries).toBe('fail');
+    await waitFor(() => expect(result.current.endpointStatuses.portfolio).toBe('fail'));
+    expect(result.current.endpointStatuses.trades).toBe('fail');
+    expect(result.current.endpointStatuses.reports).toBe('fail');
+    expect(result.current.endpointStatuses.diaries).toBe('fail');
     expect(result.current.resources.trades).toEqual([]);
     expect(result.current.resources.reports).toEqual([]);
     expect(result.current.resources.diaries).toEqual([]);
@@ -92,8 +92,8 @@ describe('useFinUsDashboard - 엔드포인트 상태 판정', () => {
   it('전부 성공하면 모두 ok로 판정하고 에러 메시지를 남기지 않는다', async () => {
     const { result } = renderHook(() => useFinUsDashboard());
 
-    await waitFor(() => expect(result.current.endpointOk.portfolio).toBe('ok'));
-    expect(result.current.endpointOk).toEqual({
+    await waitFor(() => expect(result.current.endpointStatuses.portfolio).toBe('ok'));
+    expect(result.current.endpointStatuses).toEqual({
       health: 'ok',
       balance: 'ok',
       portfolio: 'ok',
@@ -111,7 +111,7 @@ describe('useFinUsDashboard - 엔드포인트 상태 판정', () => {
 
     const { result } = renderHook(() => useFinUsDashboard());
 
-    expect(result.current.endpointOk.portfolio).toBe('unknown');
-    expect(result.current.endpointOk.health).toBe('unknown');
+    expect(result.current.endpointStatuses.portfolio).toBe('unknown');
+    expect(result.current.endpointStatuses.health).toBe('unknown');
   });
 });

--- a/frontend-react/src/hooks/useFinUsDashboard.ts
+++ b/frontend-react/src/hooks/useFinUsDashboard.ts
@@ -1,19 +1,8 @@
 import { useCallback, useEffect, useRef, useState, type FormEvent } from 'react';
 import { apiErrorMessage, finUsApi } from '../api';
-import type { AnalysisReport, ChatMessage, DashboardResources } from '../types';
+import type { AnalysisReport, ChatMessage, DashboardResources, EndpointStatuses } from '../types';
 
-export type EndpointStatus = 'unknown' | 'ok' | 'fail';
-
-export interface EndpointOk {
-  health: EndpointStatus;
-  balance: EndpointStatus;
-  portfolio: EndpointStatus;
-  trades: EndpointStatus;
-  reports: EndpointStatus;
-  diaries: EndpointStatus;
-}
-
-const initialEndpointOk: EndpointOk = {
+const initialEndpointStatuses: EndpointStatuses = {
   health: 'unknown',
   balance: 'unknown',
   portfolio: 'unknown',
@@ -54,7 +43,7 @@ export function useFinUsDashboard() {
   const [rawNews, setRawNews] = useState<string[]>([]);
   const [rawTrend, setRawTrend] = useState<string | null>(null);
   const [resources, setResources] = useState<DashboardResources>(initialResources);
-  const [endpointOk, setEndpointOk] = useState<EndpointOk>(initialEndpointOk);
+  const [endpointStatuses, setEndpointStatuses] = useState<EndpointStatuses>(initialEndpointStatuses);
   const [error, setError] = useState('');
   const [chatStatus, setChatStatus] = useState<'connecting' | 'open' | 'closed'>('connecting');
   const [chatMessages, setChatMessages] = useState<ChatMessage[]>([
@@ -90,7 +79,7 @@ export function useFinUsDashboard() {
       diaries: diaries.status === 'fulfilled' ? diaries.value : [],
     });
 
-    setEndpointOk({
+    setEndpointStatuses({
       health: health.status === 'fulfilled' ? 'ok' : 'fail',
       balance: balance.status === 'fulfilled' ? 'ok' : 'fail',
       portfolio: portfolio.status === 'fulfilled' ? 'ok' : 'fail',
@@ -221,7 +210,7 @@ export function useFinUsDashboard() {
     rawNews,
     rawTrend,
     resources,
-    endpointOk,
+    endpointStatuses,
     error,
     chatStatus,
     chatMessages,

--- a/frontend-react/src/types.ts
+++ b/frontend-react/src/types.ts
@@ -105,6 +105,17 @@ export interface DashboardResources {
   diaries: DiaryItem[];
 }
 
+export type EndpointStatus = 'unknown' | 'ok' | 'fail';
+
+export interface EndpointStatuses {
+  health: EndpointStatus;
+  balance: EndpointStatus;
+  portfolio: EndpointStatus;
+  trades: EndpointStatus;
+  reports: EndpointStatus;
+  diaries: EndpointStatus;
+}
+
 export interface ChatMessage {
   id: string;
   role: 'system' | 'user' | 'server';

--- a/frontend-react/src/types.ts
+++ b/frontend-react/src/types.ts
@@ -107,14 +107,8 @@ export interface DashboardResources {
 
 export type EndpointStatus = 'unknown' | 'ok' | 'fail';
 
-export interface EndpointStatuses {
-  health: EndpointStatus;
-  balance: EndpointStatus;
-  portfolio: EndpointStatus;
-  trades: EndpointStatus;
-  reports: EndpointStatus;
-  diaries: EndpointStatus;
-}
+// 엔드포인트 집합은 DashboardResources와 1:1이다. 파생시켜 두 곳이 어긋나는 걸 막는다.
+export type EndpointStatuses = Record<keyof DashboardResources, EndpointStatus>;
 
 export interface ChatMessage {
   id: string;


### PR DESCRIPTION
Closes #180

## 1. 위치 — `types.ts`로 이동

`EndpointOk`/`EndpointStatus`가 `hooks/useFinUsDashboard.ts`에 정의돼 있어서, `BackendPanel`이 **공유 계약 타입을 훅 모듈에서** import하고 있었습니다(`DashboardResources`는 `../types`에서 오는데도). 훅의 내부 구현이 아니라 훅과 컴포넌트가 공유하는 계약이므로 `types.ts`가 제자리입니다.

지금은 `import type`이라 순환이 아니지만, 나중에 값(value) import가 추가되면 컴포넌트 → 훅 → 타입 사이클이 생깁니다.

## 2. 이름 — `EndpointOk` → `EndpointStatuses`

`EndpointOk`는 boolean 시절의 잔재입니다. 값이 `'unknown' | 'ok' | 'fail'` 삼상태가 된 지금 이름과 값이 어긋납니다.

```ts
endpointOk.health === 'fail'   // "ok가 fail이다" — 자기모순적으로 읽힘
```

`EndpointStatus`(단수, 개별 상태값)는 이름을 유지하고, `EndpointOk`만 `EndpointStatuses`로 개명해 `types.ts`의 `DashboardResources` 아래로 옮겼습니다. prop 이름도 `endpointOk` → `endpointStatuses`로 함께 갱신했습니다.

`grep -rn "EndpointOk\|endpointOk" src/` → **잔존 0건**.

## 3. 함께 처리 — 접근성 (PR #187 리뷰 잔여분)

PR #187 리뷰에서 선택 사항으로 남았던 항목이 머지에 포함되지 않아 여기서 정리합니다.

상태 점의 `role="status"` → `role="img"`. `role="status"`는 암묵적으로 `aria-live="polite"`라, 엔드포인트 6개에 각각 붙으면 **라이브 리전이 6개** 생깁니다. 새로고침으로 상태가 갱신될 때마다 스크린리더가 6개 상태를 연달아 읽습니다.

여기서 점은 "변경을 알리는 알림"이 아니라 "상태를 나타내는 지표"이므로 `img`가 의미에 맞고, 접근 가능한 이름은 기존 `aria-label`이 그대로 제공합니다. 왜 `status`가 아닌지 근거를 주석에 남겨, 나중에 "상태니까 `role="status"`가 맞지 않나" 하고 되돌리는 걸 막았습니다.

## 검증

- `npx tsc --noEmit` → **에러 0**
- `npm test` → **8 passed (2 files)** — 개명 반영 외 테스트 로직 변경 없음
- `npm run build` → **성공**
- `package-lock.json` 무변경

## 범위

`types.ts`, `hooks/useFinUsDashboard.ts`, `components/BackendPanel.tsx`, `App.tsx`, 테스트 2개.
