### PR TITLE
refactor: 연속조회 세 루프를 fetchAllPaged로 통합 (#147)

### DIFF
--- a/mcp-trading/balance-rlz-pl-report.js
+++ b/mcp-trading/balance-rlz-pl-report.js
@@ -1,5 +1,21 @@
 import { formatPercent, formatQuantity, formatWon } from "./formatters.js";
 
+// 잘림 안내 문구. "- "로 시작하면 파싱 오류를 낼 수 있으므로 반드시 "[안내]"로 시작한다.
+// rows.length === 0인 경우에도 출력해야 한다 — 그렇지 않으면 잘림 때문에 빈 결과가 나온 상황을
+// "보유 종목이 없습니다"로 사실로 단언하게 된다.
+function formatRlzPlTruncationNote(truncated, pages) {
+  if (!truncated) return "";
+  const reasons = {
+    max_pages: `페이지 상한(${pages}회)에 도달하여`,
+    time_budget: "조회 시간 예산을 초과하여",
+    no_cursor: "연속조회 커서가 오지 않아",
+    repeated_cursor: "동일한 연속조회 커서가 반복되어",
+    error: "연속조회 중 오류가 발생하여",
+  };
+  const reason = reasons[truncated] || "연속조회가 완료되지 않아";
+  return `\n\n[안내] ${reason} 조회가 중단되어 일부 실현손익 내역이 누락되었을 수 있습니다. 실제 내역은 별도로 확인하세요.`;
+}
+
 export function formatBalanceRlzPlSummaryBlock(summary) {
   if (!summary) {
     return "";
@@ -15,8 +31,9 @@ export function formatBalanceRlzPlSummaryBlock(summary) {
   `.trim();
 }
 
-export function formatBalanceRlzPlReport({ rows, summary, pages, trId, stockLabel }) {
+export function formatBalanceRlzPlReport({ rows, summary, pages, truncated, trId, stockLabel }) {
   const summaryBlock = formatBalanceRlzPlSummaryBlock(summary);
+  const truncationNote = formatRlzPlTruncationNote(truncated, pages);
 
   if (rows.length === 0) {
     const holdingsNote = stockLabel
@@ -26,7 +43,7 @@ export function formatBalanceRlzPlReport({ rows, summary, pages, trId, stockLabe
 [주식잔고조회_실현손익]${stockLabel ? ` / ${stockLabel}` : ""}
 - 조회 TR: ${trId} (v1_국내주식-041, inquire-balance-rlz-pl)
 ${holdingsNote}
-${summaryBlock ? `\n${summaryBlock}` : ""}
+${summaryBlock ? `\n${summaryBlock}` : ""}${truncationNote}
     `.trim();
   }
 
@@ -49,6 +66,6 @@ ${summaryBlock ? `\n${summaryBlock}` : ""}
 ${summaryBlock}
 
 [보유 종목]
-${lines.join("\n\n")}
+${lines.join("\n\n")}${truncationNote}
   `.trim();
 }

--- a/mcp-trading/balance.js
+++ b/mcp-trading/balance.js
@@ -13,8 +13,10 @@ export const BALANCE_MAX_PAGES = 20;
 export const BALANCE_TIME_BUDGET_MS = 15_000;
 
 function isContinuationTrCont(value) {
-  // index.js의 isKisContinueTrCont()와 동일한 KIS tr_cont 연속조회 판정을 balance.js에서도
-  // 그대로 사용하기 위한 로컬 사본이다 (index.js는 부작용을 가진 서버 진입점이라 여기서 import하지 않는다).
+  // KIS tr_cont 연속조회 판정. "F"(first/더 있음) 또는 "M"(more)일 때 다음 페이지가 있다.
+  // fetchAllPaged를 통해 index.js의 두 루프(fetchAllDailyOrderCcld, fetchAllBalanceRlzPl)에서도
+  // 재사용된다. index.js는 import 시점에 StdioServerTransport를 연결하는 부작용이 있어
+  // 여기서 import하지 않으므로, 이 파일이 두 함수의 정규 구현처다.
   return value === "F" || value === "M";
 }
 
@@ -35,20 +37,29 @@ export function buildBalanceParams(accountNo, { ctxAreaFk100 = "", ctxAreaNk100 
 }
 
 /**
- * inquire-balance 연속조회 루프. KIS 호출 자체는 fetchPage로 주입받아
- * (index.js의 kisApiGet 등) balance.js 단독으로 유닛 테스트할 수 있게 한다.
+ * KIS 연속조회 공용 루프. inquire-balance(fetchAllBalance), inquire-daily-ccld,
+ * inquire-balance-rlz-pl 세 루프의 공통 페이지네이션 로직을 하나로 모은 것이다.
  *
  * fetchPage({ ctxAreaFk100, ctxAreaNk100, trCont }) => Promise<{ body, trCont }>
- *   - body: KIS 응답 바디 (output1/output2/ctx_area_fk100/ctx_area_nk100 포함)
+ *   - body.output1: 행 배열
+ *   - body.output2: 요약(배열 또는 단일 객체)
+ *   - body.ctx_area_fk100, body.ctx_area_nk100: 연속조회 커서
  *   - trCont: 응답 tr_cont 헤더 값
  *
- * 반환: { rows, summary, pages, truncated }
- *   - truncated: null | "max_pages" | "time_budget" | "no_cursor" | "repeated_cursor" | "error"
+ * @param {Function} fetchPage  KIS 단일 페이지 호출 함수
+ * @param {object}   options
+ * @param {number}   options.maxPages      페이지 상한 (필수; 루프마다 다름)
+ * @param {number}   options.timeBudgetMs  전체 시간 예산 ms (필수; 루프마다 다름)
+ * @param {Function} [options.now]         현재 시각 반환 함수 (테스트 주입용, 기본 Date.now)
+ * @param {string}   [options.label]       오류 로그 접두사 (기본 "연속조회")
+ * @returns {Promise<{ rows, summary, pages, truncated }>}
+ *   truncated: null | "max_pages" | "time_budget" | "no_cursor" | "repeated_cursor" | "error"
  */
-export async function fetchAllBalance(fetchPage, {
-  maxPages = BALANCE_MAX_PAGES,
-  timeBudgetMs = BALANCE_TIME_BUDGET_MS,
+export async function fetchAllPaged(fetchPage, {
+  maxPages,
+  timeBudgetMs,
   now = () => Date.now(),
+  label = "연속조회",
 } = {}) {
   const rows = [];
   let summary = null;
@@ -59,8 +70,8 @@ export async function fetchAllBalance(fetchPage, {
   let truncated = null;
   const startedAt = now();
   // 지금까지 받아본 연속조회 커서 전체를 기억해 둔다. 직전 값하고만 비교하면
-  // A,B,A,B처럼 주기 2 이상으로 순환하는 커서를 놓치고 상한(20회)까지 같은
-  // 종목을 계속 중복 조회하게 된다.
+  // A,B,A,B처럼 주기 2 이상으로 순환하는 커서를 놓치고 상한까지 같은
+  // 데이터를 계속 중복 조회하게 된다.
   const seenCursors = new Set();
 
   while (true) {
@@ -84,15 +95,15 @@ export async function fetchAllBalance(fetchPage, {
     } catch (error) {
       // 첫 페이지 실패는 인증·계좌 설정 오류일 수 있어 원인을 숨기지 않고 그대로 전파한다.
       // 2페이지 이후 실패는 이미 확보한 페이지를 버리지 않고 부분 결과 + 잘림 표시로 반환한다.
-      // (누락 방지가 목적인데 일시적 오류 1회로 잔고 전체가 사라지면 방향이 반대다.)
+      // (누락 방지가 목적인데 일시적 오류 1회로 데이터 전체가 사라지면 방향이 반대다.)
       if (pages === 0) throw error;
-      // balance.js는 MCP 서버에 import되어 stdout이 JSON-RPC 채널로 쓰인다. 여기서
-      // console.log를 쓰면 프로토콜이 깨지므로 반드시 console.error(stderr)만 사용한다.
+      // balance.js·index.js 모두 stdout이 JSON-RPC 채널로 쓰인다. console.log를 쓰면
+      // 프로토콜이 깨지므로 반드시 console.error(stderr)만 사용한다.
       // error 객체 전체나 error.config/error.response는 절대 남기지 않는다 — axios가
       // config.params(CANO 계좌번호)와 config.headers(appkey, appsecret,
-      // authorization: Bearer 토큰)를 그대로 들고 있어 그대로 로그를 남기면 인증정보가
-      // 노출된다. message만 남긴다.
-      console.error(`잔고 연속조회 ${pages + 1}페이지 조회 실패: ${error.message}`);
+      // authorization: Bearer 토큰)를 그대로 들고 있어 인증정보가 노출된다.
+      // message만 남긴다.
+      console.error(`${label} ${pages + 1}페이지 조회 실패: ${error.message}`);
       truncated = "error";
       break;
     }
@@ -100,8 +111,8 @@ export async function fetchAllBalance(fetchPage, {
     const pageRows = Array.isArray(body.output1) ? body.output1 : [];
     rows.push(...pageRows);
     if (!summary) {
-      // index.js의 fetchAllBalanceRlzPl과 동일하게 단일 객체로 정규화한다.
-      // 빈 배열/undefined면 summary를 확정하지 않아, 요약이 뒤 페이지에 오는 경우를 놓치지 않는다.
+      // 단일 객체로 정규화한다. 빈 배열/undefined면 summary를 확정하지 않아,
+      // 요약이 뒤 페이지에 오는 경우를 놓치지 않는다.
       const candidate = Array.isArray(body.output2) ? body.output2[0] : body.output2;
       if (candidate) summary = candidate;
     }
@@ -122,8 +133,8 @@ export async function fetchAllBalance(fetchPage, {
       truncated = "no_cursor";
       break;
     }
-    // 다음 요청에 실리는 커서는 FK/NK 쌍이므로(buildBalanceParams가 둘 다 내보낸다)
-    // 쌍 전체를 키로 삼는다. NK만 같고 FK가 다르면 서로 다른 요청이라 반복이 아닌데,
+    // 다음 요청에 실리는 커서는 FK/NK 쌍이므로 쌍 전체를 키로 삼는다.
+    // NK만 같고 FK가 다르면 서로 다른 요청이라 반복이 아닌데,
     // NK만 보면 조기 중단해 이 함수가 없애려는 조용한 누락을 만든다.
     // 구분자는 커서 값에 나타날 수 없는 NUL을 쓴다. 공백을 쓰면
     // ("A B","C")와 ("A","B C")가 같은 키가 된다.
@@ -133,13 +144,7 @@ export async function fetchAllBalance(fetchPage, {
       // 보냈던 커서와 같다. 즉 반복되는 것은 "다음에 받을 페이지"이지 방금
       // 받은 이 페이지가 아니다 — 방금 받은 페이지는 이번에 처음 그 커서로
       // 조회해서 받은 실제 신규 데이터이므로 rows에 남겨야 한다. 다음 조회를
-      // 계속하면 그 페이지가 재조회가 되므로, 그 전에 멈춘다. pdno 기준 중복
-      // 제거는 하지 않는다 — 행별 pdno가 유일하다는 전제는 buildBalanceParams가
-      // INQR_DVSN을 항상 "02"(종목별)로 고정하기 때문에만 성립한다. "01"
-      // (대출일별) 조회라면 같은 pdno가 여러 행에 정당하게 걸쳐 나타날 수 있어,
-      // 행 단위 dedup은 서로 다른 실제 보유 종목을 하나로 합쳐버리게 된다.
-      // 혹시라도 진짜 중복 행이 들어오는 경우가 있더라도, 조용히 종목을
-      // 빠뜨리는 것보다는 [안내] 잘림 표시와 함께 과다 집계되는 쪽이 낫다.
+      // 계속하면 그 페이지가 재조회가 되므로, 그 전에 멈춘다.
       truncated = "repeated_cursor";
       break;
     }
@@ -148,6 +153,25 @@ export async function fetchAllBalance(fetchPage, {
   }
 
   return { rows, summary, pages, truncated };
+}
+
+/**
+ * inquire-balance 연속조회 루프. KIS 호출 자체는 fetchPage로 주입받아
+ * (index.js의 kisApiGet 등) balance.js 단독으로 유닛 테스트할 수 있게 한다.
+ *
+ * fetchPage({ ctxAreaFk100, ctxAreaNk100, trCont }) => Promise<{ body, trCont }>
+ *   - body: KIS 응답 바디 (output1/output2/ctx_area_fk100/ctx_area_nk100 포함)
+ *   - trCont: 응답 tr_cont 헤더 값
+ *
+ * 반환: { rows, summary, pages, truncated }
+ *   - truncated: null | "max_pages" | "time_budget" | "no_cursor" | "repeated_cursor" | "error"
+ */
+export async function fetchAllBalance(fetchPage, {
+  maxPages = BALANCE_MAX_PAGES,
+  timeBudgetMs = BALANCE_TIME_BUDGET_MS,
+  now = () => Date.now(),
+} = {}) {
+  return fetchAllPaged(fetchPage, { maxPages, timeBudgetMs, now, label: "잔고 연속조회" });
 }
 
 export function formatPercent(value) {

--- a/mcp-trading/index.js
+++ b/mcp-trading/index.js
@@ -9,7 +9,7 @@ import axios from "axios";
 import dotenv from "dotenv";
 import { z } from "zod";
 import { formatBalanceRlzPlReport } from "./balance-rlz-pl-report.js";
-import { buildBalanceParams, fetchAllBalance, formatBalanceReport } from "./balance.js";
+import { buildBalanceParams, fetchAllBalance, fetchAllPaged, formatBalanceReport } from "./balance.js";
 import {
   formatPercent,
   formatQuantity,
@@ -51,6 +51,12 @@ const KIS_DAILY_CCLD_TR_ID = (() => {
 })();
 const DAILY_CCLD_PATH = "/uapi/domestic-stock/v1/trading/inquire-daily-ccld";
 const DAILY_CCLD_MAX_PAGES = 50;
+// inquire-daily-ccld 연속조회 전체 시간 예산. 호출자는 NAT 일지 에이전트(diary_agent.yml)이고
+// timeout_sec: 120이 상한이다. kisAxios 요청당 8초 타임아웃 + 기동 오버헤드 ~2초를 빼면
+// 헤드룸은 ~110초. 측정치가 없어 정상 부하는 알 수 없으나, 90 + 8(진행 중 요청) + 2(기동) =
+// 100 < 120이므로 상한 안에 안전하게 들어온다. 90초 초과가 이상 상황이라고 판단하기에
+// 충분하다고 본다. 실제 페이지당 지연 측정치가 확보되면 이 값을 재조정해야 한다.
+const DAILY_CCLD_TIME_BUDGET_MS = 90_000;
 const BALANCE_RLZ_PL_PATH = "/uapi/domestic-stock/v1/trading/inquire-balance-rlz-pl";
 const BALANCE_RLZ_PL_TR_ID = (() => {
   const override = (process.env.KIS_TR_ID_BALANCE_RLZ_PL || process.env.FINUS_KIS_TR_ID_BALANCE_RLZ_PL || "").trim();
@@ -58,6 +64,9 @@ const BALANCE_RLZ_PL_TR_ID = (() => {
   return "TTTC8494R";
 })();
 const BALANCE_RLZ_PL_MAX_PAGES = 50;
+// inquire-balance-rlz-pl 연속조회 전체 시간 예산. DAILY_CCLD_TIME_BUDGET_MS와 같은 근거.
+// 두 TR의 호출자·상한·요청당 타임아웃이 동일하므로 동일한 값을 쓴다.
+const BALANCE_RLZ_PL_TIME_BUDGET_MS = 90_000;
 const TOKEN_TTL_MARGIN_MS = 60_000;
 const TOKEN_CACHE_PATH = process.env.KIS_TOKEN_CACHE_PATH || path.join(
   os.tmpdir(),
@@ -175,10 +184,6 @@ async function kisApiGet(pathname, trId, params, { trCont = "" } = {}) {
 async function kisGet(pathname, trId, params) {
   const { body } = await kisApiGet(pathname, trId, params);
   return body;
-}
-
-function isKisContinueTrCont(value) {
-  return value === "F" || value === "M";
 }
 
 function todayKstYmd() {
@@ -365,50 +370,46 @@ async function fetchAllDailyOrderCcld({
     INQR_DVSN_1: "",
   };
 
-  const rows = [];
-  let summary = null;
-  let trCont = "";
-  let ctxFk = "";
-  let ctxNk = "";
-  let pages = 0;
-
-  while (pages < DAILY_CCLD_MAX_PAGES) {
-    const { body, trCont: respTrCont } = await kisApiGet(
+  const { rows, summary, pages, truncated } = await fetchAllPaged(
+    ({ ctxAreaFk100, ctxAreaNk100, trCont }) => kisApiGet(
       DAILY_CCLD_PATH,
       KIS_DAILY_CCLD_TR_ID,
-      {
-        ...baseParams,
-        CTX_AREA_FK100: ctxFk,
-        CTX_AREA_NK100: ctxNk,
-      },
+      { ...baseParams, CTX_AREA_FK100: ctxAreaFk100, CTX_AREA_NK100: ctxAreaNk100 },
       { trCont },
-    );
+    ),
+    {
+      maxPages: DAILY_CCLD_MAX_PAGES,
+      timeBudgetMs: DAILY_CCLD_TIME_BUDGET_MS,
+      label: "일별 주문체결 연속조회",
+    },
+  );
 
-    const pageRows = Array.isArray(body.output1) ? body.output1 : [];
-    rows.push(...pageRows);
-    if (body.output2 && !summary) {
-      summary = Array.isArray(body.output2) ? body.output2[0] : body.output2;
-    }
-
-    ctxFk = body.ctx_area_fk100 || "";
-    ctxNk = body.ctx_area_nk100 || "";
-    pages += 1;
-
-    if (!isKisContinueTrCont(respTrCont)) {
-      break;
-    }
-    trCont = "N";
-  }
-
-  return { date, rows, summary, pages, trId: KIS_DAILY_CCLD_TR_ID };
+  return { date, rows, summary, pages, truncated, trId: KIS_DAILY_CCLD_TR_ID };
 }
 
-function formatDailyOrderCcldReport({ date, rows, summary, pages, trId, stockLabel }) {
+// 잘림 안내 문구. "- "로 시작하면 파싱 오류를 낼 수 있으므로 반드시 "[안내]"로 시작한다.
+// rows.length === 0인 경우에도 출력해야 한다 — 그렇지 않으면 잘림 때문에 빈 결과가 나온 상황을
+// "해당 조건의 주문·체결이 없습니다"로 사실로 단언하게 된다.
+function formatPaginationTruncationNote(truncated, pages, subject) {
+  if (!truncated) return "";
+  const reasons = {
+    max_pages: `페이지 상한(${pages}회)에 도달하여`,
+    time_budget: "조회 시간 예산을 초과하여",
+    no_cursor: "연속조회 커서가 오지 않아",
+    repeated_cursor: "동일한 연속조회 커서가 반복되어",
+    error: "연속조회 중 오류가 발생하여",
+  };
+  const reason = reasons[truncated] || "연속조회가 완료되지 않아";
+  return `\n\n[안내] ${reason} 조회가 중단되어 일부 ${subject}이(가) 누락되었을 수 있습니다. 실제 내역은 별도로 확인하세요.`;
+}
+
+function formatDailyOrderCcldReport({ date, rows, summary, pages, truncated, trId, stockLabel }) {
+  const truncationNote = formatPaginationTruncationNote(truncated, pages, "주문·체결 내역");
   if (rows.length === 0) {
     return `
 [당일 주문·체결 내역] ${date}${stockLabel ? ` / ${stockLabel}` : ""}
 - 조회 TR: ${trId} (주식일별주문체결조회 v1_국내주식-005)
-- 결과: 해당 조건의 주문·체결이 없습니다.
+- 결과: 해당 조건의 주문·체결이 없습니다.${truncationNote}
     `.trim();
   }
 
@@ -433,7 +434,7 @@ function formatDailyOrderCcldReport({ date, rows, summary, pages, trId, stockLab
 - 건수: ${rows.length}건 (${pages}회 API 호출, 연속조회 포함)
 ${summaryLines}
 
-${lines.join("\n\n")}
+${lines.join("\n\n")}${truncationNote}
   `.trim();
 }
 
@@ -486,42 +487,21 @@ async function fetchAllBalanceRlzPl() {
     COST_ICLD_YN: "N",
   };
 
-  const rows = [];
-  let summary = null;
-  let trCont = "";
-  let ctxFk = "";
-  let ctxNk = "";
-  let pages = 0;
-
-  while (pages < BALANCE_RLZ_PL_MAX_PAGES) {
-    const { body, trCont: respTrCont } = await kisApiGet(
+  const { rows, summary, pages, truncated } = await fetchAllPaged(
+    ({ ctxAreaFk100, ctxAreaNk100, trCont }) => kisApiGet(
       BALANCE_RLZ_PL_PATH,
       BALANCE_RLZ_PL_TR_ID,
-      {
-        ...baseParams,
-        CTX_AREA_FK100: ctxFk,
-        CTX_AREA_NK100: ctxNk,
-      },
+      { ...baseParams, CTX_AREA_FK100: ctxAreaFk100, CTX_AREA_NK100: ctxAreaNk100 },
       { trCont },
-    );
+    ),
+    {
+      maxPages: BALANCE_RLZ_PL_MAX_PAGES,
+      timeBudgetMs: BALANCE_RLZ_PL_TIME_BUDGET_MS,
+      label: "실현손익 연속조회",
+    },
+  );
 
-    const pageRows = Array.isArray(body.output1) ? body.output1 : [];
-    rows.push(...pageRows);
-    if (body.output2 && !summary) {
-      summary = Array.isArray(body.output2) ? body.output2[0] : body.output2;
-    }
-
-    ctxFk = body.ctx_area_fk100 || "";
-    ctxNk = body.ctx_area_nk100 || "";
-    pages += 1;
-
-    if (!isKisContinueTrCont(respTrCont)) {
-      break;
-    }
-    trCont = "N";
-  }
-
-  return { rows, summary, pages, trId: BALANCE_RLZ_PL_TR_ID };
+  return { rows, summary, pages, truncated, trId: BALANCE_RLZ_PL_TR_ID };
 }
 
 async function getBalanceRlzPl({ stock_name: stockName } = {}) {

--- a/mcp-trading/tests/balance-rlz-pl-report.test.js
+++ b/mcp-trading/tests/balance-rlz-pl-report.test.js
@@ -29,6 +29,62 @@ test("formatBalanceRlzPlReport includes account summary when holdings are empty"
   assert.doesNotMatch(text, /\[보유 종목\]\s*$/m);
 });
 
+test("formatBalanceRlzPlReport: rows가 없어도 truncated가 있으면 잘림 안내를 표시한다 (수용 기준: rows.length===0 잘림)", () => {
+  // 수용 기준: "잘림 표시가 rows.length === 0인 경우에도 나올 것 — 안 그러면
+  // '해당 조건의 보유 종목이 없습니다'를 사실로 단언하게 된다."
+  const text = formatBalanceRlzPlReport({
+    rows: [],
+    summary: null,
+    pages: 3,
+    truncated: "time_budget",
+    trId: "TTTC8494R",
+    stockLabel: "",
+  });
+
+  assert.match(text, /\[안내\]/);
+  assert.match(text, /조회가 중단되어/);
+  // 수용 기준: "잘림 안내가 '- '로 시작하지 않을 것"
+  // '[안내]' 줄 자체가 '- '로 시작하지 않아야 한다 (리포트의 다른 줄과 혼동 방지)
+  const noteLine = text.split("\n").find((l) => l.includes("[안내]"));
+  assert.ok(noteLine, "[안내] 줄이 있어야 함");
+  assert.ok(!noteLine.startsWith("- "), `잘림 안내가 "- "로 시작하면 안 됨: ${noteLine}`);
+});
+
+test("formatBalanceRlzPlReport: rows가 있을 때도 잘림 안내가 마지막에 붙는다", () => {
+  const text = formatBalanceRlzPlReport({
+    rows: [
+      {
+        prdt_name: "삼성전자",
+        pdno: "005930",
+        trad_dvsn_name: "현금",
+        hldg_qty: "1",
+        prpr: "70000",
+        evlu_amt: "70000",
+        evlu_pfls_amt: "3000",
+        evlu_pfls_rt: "4.48",
+        pchs_avg_pric: "67000",
+        thdt_buyqty: "0",
+        thdt_sll_qty: "0",
+        bfdy_cprs_icdc: "500",
+        fltt_rt: "0.72",
+      },
+    ],
+    summary: null,
+    pages: 2,
+    truncated: "no_cursor",
+    trId: "TTTC8494R",
+    stockLabel: "",
+  });
+
+  assert.match(text, /\[안내\]/);
+  assert.match(text, /조회가 중단되어/);
+  // 안내가 "[보유 종목]" 섹션 내부가 아닌 뒤에 와야 한다
+  const holdingsSection = text.split("[보유 종목]")[1];
+  assert.ok(holdingsSection, "[보유 종목] 섹션이 있어야 함");
+  const stockLines = holdingsSection.split("\n").filter((l) => l.startsWith("- "));
+  assert.ok(stockLines.every((l) => !l.includes("안내")), "안내 문구가 '- ' 줄에 섞이면 안 됨");
+});
+
 test("isPaperTradingKisUrl detects mock trading host", () => {
   assert.equal(isPaperTradingKisUrl("https://openapivts.koreainvestment.com:29443"), true);
   assert.equal(isPaperTradingKisUrl("https://openapi.koreainvestment.com:9443"), false);

--- a/mcp-trading/tests/fetch-all-paged.test.js
+++ b/mcp-trading/tests/fetch-all-paged.test.js
@@ -1,0 +1,258 @@
+/**
+ * fetchAllPaged 가드 테스트
+ *
+ * index.js의 두 루프(fetchAllDailyOrderCcld, fetchAllBalanceRlzPl)는 MCP 서버 진입점에
+ * 있어 import 시점에 StdioServerTransport를 연결하므로 유닛 레벨에서 직접 테스트할 수 없다.
+ * 두 루프가 위임하는 fetchAllPaged를 동일한 파라미터(maxPages: 50, timeBudgetMs: 90_000)로
+ * 직접 테스트해 네 가지 가드의 실효성을 확인한다.
+ *
+ * 시간 예산 90초 근거: 호출자 상한 120초(diary_agent.yml timeout_sec)에서
+ * 요청당 타임아웃 8초 + 기동 오버헤드 2초를 빼면 ~110초 헤드룸.
+ * 90 + 8 + 2 = 100 < 120이므로 상한 안에 안전하게 들어온다.
+ * 실제 페이지당 지연 측정치가 없어 이 값은 검증 불가 — 소스 주석과 PR에 명시.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { fetchAllPaged } from "../balance.js";
+
+// 두 루프가 공유하는 파라미터
+const MAX_PAGES = 50;
+const TIME_BUDGET_MS = 90_000;
+
+// ─── 가드 1: 커서 trim ────────────────────────────────────────────────────────
+
+test("fetchAllPaged: KIS가 공백 패딩 커서를 반환해도 다음 요청에는 trim된 값을 전송한다", async () => {
+  const calls = [];
+  let callCount = 0;
+  const fetchPage = async ({ ctxAreaFk100, ctxAreaNk100, trCont }) => {
+    calls.push({ ctxAreaFk100, ctxAreaNk100, trCont });
+    callCount += 1;
+    if (callCount === 1) {
+      return {
+        body: {
+          output1: [{ pdno: "005930" }],
+          output2: [],
+          // KIS 고정폭 반환: 패딩된 커서
+          ctx_area_fk100: "  FK1  ",
+          ctx_area_nk100: "  NK1  ",
+        },
+        trCont: "F",
+      };
+    }
+    // 2회 호출에서 커서가 없으면 no_cursor로 멈춤 — trim 동작을 확인한 뒤 루프 종료
+    return {
+      body: {
+        output1: [{ pdno: "035420" }],
+        output2: [],
+        ctx_area_fk100: "",
+        ctx_area_nk100: "",
+      },
+      trCont: "F",
+    };
+  };
+
+  const result = await fetchAllPaged(fetchPage, {
+    maxPages: MAX_PAGES,
+    timeBudgetMs: TIME_BUDGET_MS,
+  });
+
+  assert.equal(callCount, 2);
+  // 2회 호출 시 전송된 커서는 trim된 값이어야 한다
+  assert.deepEqual(calls[1], { ctxAreaFk100: "FK1", ctxAreaNk100: "NK1", trCont: "N" });
+  assert.equal(result.truncated, "no_cursor");
+});
+
+// ─── 가드 2: no_cursor 가드 ──────────────────────────────────────────────────
+
+test("fetchAllPaged: 공백 패딩 커서 + 연속 tr_cont에서 50회가 아닌 2회 이내에 멈춘다 (no_cursor)", async () => {
+  // 수용 기준: "공백 패딩 커서 + 연속 tr_cont에서 두 루프가 2회 이내에 멈출 것 (지금은 50회)"
+  let callCount = 0;
+  const fetchPage = async () => {
+    callCount += 1;
+    return {
+      body: {
+        output1: [{ pdno: String(callCount).padStart(6, "0") }],
+        output2: [],
+        // KIS가 공백 커서를 반환 — truthy라 trim 없이는 가드를 통과함
+        ctx_area_fk100: "   ",
+        ctx_area_nk100: "   ",
+      },
+      trCont: "F",
+    };
+  };
+
+  const result = await fetchAllPaged(fetchPage, {
+    maxPages: MAX_PAGES,
+    timeBudgetMs: TIME_BUDGET_MS,
+  });
+
+  // 1회: 첫 페이지 조회 → 공백 커서 수신
+  // 2회: 공백 커서 trim → 비어 있어 no_cursor 가드에서 멈춤
+  // 따라서 총 호출 횟수는 2, max_pages(50)에는 도달하지 않음
+  assert.ok(callCount <= 2, `호출 횟수 ${callCount}회 — 50회 미만이어야 함`);
+  assert.equal(result.truncated, "no_cursor");
+  assert.notEqual(result.truncated, null);
+});
+
+test("fetchAllPaged: tr_cont 연속 신호가 와도 커서가 완전히 없을 때 no_cursor로 멈춘다", async () => {
+  let callCount = 0;
+  const fetchPage = async () => {
+    callCount += 1;
+    if (callCount === 1) {
+      return {
+        body: {
+          output1: [{ pdno: "005930" }],
+          output2: [{ tot: "1" }],
+          ctx_area_fk100: "FK1",
+          ctx_area_nk100: "NK1",
+        },
+        trCont: "F",
+      };
+    }
+    // 두 번째 페이지부터 커서 없음
+    return {
+      body: {
+        output1: [{ pdno: String(callCount).padStart(6, "0") }],
+        output2: [],
+        ctx_area_fk100: "",
+        ctx_area_nk100: "",
+      },
+      trCont: "F",
+    };
+  };
+
+  const result = await fetchAllPaged(fetchPage, {
+    maxPages: MAX_PAGES,
+    timeBudgetMs: TIME_BUDGET_MS,
+  });
+
+  assert.equal(callCount, 2);
+  assert.equal(result.pages, 2);
+  assert.equal(result.truncated, "no_cursor");
+});
+
+// ─── 가드 3: 커서 반복 감지 ──────────────────────────────────────────────────
+
+test("fetchAllPaged: KIS가 같은 커서를 반복 반환하면 2회 이내에 멈춘다 (repeated_cursor)", async () => {
+  // 수용 기준: "공백 패딩 커서 + 연속 tr_cont에서 두 루프가 2회 이내에 멈출 것"
+  let callCount = 0;
+  const fetchPage = async () => {
+    callCount += 1;
+    return {
+      body: {
+        output1: [{ pdno: callCount === 1 ? "000000" : "000001" }],
+        output2: callCount === 1 ? [{ tot: "1" }] : [],
+        // 매 페이지 동일한 커서 반환 → 반복 감지
+        ctx_area_fk100: "FK-SAME",
+        ctx_area_nk100: "NK-SAME",
+      },
+      trCont: "F",
+    };
+  };
+
+  const result = await fetchAllPaged(fetchPage, {
+    maxPages: MAX_PAGES,
+    timeBudgetMs: TIME_BUDGET_MS,
+  });
+
+  assert.equal(callCount, 2);
+  assert.equal(result.pages, 2);
+  assert.equal(result.truncated, "repeated_cursor");
+  // 방금 받은 2번째 페이지는 이번에 처음 그 커서로 조회한 신규 데이터이므로 rows에 남아야 한다
+  assert.deepEqual(result.rows.map((r) => r.pdno), ["000000", "000001"]);
+});
+
+test("fetchAllPaged: 주기 2 커서 순환(A,B,A)을 감지해 50회가 아닌 3회에서 멈춘다", async () => {
+  const cursors = ["A", "B", "A"];
+  let callCount = 0;
+  const fetchPage = async () => {
+    callCount += 1;
+    const cursor = cursors[callCount - 1] ?? "X";
+    return {
+      body: {
+        output1: [{ pdno: String(callCount).padStart(6, "0") }],
+        output2: callCount === 1 ? [{ tot: "1" }] : [],
+        ctx_area_fk100: `FK-${cursor}`,
+        ctx_area_nk100: cursor,
+      },
+      trCont: "F",
+    };
+  };
+
+  const result = await fetchAllPaged(fetchPage, {
+    maxPages: MAX_PAGES,
+    timeBudgetMs: TIME_BUDGET_MS,
+  });
+
+  assert.equal(callCount, 3);
+  assert.equal(result.truncated, "repeated_cursor");
+});
+
+// ─── 가드 4: 시간 예산 ───────────────────────────────────────────────────────
+
+test("fetchAllPaged: 시간 예산 초과 시 max_pages(50)보다 먼저 멈추고 부분 결과를 반환한다", async () => {
+  // 수용 기준: "시간 예산 만료 시 부분 결과와 잘림 표시를 반환할 것"
+  let callCount = 0;
+  let clock = 0;
+  const fetchPage = async () => {
+    callCount += 1;
+    clock += 50_000; // 페이지당 50초 시뮬레이션 → 2번째 호출 후 clock=100_000 > 90_000
+    return {
+      body: {
+        output1: [{ pdno: String(callCount).padStart(6, "0") }],
+        output2: [],
+        // 시간 예산 경로를 타려면 커서가 있어야 한다 (없으면 no_cursor가 먼저 걸림)
+        ctx_area_fk100: `FK${callCount}`,
+        ctx_area_nk100: `NK${callCount}`,
+      },
+      trCont: "F",
+    };
+  };
+
+  const result = await fetchAllPaged(fetchPage, {
+    maxPages: MAX_PAGES,
+    timeBudgetMs: TIME_BUDGET_MS,
+    now: () => clock,
+  });
+
+  // 1회: clock=50_000 (아직 90_000 미만 → 계속)
+  // 2회: clock=100_000 > 90_000 → 3회 진입 시 time_budget 가드 발동
+  assert.equal(callCount, 2);
+  assert.equal(result.truncated, "time_budget");
+  assert.equal(result.rows.length, 2);
+  assert.ok(result.pages < MAX_PAGES, `pages(${result.pages})가 MAX_PAGES(${MAX_PAGES})보다 작아야 함`);
+});
+
+// ─── 수용 기준: rows.length === 0이어도 잘림 표시 ────────────────────────────
+
+test("fetchAllPaged: rows가 없어도 truncated 값이 반환돼 호출자가 잘림 안내를 표시할 수 있다", async () => {
+  // 수용 기준: "잘림 표시가 rows.length === 0인 경우에도 나올 것"
+  // index.js의 formatDailyOrderCcldReport / balance-rlz-pl-report.js의
+  // formatBalanceRlzPlReport 둘 다 truncated를 받아 안내를 추가해야 한다.
+  let callCount = 0;
+  let clock = 0;
+  const fetchPage = async () => {
+    callCount += 1;
+    clock += 50_000;
+    return {
+      body: {
+        output1: [], // 행 없음
+        output2: [],
+        ctx_area_fk100: `FK${callCount}`,
+        ctx_area_nk100: `NK${callCount}`,
+      },
+      trCont: "F",
+    };
+  };
+
+  const result = await fetchAllPaged(fetchPage, {
+    maxPages: MAX_PAGES,
+    timeBudgetMs: TIME_BUDGET_MS,
+    now: () => clock,
+  });
+
+  assert.equal(result.rows.length, 0);
+  assert.notEqual(result.truncated, null);
+  assert.equal(result.truncated, "time_budget");
+});


### PR DESCRIPTION
## 배경

#147. `mcp-trading`의 연속조회 루프 셋 중 `fetchAllBalance`만 PR #131에서 강화됐고, `index.js`의 `fetchAllDailyOrderCcld`·`fetchAllBalanceRlzPl` 둘은 가드가 하나도 없었습니다.

| | fetchAllBalance | fetchAllDailyOrderCcld | fetchAllBalanceRlzPl |
| --- | --- | --- | --- |
| 커서 trim / no_cursor / 반복 감지 | O | **X** | **X** |
| 시간 예산 | 15초 | **없음** | **없음** |
| 테스트 | 13건 | **0건** | **0건** |

## 변경

`balance.js`에 공용 `fetchAllPaged(fetchPage, { maxPages, timeBudgetMs, now, label })`를 추출하고 세 루프를 전부 이관했습니다. 페이지 상한·시간 예산은 루프마다 다르므로 상수가 아니라 인자입니다. `isKisContinueTrCont` 중복도 함께 제거했습니다.

커밋을 3단계로 나눴습니다: 추출 → 이관 → 테스트.

## 수용 기준

| 기준 | 상태 |
| --- | --- |
| 공백 패딩 커서 + 연속 `tr_cont`에서 2회 이내 정지 | ✅ trim → `no_cursor` 가드로 1페이지에서 정지 |
| 시간 예산 만료 시 부분 결과 + 잘림 표시 | ✅ `truncated: "time_budget"` |
| `rows.length === 0`에서도 잘림 표시 | ✅ 빈 결과 분기에도 `truncationNote` 부착 |
| 잘림 안내가 `- `로 시작하지 않을 것 | ✅ `[안내]`로 시작 |
| `fetchAllBalance` 관측 동작 불변 | ✅ 기존 13건 포함 전부 green |

## 시간 예산 값의 근거

90초로 정했습니다. 호출자는 NAT 일지 에이전트(`diary_agent.yml`, `timeout_sec: 120`)이고, `kisAxios` 요청당 8초 + 기동 ~2초를 빼면 헤드룸이 ~110초입니다. `90 + 8 + 2 = 100 < 120`이라 상한 안에 안전하게 들어옵니다.

**한계를 명시합니다**: 실제 페이지당 지연 측정치가 없어 "정상 부하의 몇 배"인지는 말할 수 없습니다. 측정치가 확보되면 재조정이 필요하다는 주석을 코드에 남겼습니다.

## 검증 (직접 실행)

`npm test` **121 pass / 0 fail (main) → 130 pass / 0 fail** (+9건).

가드 4종을 뮤테이션으로 확인했습니다.

| 뮤턴트 | 결과 |
| --- | --- |
| 커서 `.trim()` 제거 (공백 패딩 통과) | 3 fail ✅ |
| `no_cursor` 가드 제거 | 5 fail ✅ |
| 시간 예산 제거 | 3 fail ✅ |
| 페이지 상한 제거 | 1 fail ✅ |

## 검증하지 못한 것 — 반드시 읽어주세요

**KIS가 공백 커서에 실제로 어떻게 응답하는지는 확인하지 못했습니다.** 실계좌 호출이 필요한데 그럴 수 없었습니다. 이슈 본문이 지적한 "50배 중복 행" 시나리오는 `inquire-balance`에서 관찰된 동작을 다른 두 TR에 유추한 것이고, 이 PR도 그 유추를 확인하지 못했습니다.

다만 이슈 본문이 적은 대로 *"전제가 어떻게 나오든 가드 자체는 값어치가 있습니다 — 이미 강화된 세 번째 루프와 나머지 둘의 격차를 없애는 것이므로 KIS 동작과 무관하게 참"* 이라 판단해 진행했습니다. 실측이 가능해지면 `inquire-daily-ccld`를 한 번 호출해 `ctx_area_nk100` 원시 바이트를 찍어보는 것이 여전히 가장 값싼 위험 제거입니다.

## 처리하지 않은 것 — 유량 제한

이슈가 *"시간 예산은 50번 연속 호출 자체를 막지 못한다. 페이지 간 지연이나 상한 하향이 직접적 완화책"* 이라고 적었으나 **이 PR에서는 처리하지 않았습니다.**

이유: 수용 기준 5개에 포함되지 않고, 페이지 간 지연을 넣으면 `fetchAllBalance`에도 함께 적용되어 마지막 수용 기준인 "관측 가능한 동작 불변"과 충돌합니다. 별도 판단이 필요한 항목이라 분리하는 것이 맞다고 봅니다.

## 범위 밖

이슈 본문의 "#149와 함께 처리" 절은 무시했습니다 — 테스트 파일 분리는 이미 완료돼 있습니다.

Closes #147