### PR TITLE
test: order-submit 반복 store 리터럴을 stubStore() 헬퍼로 추출 (#193)

### DIFF
--- a/mcp-trading/tests/order-submit.test.js
+++ b/mcp-trading/tests/order-submit.test.js
@@ -26,6 +26,25 @@ function tempDedupLedgerPath(t) {
   return path.join(dir, "ledger.json");
 }
 
+// release(key) → releaseCalls 기록, withMarkSucceededGuard=true 시 markSucceeded 가드 추가
+// (submit()이 throw할 때 markSucceeded가 절대 호출되지 않아야 하는 테스트용)
+function stubStore({ withMarkSucceededGuard = false } = {}) {
+  const releaseCalls = [];
+  return {
+    releaseCalls,
+    store: {
+      release: (key) => releaseCalls.push(key),
+      ...(withMarkSucceededGuard
+        ? {
+            markSucceeded() {
+              throw new Error("markSucceeded should not run when submit() throws");
+            },
+          }
+        : {}),
+    },
+  };
+}
+
 // Mutation this catches: moving markSucceeded back inside the try (or letting any
 // exception from it flow into the shared catch) so that a ledger write failure is
 // treated the same as an order failure — release() gets called and/or the success
@@ -95,15 +114,7 @@ test("submitOrder: after a markSucceeded failure, the ledger entry stays in plac
 // from before #161: KIS explicitly said rt_cd !== "0", so nothing was submitted and
 // the guard must be released for a legitimate retry.
 test("submitOrder: releases the dedup guard when KIS rejects the order (rt_cd !== \"0\") — unchanged behavior", async (t) => {
-  const releaseCalls = [];
-  const store = {
-    release(key) {
-      releaseCalls.push(key);
-    },
-    markSucceeded() {
-      throw new Error("markSucceeded should not run when submit() throws");
-    },
-  };
+  const { releaseCalls, store } = stubStore({ withMarkSucceededGuard: true });
 
   const rejected = new Error("KIS API 오류: 주문가능금액을 초과하였습니다.");
   rejected.kisOrderRejected = true;
@@ -123,15 +134,7 @@ test("submitOrder: releases the dedup guard when KIS rejects the order (rt_cd !=
 // full TTL and DuplicateOrderError tells the user to "check the order shortly" for an
 // order that provably never existed, with no escape except changing quantity/price.
 test("submitOrder: releases the dedup guard when the KIS POST never went out (kisOrderNotSubmitted, e.g. token/hashkey pre-flight failure)", async (t) => {
-  const releaseCalls = [];
-  const store = {
-    release(key) {
-      releaseCalls.push(key);
-    },
-    markSucceeded() {
-      throw new Error("markSucceeded should not run when submit() throws");
-    },
-  };
+  const { releaseCalls, store } = stubStore({ withMarkSucceededGuard: true });
 
   const notSubmitted = new Error("Access Token 발급 실패: EGW00133 초당 거래건수를 초과하였습니다.");
   notSubmitted.kisOrderNotSubmitted = true;
@@ -149,12 +152,7 @@ test("submitOrder: releases the dedup guard when the KIS POST never went out (ki
 // received the order is unknown — releasing here could let a duplicate through while
 // the original order might still be live, so the guard must stay (fail-closed).
 test("submitOrder: does not release the dedup guard when the axios POST fails and submission status is unknown — unchanged behavior", async (t) => {
-  const releaseCalls = [];
-  const store = {
-    release(key) {
-      releaseCalls.push(key);
-    },
-  };
+  const { releaseCalls, store } = stubStore();
 
   const submitFailure = new Error("connect ETIMEDOUT");
   submitFailure.kisOrderSubmittedMaybe = true;
@@ -172,12 +170,7 @@ test("submitOrder: does not release the dedup guard when the axios POST fails an
 // application code unrelated to the KIS call) must default to NOT releasing — the old
 // code's `!error.kisOrderSubmittedMaybe` fell through to release() here instead.
 test("submitOrder: does not release the dedup guard for an error with none of the three recognized flags (inversion of pre-#161 behavior, which released here)", async (t) => {
-  const releaseCalls = [];
-  const store = {
-    release(key) {
-      releaseCalls.push(key);
-    },
-  };
+  const { releaseCalls, store } = stubStore();
 
   const unrecognizedError = new TypeError("Cannot read properties of undefined (reading 'output')");
 
@@ -236,12 +229,7 @@ test("submitOrder: a non-Error thrown by markSucceeded (e.g. a plain string) doe
 // unguarded when submit() itself rejects with a non-Error value (e.g. `throw null`,
 // which real code should never do, but a defensive guard must still not crash on it).
 test("submitOrder: a non-Error value thrown by submit() (e.g. null) does not crash and defaults to not releasing", async (t) => {
-  const releaseCalls = [];
-  const store = {
-    release(key) {
-      releaseCalls.push(key);
-    },
-  };
+  const { releaseCalls, store } = stubStore();
 
   await assert.rejects(
     () => submitOrder({ dedupStore: store, dedupKey: "order-key-null-throw", submit: async () => { throw null; } }), // eslint-disable-line no-throw-literal


### PR DESCRIPTION
## 배경

#193. PR #192에서 `submitOrder` 테스트가 한 파일에 모이면서 ad-hoc `const store = {...}` 리터럴 중복이 드러났습니다.

## 변경

`stubStore({ withMarkSucceededGuard })` 헬퍼를 추가하고 **5곳**을 이관했습니다.

```js
function stubStore({ withMarkSucceededGuard = false } = {}) {
  const releaseCalls = [];
  return {
    releaseCalls,
    store: {
      release: (key) => releaseCalls.push(key),
      ...(withMarkSucceededGuard ? { markSucceeded() { throw new Error("markSucceeded should not run when submit() throws"); } } : {}),
    },
  };
}
```

**7곳 전부를 뭉개지 않았습니다.** 형태가 다른 2곳은 그대로 뒀습니다 — `markSucceeded`가 non-Error를 던지는 테스트와 `releaseCalls`를 쓰지 않는 테스트로, 헬퍼에 욱여넣으면 각 테스트 고유의 조건이 흐려집니다. 목적은 줄 수 감소가 아니라 의도를 선명하게 하는 것입니다.

이슈 스니펫의 `markSucceededShouldRun` 대신 `withMarkSucceededGuard`로 이름을 바꿨습니다 — 실제 의미가 "가드를 붙인다"이지 "실행된다"가 아닙니다.

## 검증 (직접 실행)

**테스트 개수 불변**: `node --test tests/order-submit.test.js` 9 pass / 0 fail → 9 pass / 0 fail.

**뮤테이션 점수가 리팩터 전후 완전히 동일합니다.** 커버리지 손실이 없다는 뜻입니다.

| 뮤턴트 | `main` | 이 PR |
| --- | --- | --- |
| A. fail-closed 반전 (인식 못한 예외도 해제) | 2 fail | 2 fail |
| B. `release()` 호출 제거 | 3 fail | 3 fail |
| C. `markSucceeded` 후 `release()`도 호출 | 미검출 | 미검출 |
| D. `releaseError.message` 무가드 참조 | 미검출 | 미검출 |

`release()`의 반환값이 프로덕션에서 쓰이지 않는 것(`order-submit.js:19`이 반환값을 버리는 문장)을 확인하고 화살표 함수로 바꿨습니다.

프로덕션 코드 변경은 0줄입니다.

## 참고 — 이 PR 범위 밖

위 표의 **C·D는 `main`에서도 미검출**입니다. 이 PR이 만든 공백이 아니라 원래 있던 것으로, `order-submit.js`의 두 경로가 테스트되지 않고 있습니다.

- C: `markSucceeded` 성공 후 가드가 해제되는 회귀
- D: `release()`가 non-Error를 던질 때 `releaseError.message` 무가드 참조

후속 이슈로 뗄지 판단이 필요합니다. 이 PR에서 테스트를 추가하면 "순수 리팩터"라는 성질이 깨지므로 넣지 않았습니다.

Closes #193