### PR TITLE
chore: 효과 없는 eslint-disable-line 주석을 의도 전달 주석으로 교체 (#194)

### DIFF
--- a/mcp-trading/tests/kis-client.test.js
+++ b/mcp-trading/tests/kis-client.test.js
@@ -310,7 +310,7 @@ test("kisOrderPost: throws a named error identifying the missing dependency when
 // the original string would fail.
 test("kisOrderPost: a bare string thrown by getAccessToken propagates unchanged instead of crashing on the tagging assignment", async () => {
   const getAccessToken = async () => {
-    throw "token service unavailable"; // eslint-disable-line no-throw-literal -- exercising the primitive-error guard
+    throw "token service unavailable"; // 의도적으로 원시 문자열을 던져 에러 태깅 할당(error.kisOrderSubmittedMaybe) 전 타입 가드를 검증한다
   };
   const kisAxios = fakeAxios({
     post: async () => { throw new Error("no HTTP call should happen"); },
@@ -339,7 +339,7 @@ test("kisOrderPost: a bare string thrown by the order POST propagates unchanged 
   const getAccessToken = async () => "test-token";
   const kisAxios = fakeAxios({
     post: async () => {
-      throw "socket hang up"; // eslint-disable-line no-throw-literal -- exercising the primitive-error guard
+      throw "socket hang up"; // 의도적으로 원시 문자열을 던져 KIS POST 후 에러 태깅 할당 전 타입 가드를 검증한다
     },
   });
 

--- a/mcp-trading/tests/kis-client.test.js
+++ b/mcp-trading/tests/kis-client.test.js
@@ -310,7 +310,7 @@ test("kisOrderPost: throws a named error identifying the missing dependency when
 // the original string would fail.
 test("kisOrderPost: a bare string thrown by getAccessToken propagates unchanged instead of crashing on the tagging assignment", async () => {
   const getAccessToken = async () => {
-    throw "token service unavailable"; // 의도적으로 원시 문자열을 던져 에러 태깅 할당(error.kisOrderSubmittedMaybe) 전 타입 가드를 검증한다
+    throw "token service unavailable"; // 의도적으로 원시 문자열을 던져 pre-flight 에러 태깅 할당(error.kisOrderNotSubmitted) 전 타입 가드를 검증한다
   };
   const kisAxios = fakeAxios({
     post: async () => { throw new Error("no HTTP call should happen"); },
@@ -339,7 +339,7 @@ test("kisOrderPost: a bare string thrown by the order POST propagates unchanged 
   const getAccessToken = async () => "test-token";
   const kisAxios = fakeAxios({
     post: async () => {
-      throw "socket hang up"; // 의도적으로 원시 문자열을 던져 KIS POST 후 에러 태깅 할당 전 타입 가드를 검증한다
+      throw "socket hang up"; // 의도적으로 원시 문자열을 던져 POST 에러 태깅 할당(error.kisOrderSubmittedMaybe) 전 타입 가드를 검증한다
     },
   });
 

--- a/mcp-trading/tests/order-submit.test.js
+++ b/mcp-trading/tests/order-submit.test.js
@@ -213,7 +213,7 @@ test("submitOrder: a non-Error thrown by markSucceeded (e.g. a plain string) doe
   const consoleError = t.mock.method(console, "error", () => {});
   const store = {
     markSucceeded() {
-      throw "disk full"; // eslint-disable-line no-throw-literal -- simulating a non-Error rejection
+      throw "disk full"; // 의도적으로 문자열을 던져 markSucceeded catch 블록의 error.message 무가드 참조를 잡는다
     },
   };
 
@@ -232,7 +232,7 @@ test("submitOrder: a non-Error value thrown by submit() (e.g. null) does not cra
   const { releaseCalls, store } = stubStore();
 
   await assert.rejects(
-    () => submitOrder({ dedupStore: store, dedupKey: "order-key-null-throw", submit: async () => { throw null; } }), // eslint-disable-line no-throw-literal
+    () => submitOrder({ dedupStore: store, dedupKey: "order-key-null-throw", submit: async () => { throw null; } }), // 의도적으로 null을 던져 submit() 거부 시 error.kisOrderRejected 등 property 접근의 무가드 참조를 잡는다
     (err) => err === null,
   );
   assert.deepEqual(releaseCalls, [], "a non-Error rejection must default to fail-closed (no release)");

--- a/mcp-trading/tests/order-submit.test.js
+++ b/mcp-trading/tests/order-submit.test.js
@@ -26,6 +26,25 @@ function tempDedupLedgerPath(t) {
   return path.join(dir, "ledger.json");
 }
 
+// release(key) → releaseCalls 기록, withMarkSucceededGuard=true 시 markSucceeded 가드 추가
+// (submit()이 throw할 때 markSucceeded가 절대 호출되지 않아야 하는 테스트용)
+function stubStore({ withMarkSucceededGuard = false } = {}) {
+  const releaseCalls = [];
+  return {
+    releaseCalls,
+    store: {
+      release: (key) => releaseCalls.push(key),
+      ...(withMarkSucceededGuard
+        ? {
+            markSucceeded() {
+              throw new Error("markSucceeded should not run when submit() throws");
+            },
+          }
+        : {}),
+    },
+  };
+}
+
 // Mutation this catches: moving markSucceeded back inside the try (or letting any
 // exception from it flow into the shared catch) so that a ledger write failure is
 // treated the same as an order failure — release() gets called and/or the success
@@ -95,15 +114,7 @@ test("submitOrder: after a markSucceeded failure, the ledger entry stays in plac
 // from before #161: KIS explicitly said rt_cd !== "0", so nothing was submitted and
 // the guard must be released for a legitimate retry.
 test("submitOrder: releases the dedup guard when KIS rejects the order (rt_cd !== \"0\") — unchanged behavior", async (t) => {
-  const releaseCalls = [];
-  const store = {
-    release(key) {
-      releaseCalls.push(key);
-    },
-    markSucceeded() {
-      throw new Error("markSucceeded should not run when submit() throws");
-    },
-  };
+  const { releaseCalls, store } = stubStore({ withMarkSucceededGuard: true });
 
   const rejected = new Error("KIS API 오류: 주문가능금액을 초과하였습니다.");
   rejected.kisOrderRejected = true;
@@ -123,15 +134,7 @@ test("submitOrder: releases the dedup guard when KIS rejects the order (rt_cd !=
 // full TTL and DuplicateOrderError tells the user to "check the order shortly" for an
 // order that provably never existed, with no escape except changing quantity/price.
 test("submitOrder: releases the dedup guard when the KIS POST never went out (kisOrderNotSubmitted, e.g. token/hashkey pre-flight failure)", async (t) => {
-  const releaseCalls = [];
-  const store = {
-    release(key) {
-      releaseCalls.push(key);
-    },
-    markSucceeded() {
-      throw new Error("markSucceeded should not run when submit() throws");
-    },
-  };
+  const { releaseCalls, store } = stubStore({ withMarkSucceededGuard: true });
 
   const notSubmitted = new Error("Access Token 발급 실패: EGW00133 초당 거래건수를 초과하였습니다.");
   notSubmitted.kisOrderNotSubmitted = true;
@@ -149,12 +152,7 @@ test("submitOrder: releases the dedup guard when the KIS POST never went out (ki
 // received the order is unknown — releasing here could let a duplicate through while
 // the original order might still be live, so the guard must stay (fail-closed).
 test("submitOrder: does not release the dedup guard when the axios POST fails and submission status is unknown — unchanged behavior", async (t) => {
-  const releaseCalls = [];
-  const store = {
-    release(key) {
-      releaseCalls.push(key);
-    },
-  };
+  const { releaseCalls, store } = stubStore();
 
   const submitFailure = new Error("connect ETIMEDOUT");
   submitFailure.kisOrderSubmittedMaybe = true;
@@ -172,12 +170,7 @@ test("submitOrder: does not release the dedup guard when the axios POST fails an
 // application code unrelated to the KIS call) must default to NOT releasing — the old
 // code's `!error.kisOrderSubmittedMaybe` fell through to release() here instead.
 test("submitOrder: does not release the dedup guard for an error with none of the three recognized flags (inversion of pre-#161 behavior, which released here)", async (t) => {
-  const releaseCalls = [];
-  const store = {
-    release(key) {
-      releaseCalls.push(key);
-    },
-  };
+  const { releaseCalls, store } = stubStore();
 
   const unrecognizedError = new TypeError("Cannot read properties of undefined (reading 'output')");
 
@@ -236,12 +229,7 @@ test("submitOrder: a non-Error thrown by markSucceeded (e.g. a plain string) doe
 // unguarded when submit() itself rejects with a non-Error value (e.g. `throw null`,
 // which real code should never do, but a defensive guard must still not crash on it).
 test("submitOrder: a non-Error value thrown by submit() (e.g. null) does not crash and defaults to not releasing", async (t) => {
-  const releaseCalls = [];
-  const store = {
-    release(key) {
-      releaseCalls.push(key);
-    },
-  };
+  const { releaseCalls, store } = stubStore();
 
   await assert.rejects(
     () => submitOrder({ dedupStore: store, dedupKey: "order-key-null-throw", submit: async () => { throw null; } }), // eslint-disable-line no-throw-literal


### PR DESCRIPTION
> **⚠️ 이 PR은 #199(이슈 #193) 위에 쌓여 있습니다.** 같은 파일(`order-submit.test.js`)을 건드려 충돌을 피하려고 그 브랜치 위에서 작업했습니다. 따라서 **커밋 목록에 #199의 커밋(`045dd78`)이 함께 보입니다.**
>
> **#199를 먼저 머지해 주세요.** 그러면 이 PR의 diff는 아래 4줄짜리 주석 변경만 남습니다. (base를 `test/issue-193-stub-store-helper`로 잡으려 했으나, 그 브랜치가 fork에만 있어 GitHub이 크로스 저장소 base를 허용하지 않았습니다.)
>
> 이 PR 고유의 변경만 보려면: `git diff 045dd78..HEAD`

## 배경

#194. `eslint-disable-line` 주석이 있으나 저장소에 ESLint가 없어 아무 효과가 없는 상태였습니다.

확인한 사실:
- `git ls-files | grep -iE "eslintrc|eslint\.config"` → **0건** (저장소 전체)
- `frontend-react/`에도 eslint 설정·lint 스크립트 **없음** (있었다면 거기서는 주석이 유효하므로 손대지 않을 계획이었으나, 실제로 없었습니다)
- `mcp-trading/package.json` scripts → `{"test": "node --test tests/*.test.js"}` 뿐

## 변경

ESLint는 도입하지 않고, 주석을 **의도를 전달하는 일반 주석**으로 바꿨습니다. 각 지점이 어떤 회귀를 잡는 테스트인지 읽고 개별 문구를 썼습니다.

이슈에는 2곳으로 적혀 있었으나, 저장소 전체 grep으로 **`kis-client.test.js`에서 2곳을 더 찾아 총 4곳**을 처리했습니다.

| 파일 | 바뀐 문구 |
| --- | --- |
| `kis-client.test.js:313` | 의도적으로 원시 문자열을 던져 에러 태깅 할당(`error.kisOrderSubmittedMaybe`) 전 타입 가드를 검증한다 |
| `kis-client.test.js:342` | 의도적으로 원시 문자열을 던져 KIS POST 후 에러 태깅 할당 전 타입 가드를 검증한다 |
| `order-submit.test.js:216` | 의도적으로 문자열을 던져 `markSucceeded` catch 블록의 `error.message` 무가드 참조를 잡는다 |
| `order-submit.test.js:235` | 의도적으로 `null`을 던져 `submit()` 거부 시 `error.kisOrderRejected` 등 property 접근의 무가드 참조를 잡는다 |

## 검증 (직접 실행)

- `npm test` — **121 pass / 0 fail** (변경 전과 동일)
- 저장소 전체 `eslint-disable` 잔존 — **0건**
- `git diff 045dd78..HEAD`에서 주석 외 변경 **0건** 확인

Closes #194