### PR TITLE
fix: 도구 없는 provider가 매매 판단을 생성하지 않도록 하고 출처를 명시 (#162)

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -66,6 +66,77 @@ def _run_schema_migrations() -> None:
                 raise
 
 
+# A (#162): decision/confidence_score를 nullable로 변경하는 테이블 재생성.
+# SQLite는 ALTER TABLE로 NOT NULL constraint 제거가 불가능하므로 (공식 권장:
+# CREATE new → INSERT SELECT → DROP old → RENAME), 부팅 시 필요한 경우에만 실행.
+# _run_schema_migrations()가 provider_supports_tools 컬럼을 먼저 추가하므로,
+# 이 함수가 실행될 때 해당 컬럼은 항상 존재한다.
+_RECREATE_AGENTREPORT_NULLABLE_DDL = (
+    "CREATE TABLE agentreport_new ("
+    "id INTEGER PRIMARY KEY, "
+    "stock_code VARCHAR NOT NULL, "
+    "stock_name VARCHAR NOT NULL, "
+    "provider VARCHAR NOT NULL, "
+    "summary VARCHAR NOT NULL, "
+    "decision VARCHAR, "            # nullable: 도구 없는 provider는 null
+    "confidence_score FLOAT, "      # nullable: 도구 없는 provider는 null
+    "reason VARCHAR NOT NULL DEFAULT '', "
+    "provider_supports_tools BOOLEAN NOT NULL DEFAULT 0, "
+    "created_at DATETIME NOT NULL"
+    ")"
+)
+_RECREATE_AGENTREPORT_COLS = (
+    "id, stock_code, stock_name, provider, summary, decision, "
+    "confidence_score, reason, provider_supports_tools, created_at"
+)
+
+
+def _run_table_recreate_migrations() -> None:
+    """decision/confidence_score 컬럼을 nullable로 변경하는 agentreport 테이블 재생성.
+
+    기존 행은 모두 NOT NULL 시절 저장돼 있으므로 decision/confidence_score 값을
+    그대로 유지한다(NULL이 아닌 기존 값은 보존). 새로 저장하는 도구 없는 provider
+    리포트만 NULL로 기록된다.
+
+    주의: BOOLEAN NOT NULL DEFAULT 0, VARCHAR 타입명, "duplicate column" 등의 문자열은
+    SQLite 전용이다. 다른 방언으로 전환할 때는 alembic을 도입해야 한다.
+    """
+    if engine.dialect.name != "sqlite":
+        raise RuntimeError(
+            f"테이블 재생성 마이그레이션은 SQLite 전용입니다 (현재: {engine.dialect.name}). "
+            "다른 DB로 옮기려면 alembic을 도입하세요."
+        )
+    inspector = inspect(engine)
+    if "agentreport" not in inspector.get_table_names():
+        # create_all이 최신 스키마(nullable decision/confidence_score)로 새로 만들었으므로
+        # 건드릴 필요 없음
+        return
+
+    col_info = {col["name"]: col for col in inspector.get_columns("agentreport")}
+    decision_col = col_info.get("decision")
+    if decision_col is None or decision_col.get("nullable", True):
+        # 컬럼이 없거나(create_all이 최신 스키마로 만든 경우) 이미 nullable이면 skip
+        return
+
+    # decision이 NOT NULL인 경우: 테이블 재생성으로 nullable로 변경
+    try:
+        with engine.begin() as conn:
+            conn.execute(text(_RECREATE_AGENTREPORT_NULLABLE_DDL))
+            conn.execute(text(
+                f"INSERT INTO agentreport_new ({_RECREATE_AGENTREPORT_COLS}) "
+                f"SELECT {_RECREATE_AGENTREPORT_COLS} FROM agentreport"
+            ))
+            conn.execute(text("DROP TABLE agentreport"))
+            conn.execute(text("ALTER TABLE agentreport_new RENAME TO agentreport"))
+    except OperationalError as exc:
+        # 동시 실행된 워커가 이미 재생성을 완료했는지 재확인한다.
+        refreshed = {col["name"]: col for col in inspect(engine).get_columns("agentreport")}
+        refreshed_col = refreshed.get("decision")
+        if refreshed_col is not None and refreshed_col.get("nullable", True):
+            return  # 다른 워커가 이미 완료한 상태
+        raise
+
+
 def init_db():
     """
     데이터베이스 테이블을 초기화합니다.
@@ -76,6 +147,7 @@ def init_db():
         if "already exists" not in str(exc).lower():
             raise
     _run_schema_migrations()
+    _run_table_recreate_migrations()
 
 def get_session():
     """

--- a/backend/database.py
+++ b/backend/database.py
@@ -89,6 +89,14 @@ _RECREATE_AGENTREPORT_COLS = (
     "id, stock_code, stock_name, provider, summary, decision, "
     "confidence_score, reason, provider_supports_tools, created_at"
 )
+# DROP TABLE은 그 테이블에 딸린 인덱스도 함께 지운다. 재생성 후 다시 만들지 않으면
+# models.py의 index=True로 선언된 stock_code·stock_name 인덱스가 영구히 사라진다 —
+# 테이블이 이미 존재하므로 create_all()은 다시 만들어 주지 않는다. 이름은 SQLModel이
+# 붙이는 규칙(ix_<table>_<column>)을 그대로 따라야 create_all()과 충돌하지 않는다.
+_RECREATE_AGENTREPORT_INDEX_DDL = (
+    "CREATE INDEX IF NOT EXISTS ix_agentreport_stock_code ON agentreport (stock_code)",
+    "CREATE INDEX IF NOT EXISTS ix_agentreport_stock_name ON agentreport (stock_name)",
+)
 
 
 def _run_table_recreate_migrations() -> None:
@@ -128,6 +136,8 @@ def _run_table_recreate_migrations() -> None:
             ))
             conn.execute(text("DROP TABLE agentreport"))
             conn.execute(text("ALTER TABLE agentreport_new RENAME TO agentreport"))
+            for index_sql in _RECREATE_AGENTREPORT_INDEX_DDL:
+                conn.execute(text(index_sql))
     except OperationalError as exc:
         # 동시 실행된 워커가 이미 재생성을 완료했는지 재확인한다.
         refreshed = {col["name"]: col for col in inspect(engine).get_columns("agentreport")}

--- a/backend/database.py
+++ b/backend/database.py
@@ -89,6 +89,12 @@ _RECREATE_AGENTREPORT_COLS = (
     "id, stock_code, stock_name, provider, summary, decision, "
     "confidence_score, reason, provider_supports_tools, created_at"
 )
+# Improvement #1 (#162 리뷰): 재생성 직전 실제 컬럼 집합과 DDL 가정을 비교하는 단언에 쓴다.
+# _PENDING_COLUMN_MIGRATIONS에 agentreport 컬럼이 추가되어도 이 집합을 갱신하지 않으면
+# 부팅 실패(RuntimeError)로 드러난다 — DDL을 갱신하기 전까지는 재생성을 막는다.
+_RECREATE_AGENTREPORT_COL_SET: frozenset[str] = frozenset(
+    c.strip() for c in _RECREATE_AGENTREPORT_COLS.split(",")
+)
 # DROP TABLE은 그 테이블에 딸린 인덱스도 함께 지운다. 재생성 후 다시 만들지 않으면
 # models.py의 index=True로 선언된 stock_code·stock_name 인덱스가 영구히 사라진다 —
 # 테이블이 이미 존재하므로 create_all()은 다시 만들어 주지 않는다. 이름은 SQLModel이
@@ -126,9 +132,32 @@ def _run_table_recreate_migrations() -> None:
         # 컬럼이 없거나(create_all이 최신 스키마로 만든 경우) 이미 nullable이면 skip
         return
 
+    # Improvement #1 (#162 리뷰): 실제 컬럼 집합이 DDL의 가정과 일치하는지 단언한다.
+    # _run_schema_migrations()가 새 컬럼 X를 ALTER로 추가한 뒤 이 함수가 X 없는 테이블을
+    # 만들면 X와 그 데이터가 조용히 소실된다. 불일치 시 명시적 부팅 실패로 만든다.
+    actual_cols = set(col_info.keys())
+    if actual_cols != _RECREATE_AGENTREPORT_COL_SET:
+        raise RuntimeError(
+            "agentreport 스키마가 재생성 DDL의 가정과 다릅니다. DDL을 갱신하지 않으면 "
+            f"차이나는 컬럼이 소실됩니다: DB에만 있음={sorted(actual_cols - _RECREATE_AGENTREPORT_COL_SET)}, "
+            f"DDL에만 있음={sorted(_RECREATE_AGENTREPORT_COL_SET - actual_cols)}"
+        )
+
     # decision이 NOT NULL인 경우: 테이블 재생성으로 nullable로 변경
     try:
         with engine.begin() as conn:
+            # Critical fix (#162 리뷰): 이전 시도가 중단되어 남겨진 고아 테이블을 먼저 회수한다.
+            # pysqlite는 DML에서만 암묵적으로 BEGIN하므로 CREATE TABLE은 engine.begin()
+            # 진입 시점에도 autocommit으로 즉시 커밋된다. SIGTERM/OOM kill/디스크 부족 등으로
+            # 마이그레이션이 중단되면 agentreport_new가 디스크에 남고, 다음 부팅에서
+            # CREATE TABLE "already exists" → 재확인에서 decision이 여전히 NOT NULL →
+            # raise → init_db() 실패 → 영구 부팅 불능이 된다.
+            # DROP TABLE IF EXISTS는 이 경로를 차단한다. 테이블이 없으면 no-op.
+            #
+            # 주의: 동시 워커 A가 CREATE TABLE을 커밋한 직후 B가 DROP하면 A의 진행 중
+            # 테이블이 사라진다. 현재 배포(단일 프로세스)에서는 해당 없다. 다중 워커가
+            # 필요해지면 engine 이벤트로 BEGIN IMMEDIATE를 선점해 직렬화해야 한다.
+            conn.execute(text("DROP TABLE IF EXISTS agentreport_new"))
             conn.execute(text(_RECREATE_AGENTREPORT_NULLABLE_DDL))
             conn.execute(text(
                 f"INSERT INTO agentreport_new ({_RECREATE_AGENTREPORT_COLS}) "

--- a/backend/models.py
+++ b/backend/models.py
@@ -36,9 +36,25 @@ class AgentReport(SQLModel, table=True):
     stock_name: str = Field(index=True, description="분석 종목명")
     provider: str = Field(description="사용된 LLM 제공자 (openai, anthropic 등)")
     summary: str = Field(description="분석 요약")
-    decision: str = Field(description="투자 결정 (BUY/SELL/HOLD)")
-    confidence_score: float = Field(description="신뢰도 점수 (0.0~1.0)")
-    reason: str = Field(description="투자 결정 근거")
+    # A (#162): provider_supports_tools=False인 provider(openai/anthropic/ollama)는
+    # 도구 없이 매매 판단을 생성하지 않는다. 이 경우 두 필드는 null이다.
+    # null과 "HOLD"/0.0의 의미가 다르다 — null은 "판단 없음"이고
+    # "HOLD"/0.0은 NAT이 판단한 관망 의견이다.
+    decision: Optional[str] = Field(
+        default=None,
+        description=(
+            "투자 결정 (BUY/SELL/HOLD). provider_supports_tools=True인 provider(nat)만 생성한다. "
+            "도구 없는 provider(openai/anthropic/ollama)는 null."
+        ),
+    )
+    confidence_score: Optional[float] = Field(
+        default=None,
+        description=(
+            "신뢰도 점수 (0.0~1.0). provider_supports_tools=True인 provider(nat)만 생성한다. "
+            "도구 없는 provider(openai/anthropic/ollama)는 null."
+        ),
+    )
+    reason: str = Field(default="", description="투자 결정 근거. 도구 없는 provider는 빈 문자열.")
     # provider 차원의 "능력" 신호 — 실제 도구 호출 관측이 아님 (#162):
     # - openai/anthropic/ollama: tools 파라미터 없이 모델 직접 호출 → False는 코드로 증명 가능
     # - nat=True: NAT 멀티에이전트로 라우팅됐다는 뜻이며, 그 안에서 실제 도구가

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -10,7 +10,9 @@ class TradingSignal(BaseModel):
 
 class AnalysisReport(BaseModel):
     summary: str
-    details: TradingSignal
+    # A (#162): 도구 없는 provider(openai/anthropic/ollama)는 매매 판단을 생성하지 않으므로
+    # details=None이다. provider=nat만 TradingSignal을 채운다.
+    details: TradingSignal | None = None
     source_news: list[str]
     source_signals: list[str] | None = None
     trading_trend: str | None = None

--- a/backend/services.py
+++ b/backend/services.py
@@ -198,31 +198,29 @@ def _nat_conversation_id(
     return f"{prefix}:{safe_stock}:{today}"
 
 
-async def perform_stock_analysis(
-    stock: str,
-    provider: str,
-    session: Session,
-    *,
-    trigger_source: str | None = None,
-    trigger_signal: str | None = None,
-    conversation_id: str | None = None,
-) -> dict[str, Any]:
-    """
-    종목 분석을 수행하고 결과를 DB에 저장한 뒤 반환합니다.
-    API 엔드포인트와 백그라운드 스케줄러에서 공용으로 사용됩니다.
-    """
-    trigger_context = ""
-    if trigger_signal:
-        source_label = trigger_source or "signal"
-        trigger_context = (
-            f"\n분석 트리거 데이터 출처: {source_label}\n"
-            f"--- 트리거 데이터 ---\n{trigger_signal[:4000]}\n"
-            "------------------\n"
-            "위 트리거 데이터를 투자 판단의 주요 근거로 반영하라. "
-            "필요하면 라우터·서브에이전트로 보조 시장 데이터를 추가 확인하라.\n"
-        )
+def _build_trigger_context(
+    trigger_source: str | None,
+    trigger_signal: str | None,
+) -> str:
+    """trigger_signal이 있을 때 프롬프트에 삽입할 컨텍스트 블록을 만든다."""
+    if not trigger_signal:
+        return ""
+    source_label = trigger_source or "signal"
+    return (
+        f"\n분석 트리거 데이터 출처: {source_label}\n"
+        f"--- 트리거 데이터 ---\n{trigger_signal[:4000]}\n"
+        "------------------\n"
+        "위 트리거 데이터를 투자 판단의 주요 근거로 반영하라. "
+        "필요하면 라우터·서브에이전트로 보조 시장 데이터를 추가 확인하라.\n"
+    )
 
-    user_msg = (
+
+def _build_nat_prompt(stock: str, trigger_context: str) -> str:
+    """NAT 멀티에이전트용 프롬프트. 도구를 활용해 BUY/SELL/HOLD 판단을 생성한다.
+
+    provider=nat 경로 전용이며, provider_supports_tools=True인 경우에만 호출한다.
+    """
+    return (
         f"종목: {stock}. 라우터·서브에이전트를 활용해 투자 관점 분석을 하라. "
         f"{trigger_context}"
         "Telegram 알림은 매우 긴급한 경우에만 사용한다. "
@@ -243,32 +241,131 @@ async def perform_stock_analysis(
         '"urgency_reason":"긴급 판단 사유 한 줄 또는 null",'
         '"telegram_alert":true|false}'
     )
-    
+
+
+def _build_toolless_prompt(stock: str, trigger_context: str) -> str:
+    """도구 없는 provider(openai/anthropic/ollama)용 프롬프트.
+
+    실시간 시장 데이터(MCP/KIS/뉴스)에 접근하지 못하므로 BUY/SELL/HOLD 판단과
+    신뢰도 점수를 생성하지 않는다 (#162 A). 일반적 배경 설명만 허용한다.
+    """
+    return (
+        f"종목: {stock}에 대한 일반적인 배경 정보와 투자 관련 개요를 설명하라. "
+        f"{trigger_context}"
+        "이 요청은 실시간 시장 데이터(공시·수급·뉴스 도구)에 접근하지 않는다. "
+        "따라서 BUY/SELL/HOLD 판단이나 신뢰도 점수를 생성하지 않는다 — "
+        "데이터 없이 만들어진 매매 신호는 소비자를 오도할 수 있다. "
+        "답변 마지막에 **다음 JSON 한 개만** 출력하라 (다른 텍스트 없이도 됨):\n"
+        '{"summary":"한 줄 설명",'
+        '"source_news":[],'
+        '"source_signals":[],'
+        '"trading_trend":null,'
+        '"urgency":"normal",'
+        '"urgency_reason":null,'
+        '"telegram_alert":false}'
+    )
+
+
+def _analysis_from_toolless_text(raw: str, stock: str) -> dict[str, Any]:
+    """도구 없는 provider 응답 파싱. details(decision/confidence_score)는 생성하지 않는다.
+
+    JSON 파싱에 성공하면 summary/source_news 등을 추출한다. 실패하면 원문을 요약으로
+    사용한다. 어느 경우에도 details=None을 유지한다 — None과 HOLD/0.0은 의미가 다르다.
+    """
+    text = (raw or "").strip()
+    for data in _json_objects_from_text(text):
+        try:
+            return {
+                "summary": str(data.get("summary") or text[:8000] or "빈 응답"),
+                "details": None,
+                "source_news": _string_list(data.get("source_news")),
+                "source_signals": _string_list(
+                    data.get("source_signals") or data.get("source_news")
+                ),
+                "trading_trend": data.get("trading_trend"),
+                "urgency": data.get("urgency", "normal"),
+                "urgency_reason": data.get("urgency_reason"),
+                "telegram_alert": bool(data.get("telegram_alert", False)),
+            }
+        except (ValueError, AttributeError):
+            pass
+    # JSON 파싱 실패: 원문을 요약으로 사용
+    return {
+        "summary": text[:8000] if text else "빈 응답",
+        "details": None,
+        "source_news": [],
+        "source_signals": [],
+        "trading_trend": None,
+        "urgency": "normal",
+        "urgency_reason": None,
+        "telegram_alert": False,
+    }
+
+
+async def perform_stock_analysis(
+    stock: str,
+    provider: str,
+    session: Session,
+    *,
+    trigger_source: str | None = None,
+    trigger_signal: str | None = None,
+    conversation_id: str | None = None,
+) -> dict[str, Any]:
+    """
+    종목 분석을 수행하고 결과를 DB에 저장한 뒤 반환합니다.
+    API 엔드포인트와 백그라운드 스케줄러에서 공용으로 사용됩니다.
+
+    provider=nat: NAT 멀티에이전트를 통해 도구(MCP/KIS/뉴스)를 호출하고
+    BUY/SELL/HOLD 판단·신뢰도 점수를 생성한다 (#162 A 불변).
+
+    provider=openai/anthropic/ollama: 도구 없이 일반 배경 설명만 생성한다.
+    decision·confidence_score는 저장하지 않는다 (DB와 API 응답 모두 null).
+    """
     key = normalize_llm_provider(provider)
+    supports_tools = provider_supports_tools(key)
+
+    trigger_context = _build_trigger_context(trigger_source, trigger_signal)
+
     nat_cid = conversation_id
     if key == "nat" and nat_cid is None:
         nat_cid = _nat_conversation_id(stock, trigger_source=trigger_source)
-    raw = await llm_chat(key, user_msg, conversation_id=nat_cid)
-    data = analysis_from_nat_text(str(raw), stock)
+
+    if supports_tools:
+        # NAT 멀티에이전트: 도구를 활용해 BUY/SELL/HOLD 판단 생성
+        user_msg = _build_nat_prompt(stock, trigger_context)
+        raw = await llm_chat(key, user_msg, conversation_id=nat_cid)
+        data = analysis_from_nat_text(str(raw), stock)
+        details = data.get("details") or {}
+        decision: str | None = details.get("decision") if isinstance(details, dict) else None
+        confidence_score: float | None = (
+            details.get("confidence_score") if isinstance(details, dict) else None
+        )
+        reason: str = details.get("reason", "") if isinstance(details, dict) else ""
+    else:
+        # 도구 없는 provider: 일반 설명만 생성, 매매 판단 없음
+        user_msg = _build_toolless_prompt(stock, trigger_context)
+        raw = await llm_chat(key, user_msg, conversation_id=nat_cid)
+        data = _analysis_from_toolless_text(str(raw), stock)
+        decision = None
+        confidence_score = None
+        reason = ""
 
     # #162: 이 값을 API 응답(data)과 DB 저장(report) 양쪽에 동일하게 붙인다 —
     # 소비자가 provider 문자열만 보고 도구 사용 여부를 스스로 추론하지 않게 한다.
-    supports_tools = provider_supports_tools(key)
     data["provider"] = key
     data["provider_supports_tools"] = supports_tools
 
     # 분석 리포트를 데이터베이스에 자동으로 저장
     try:
-        details = data.get("details", {})
         stock_code = await _resolve_stock_code(stock)
         report = AgentReport(
             stock_code=stock_code,
             stock_name=stock,
             provider=key,
             summary=data.get("summary", ""),
-            decision=details.get("decision", "HOLD"),
-            confidence_score=details.get("confidence_score", 0.0),
-            reason=details.get("reason", ""),
+            decision=decision,
+            confidence_score=confidence_score,
+            reason=reason,
             provider_supports_tools=supports_tools,
         )
         session.add(report)

--- a/backend/services.py
+++ b/backend/services.py
@@ -19,6 +19,7 @@ from .config import (
     NAT_BASE_URL, NAT_CHAT_MODEL, NAT_CONVERSATION_ID,
     NEWS_MCP_PARAMS, TRADING_MCP_PARAMS,
 )
+from pydantic import ValidationError
 from .schemas import TradingSignal, AnalysisReport
 from .models import AgentReport
 
@@ -266,40 +267,39 @@ def _build_toolless_prompt(stock: str, trigger_context: str) -> str:
     )
 
 
-def _analysis_from_toolless_text(raw: str, stock: str) -> dict[str, Any]:
+def _analysis_from_toolless_text(raw: str) -> dict[str, Any]:
     """도구 없는 provider 응답 파싱. details(decision/confidence_score)는 생성하지 않는다.
 
-    JSON 파싱에 성공하면 summary/source_news 등을 추출한다. 실패하면 원문을 요약으로
-    사용한다. 어느 경우에도 details=None을 유지한다 — None과 HOLD/0.0은 의미가 다르다.
+    JSON 파싱에 성공하면 summary/source_news 등을 추출하고 AnalysisReport로 스키마 검증한다.
+    실패하면 원문을 요약으로 사용한다. 어느 경우에도 details=None을 유지한다.
+
+    stock 파라미터는 이 함수 안에서 쓸 곳이 없다(details=None이므로 TradingSignal.target_stock
+    미사용) — Improvement #2 (#162 리뷰).
     """
     text = (raw or "").strip()
     for data in _json_objects_from_text(text):
         try:
-            return {
-                "summary": str(data.get("summary") or text[:8000] or "빈 응답"),
-                "details": None,
-                "source_news": _string_list(data.get("source_news")),
-                "source_signals": _string_list(
+            report = AnalysisReport(
+                summary=str(data.get("summary") or text[:8000] or "빈 응답"),
+                details=None,  # 도구 없는 provider는 매매 판단을 생성하지 않는다
+                source_news=_string_list(data.get("source_news")),
+                source_signals=_string_list(
                     data.get("source_signals") or data.get("source_news")
                 ),
-                "trading_trend": data.get("trading_trend"),
-                "urgency": data.get("urgency", "normal"),
-                "urgency_reason": data.get("urgency_reason"),
-                "telegram_alert": bool(data.get("telegram_alert", False)),
-            }
-        except (ValueError, AttributeError):
-            pass
-    # JSON 파싱 실패: 원문을 요약으로 사용
-    return {
-        "summary": text[:8000] if text else "빈 응답",
-        "details": None,
-        "source_news": [],
-        "source_signals": [],
-        "trading_trend": None,
-        "urgency": "normal",
-        "urgency_reason": None,
-        "telegram_alert": False,
-    }
+                trading_trend=data.get("trading_trend"),
+                urgency=data.get("urgency", "normal"),
+                urgency_reason=data.get("urgency_reason"),
+                telegram_alert=bool(data.get("telegram_alert", False)),
+            )
+        except ValidationError:
+            continue  # 관련 없는 JSON 객체(urgency 리터럴 위반 등) — 다음 후보로
+        return report.model_dump()
+    # JSON 파싱 실패 또는 유효한 후보 없음: 원문을 요약으로 사용
+    return AnalysisReport(
+        summary=text[:8000] if text else "빈 응답",
+        details=None,
+        source_news=[],
+    ).model_dump()
 
 
 async def perform_stock_analysis(
@@ -345,7 +345,7 @@ async def perform_stock_analysis(
         # 도구 없는 provider: 일반 설명만 생성, 매매 판단 없음
         user_msg = _build_toolless_prompt(stock, trigger_context)
         raw = await llm_chat(key, user_msg, conversation_id=nat_cid)
-        data = _analysis_from_toolless_text(str(raw), stock)
+        data = _analysis_from_toolless_text(str(raw))
         decision = None
         confidence_score = None
         reason = ""

--- a/backend/telegram_notifier.py
+++ b/backend/telegram_notifier.py
@@ -91,7 +91,9 @@ class TelegramNotifier:
         analysis_data: dict[str, Any],
     ) -> str:
         details = analysis_data.get("details") or {}
-        decision = details.get("decision", "HOLD")
+        # Improvement #3 (#162 리뷰): details=None은 도구 없는 provider — 판단이 존재하지 않는다.
+        # "HOLD"로 채우면 이 PR이 없애려는 "지어낸 판단" 문제를 알림 채널에서 재생산한다.
+        decision = details.get("decision") or "판단 없음 (도구 미사용 provider)"
         confidence = details.get("confidence_score", "")
         reason = details.get("reason") or analysis_data.get("summary", "")
         urgency = analysis_data.get("urgency", "normal")

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -177,25 +177,15 @@ def test_get_trades_empty(client: TestClient):
 
 @pytest.mark.asyncio
 async def test_analyze_stock_saves_report(client: TestClient, session: Session, monkeypatch):
-    # Mocking llm_chat and analysis_from_nat_text
+    # A (#162): openai는 도구 없는 경로(_build_toolless_prompt + _analysis_from_toolless_text)를
+    # 타므로 analysis_from_nat_text는 호출되지 않는다. llm_chat만 mocking한다.
     async def mock_llm_chat(*args, **kwargs):
         return "mocked raw response"
-
-    def mock_analysis_from_nat_text(raw_text, stock):
-        return {
-            "summary": f"Summary for {stock}",
-            "details": {
-                "decision": "BUY",
-                "confidence_score": 0.85,
-                "reason": "Strong momentum"
-            }
-        }
 
     async def mock_run_mcp_tool(*args, **kwargs):
         return "삼성전자 (005930, KOSPI)"
 
     monkeypatch.setattr("backend.services.llm_chat", mock_llm_chat)
-    monkeypatch.setattr("backend.services.analysis_from_nat_text", mock_analysis_from_nat_text)
     monkeypatch.setattr("backend.services.run_mcp_tool", mock_run_mcp_tool)
 
     # API Call
@@ -208,13 +198,16 @@ async def test_analyze_stock_saves_report(client: TestClient, session: Session, 
     # 않으면 이 두 줄이 깨진다.
     assert payload["provider"] == "openai"
     assert payload["provider_supports_tools"] is False
+    # A (#162): 도구 없는 provider는 매매 판단을 생성하지 않는다.
+    assert payload.get("details") is None
 
     # Verify DB save
     reports = session.query(AgentReport).all()
     assert len(reports) == 1
     assert reports[0].stock_name == "삼성전자"
-    assert reports[0].decision == "BUY"
-    assert reports[0].confidence_score == 0.85
+    # A (#162): 도구 없는 provider는 decision/confidence_score를 null로 저장한다.
+    assert reports[0].decision is None
+    assert reports[0].confidence_score is None
     assert reports[0].stock_code == "005930"
     # /api/v1/analyze의 기본 provider(openai)는 tools 없이 모델을 그대로 호출하므로
     # (#162) 저장되는 리포트는 도구를 쓸 수 없는 provider로 표시되어야 한다.

--- a/backend/tests/test_schema_migrations.py
+++ b/backend/tests/test_schema_migrations.py
@@ -243,3 +243,157 @@ def test_init_db_concurrent_on_empty_db_does_not_abort_startup(tmp_path, monkeyp
     columns = [row[1] for row in conn.execute("PRAGMA table_info(agentreport)")]
     conn.close()
     assert "provider_supports_tools" in columns
+
+
+# ── A (#162): decision/confidence_score nullable 마이그레이션 ────────────────
+
+
+def _create_post_c_schema_agentreport(db_path: str) -> None:
+    """PR #171(C 구현) 이후, 이 PR(A 구현) 이전의 agentreport 스키마를 재현한다.
+
+    _create_old_schema_agentreport는 Column(String) 기본값(nullable=True)을 쓰므로
+    decision/confidence_score가 이미 nullable이다. 반면 실제 배포된 DB는 SQLModel
+    `decision: str = Field(...)` 선언에서 NOT NULL로 만들어졌다. A 마이그레이션
+    (_run_table_recreate_migrations)이 실제로 NOT NULL → nullable 변환을 수행하는지
+    검증하려면 NOT NULL 컬럼을 가진 테이블이 필요하다.
+    """
+    import sqlite3
+    from sqlmodel import SQLModel
+
+    setup_engine = create_engine(f"sqlite:///{db_path}")
+    SQLModel.metadata.create_all(setup_engine)  # 최신 스키마로 다른 테이블들 생성
+    setup_engine.dispose()
+
+    conn = sqlite3.connect(db_path)
+    conn.execute("DROP TABLE agentreport")
+    conn.execute(
+        "CREATE TABLE agentreport ("
+        "id INTEGER PRIMARY KEY, "
+        "stock_code VARCHAR NOT NULL, "
+        "stock_name VARCHAR NOT NULL, "
+        "provider VARCHAR NOT NULL, "
+        "summary VARCHAR NOT NULL, "
+        "decision VARCHAR NOT NULL, "           # C 이전처럼 NOT NULL
+        "confidence_score FLOAT NOT NULL, "     # C 이전처럼 NOT NULL
+        "reason VARCHAR NOT NULL DEFAULT '', "
+        "provider_supports_tools BOOLEAN NOT NULL DEFAULT 0, "
+        "created_at DATETIME NOT NULL"
+        ")"
+    )
+    conn.execute(
+        "INSERT INTO agentreport "
+        "(stock_code, stock_name, provider, summary, decision, confidence_score, "
+        "reason, provider_supports_tools, created_at) "
+        "VALUES ('005930', '삼성전자', 'openai', '요약', 'BUY', 0.9, '지어낸 근거', 0, "
+        "'2026-01-01 00:00:00')"
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_init_db_makes_decision_and_confidence_score_nullable(tmp_path, monkeypatch):
+    """NOT NULL decision/confidence_score를 가진 구버전 DB에 init_db()를 실행하면
+    두 컬럼이 nullable로 변경되어야 한다. _run_table_recreate_migrations()가 호출되지
+    않거나 DDL에서 nullable을 제거하면 이 테스트가 깨진다.
+    """
+    import sqlite3
+
+    db_path = tmp_path / "post_c_schema_not_null.db"
+    _create_post_c_schema_agentreport(str(db_path))  # decision NOT NULL인 상태
+
+    test_engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+    monkeypatch.setattr(database, "engine", test_engine)
+
+    database.init_db()
+
+    conn = sqlite3.connect(str(db_path))
+    col_info = {row[1]: row for row in conn.execute("PRAGMA table_info(agentreport)")}
+    conn.close()
+
+    # notnull 비트(인덱스 3)가 0이어야 nullable
+    assert col_info["decision"][3] == 0, "decision이 여전히 NOT NULL이다"
+    assert col_info["confidence_score"][3] == 0, "confidence_score가 여전히 NOT NULL이다"
+
+
+def test_nullable_migration_preserves_existing_rows(tmp_path, monkeypatch):
+    """테이블 재생성 마이그레이션이 기존 데이터를 그대로 보존해야 한다.
+    INSERT SELECT가 빠지거나 컬럼 목록이 어긋나면 이 테스트가 깨진다.
+    """
+    import sqlite3
+
+    db_path = tmp_path / "preserve_rows.db"
+    _create_post_c_schema_agentreport(str(db_path))  # decision="BUY", confidence_score=0.9로 행 삽입됨
+
+    test_engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+    monkeypatch.setattr(database, "engine", test_engine)
+
+    database.init_db()
+
+    conn = sqlite3.connect(str(db_path))
+    rows = conn.execute(
+        "SELECT stock_name, decision, confidence_score, provider_supports_tools FROM agentreport"
+    ).fetchall()
+    conn.close()
+
+    assert len(rows) == 1
+    stock_name, decision, confidence_score, pst = rows[0]
+    assert stock_name == "삼성전자"
+    assert decision == "BUY"                     # 기존 NOT NULL 값은 보존
+    assert abs(confidence_score - 0.9) < 1e-9    # 기존 값 보존
+    assert pst == 0                               # provider_supports_tools 기본값 유지
+
+
+def test_nullable_migration_allows_null_decision_insert(tmp_path, monkeypatch):
+    """마이그레이션 후 decision/confidence_score에 NULL을 INSERT할 수 있어야 한다.
+    도구 없는 provider 리포트가 실제로 저장될 수 있는지 확인한다.
+    마이그레이션이 NOT NULL을 남겨두면 이 INSERT가 실패해 테스트가 깨진다.
+    """
+    import sqlite3
+
+    db_path = tmp_path / "null_insert.db"
+    _create_post_c_schema_agentreport(str(db_path))  # decision NOT NULL인 상태
+
+    test_engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+    monkeypatch.setattr(database, "engine", test_engine)
+
+    database.init_db()
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "INSERT INTO agentreport "
+        "(stock_code, stock_name, provider, summary, decision, confidence_score, "
+        "reason, provider_supports_tools, created_at) "
+        "VALUES ('005930', '삼성전자', 'openai', '배경 설명', NULL, NULL, "
+        "'', 0, '2026-01-02 00:00:00')"
+    )
+    conn.commit()
+    # created_at으로 새로 삽입한 행(도구 없는 provider)만 필터링한다.
+    # 기존 행('2026-01-01')과 구분하기 위해 날짜를 다르게 지정했다.
+    rows = conn.execute(
+        "SELECT decision, confidence_score FROM agentreport WHERE created_at='2026-01-02 00:00:00'"
+    ).fetchall()
+    conn.close()
+
+    assert len(rows) == 1
+    assert rows[0][0] is None   # decision=NULL
+    assert rows[0][1] is None   # confidence_score=NULL
+
+
+def test_nullable_migration_is_idempotent(tmp_path, monkeypatch):
+    """이미 nullable인 DB에 init_db()를 두 번 호출해도 예외 없이 통과해야 한다."""
+    import sqlite3
+
+    db_path = tmp_path / "idempotent_recreate.db"
+    _create_post_c_schema_agentreport(str(db_path))  # NOT NULL 상태에서 시작
+
+    test_engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+    monkeypatch.setattr(database, "engine", test_engine)
+
+    database.init_db()
+    database.init_db()  # 두 번째 호출에서 예외가 나면 테스트 실패
+
+    conn = sqlite3.connect(str(db_path))
+    columns = [row[1] for row in conn.execute("PRAGMA table_info(agentreport)")]
+    conn.close()
+    assert "decision" in columns
+    assert "confidence_score" in columns

--- a/backend/tests/test_schema_migrations.py
+++ b/backend/tests/test_schema_migrations.py
@@ -397,3 +397,57 @@ def test_nullable_migration_is_idempotent(tmp_path, monkeypatch):
     conn.close()
     assert "decision" in columns
     assert "confidence_score" in columns
+
+
+def _agentreport_index_names(db_path: str) -> list[str]:
+    import sqlite3
+
+    conn = sqlite3.connect(db_path)
+    try:
+        return sorted(
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='agentreport'"
+            )
+            if row[0] is not None
+        )
+    finally:
+        conn.close()
+
+
+def test_nullable_migration_preserves_indexes(tmp_path, monkeypatch):
+    """테이블 재생성 마이그레이션이 stock_code·stock_name 인덱스를 보존해야 한다.
+
+    DROP TABLE은 그 테이블에 딸린 인덱스도 함께 지운다. 재생성 후 CREATE INDEX를
+    다시 실행하지 않으면 models.py의 index=True로 선언된 두 인덱스가 영구히 사라진다 —
+    테이블이 이미 존재하므로 create_all()이 다시 만들어 주지 않기 때문에 조용한 성능
+    저하로만 남는다.
+
+    이 테스트가 잡는 mutation: _RECREATE_AGENTREPORT_INDEX_DDL 실행 루프 제거.
+    """
+    db_path = tmp_path / "preserve_indexes.db"
+    _create_post_c_schema_agentreport(str(db_path))
+
+    # 픽스처는 create_all이 만든 테이블을 DROP하고 인덱스 없이 다시 만든다.
+    # 실제 배포 DB에는 SQLModel이 붙인 인덱스가 있으므로 그 상태를 재현한다.
+    import sqlite3
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE INDEX ix_agentreport_stock_code ON agentreport (stock_code)")
+    conn.execute("CREATE INDEX ix_agentreport_stock_name ON agentreport (stock_name)")
+    conn.commit()
+    conn.close()
+
+    before = _agentreport_index_names(str(db_path))
+    assert before == ["ix_agentreport_stock_code", "ix_agentreport_stock_name"], (
+        f"이 테스트의 전제(마이그레이션 전 인덱스 2개 존재)가 깨졌습니다: {before}"
+    )
+
+    test_engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+    monkeypatch.setattr(database, "engine", test_engine)
+
+    database.init_db()
+
+    assert _agentreport_index_names(str(db_path)) == before, (
+        "테이블 재생성 마이그레이션이 인덱스를 잃었습니다"
+    )

--- a/backend/tests/test_schema_migrations.py
+++ b/backend/tests/test_schema_migrations.py
@@ -415,6 +415,79 @@ def _agentreport_index_names(db_path: str) -> list[str]:
         conn.close()
 
 
+def test_leftover_agentreport_new_does_not_prevent_migration(tmp_path, monkeypatch):
+    """Critical (#162 리뷰): agentreport_new가 이미 존재하는 DB에서도 init_db()가 성공해야 한다.
+
+    pysqlite는 DML에서만 암묵적으로 BEGIN하므로 CREATE TABLE agentreport_new는
+    engine.begin() 블록 진입 시점에도 autocommit으로 즉시 디스크에 커밋된다.
+    SIGTERM/OOM kill/디스크 부족 등으로 마이그레이션이 중단되면 agentreport_new가
+    남고, 다음 부팅에서 CREATE TABLE "already exists" → 재확인에서 decision이 여전히
+    NOT NULL → raise → 영구 부팅 불능이 된다.
+
+    이 테스트가 잡는 mutation: DROP TABLE IF EXISTS agentreport_new 줄 제거.
+    """
+    db_path = tmp_path / "leftover_new.db"
+    _create_post_c_schema_agentreport(str(db_path))  # agentreport: decision NOT NULL
+
+    # 이전 시도가 중단된 상황을 재현: agentreport_new 고아 테이블을 미리 만들어 둔다.
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE agentreport_new ("
+        "id INTEGER PRIMARY KEY, "
+        "stock_code VARCHAR NOT NULL, "
+        "stock_name VARCHAR NOT NULL, "
+        "provider VARCHAR NOT NULL, "
+        "summary VARCHAR NOT NULL, "
+        "decision VARCHAR, "
+        "confidence_score FLOAT, "
+        "reason VARCHAR NOT NULL DEFAULT '', "
+        "provider_supports_tools BOOLEAN NOT NULL DEFAULT 0, "
+        "created_at DATETIME NOT NULL"
+        ")"
+    )
+    conn.commit()
+    conn.close()
+
+    test_engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+    monkeypatch.setattr(database, "engine", test_engine)
+
+    # 고아 테이블이 있어도 init_db()가 예외 없이 완료되어야 한다.
+    database.init_db()
+
+    conn = sqlite3.connect(str(db_path))
+    col_info = {row[1]: row for row in conn.execute("PRAGMA table_info(agentreport)")}
+    tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    conn.close()
+
+    assert col_info["decision"][3] == 0, "decision이 여전히 NOT NULL이다"
+    assert "agentreport_new" not in tables, "agentreport_new 고아 테이블이 남아 있다"
+
+
+def test_column_set_mismatch_raises_before_recreation(tmp_path, monkeypatch):
+    """Improvement #1 (#162 리뷰): 실제 컬럼 집합이 DDL 가정과 다를 때 RuntimeError를 던져야 한다.
+
+    _PENDING_COLUMN_MIGRATIONS에 agentreport의 새 컬럼이 추가된 뒤 이 함수의 DDL을
+    갱신하지 않으면 컬럼과 데이터가 조용히 소실된다. 단언으로 명시적 부팅 실패를 만든다.
+
+    이 테스트가 잡는 mutation: _RECREATE_AGENTREPORT_COL_SET 불일치 단언 제거.
+    """
+    db_path = tmp_path / "extra_col.db"
+    _create_post_c_schema_agentreport(str(db_path))  # agentreport: decision NOT NULL
+
+    # DDL이 모르는 컬럼 extra_col을 추가해 불일치 상황을 재현한다.
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("ALTER TABLE agentreport ADD COLUMN extra_col VARCHAR")
+    conn.commit()
+    conn.close()
+
+    test_engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+    monkeypatch.setattr(database, "engine", test_engine)
+
+    import pytest
+    with pytest.raises(RuntimeError, match="agentreport 스키마가 재생성 DDL의 가정과 다릅니다"):
+        database.init_db()
+
+
 def test_nullable_migration_preserves_indexes(tmp_path, monkeypatch):
     """테이블 재생성 마이그레이션이 stock_code·stock_name 인덱스를 보존해야 한다.
 

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -237,6 +237,10 @@ async def test_perform_stock_analysis_marks_toolless_provider_report_unverified(
     provider_supports_tools=False로 저장되고, API 응답 payload에도 같은 값이
     실려야 한다. provider_supports_tools가 항상 True를 반환하도록 뒤집으면(또는
     perform_stock_analysis가 이 값을 무시하면) 이 테스트가 깨진다.
+
+    A (#162): 도구 없는 provider는 decision/confidence_score를 생성하지 않으므로
+    AgentReport에 null로 저장되고 API 응답 payload에도 details=None이어야 한다.
+    decision=None이 아니라 HOLD/0.5로 채워지면 이 테스트가 깨진다.
     """
     async def fake_llm_chat(provider, prompt, *, conversation_id=None):
         return "plain analysis"
@@ -253,6 +257,10 @@ async def test_perform_stock_analysis_marks_toolless_provider_report_unverified(
     assert session.report.provider_supports_tools is False
     assert result["provider"] == "openai"
     assert result["provider_supports_tools"] is False
+    # A (#162): 도구 없는 provider는 매매 판단을 생성하지 않는다.
+    assert session.report.decision is None
+    assert session.report.confidence_score is None
+    assert result.get("details") is None
 
 
 @pytest.mark.asyncio
@@ -891,3 +899,132 @@ async def test_llm_nat_chat_logs_json_parse_failure(monkeypatch, caplog):
     assert "NAT response received: status_code=200 body_length=8" in caplog.text
     assert "Failed to parse NAT response JSON: status_code=200" in caplog.text
     assert "NAT response body preview: not-json" in caplog.text
+
+
+# ── A (#162): 도구 없는 provider 출력 범위 축소 ──────────────────────────────
+
+
+def test_build_toolless_prompt_does_not_request_decision_or_confidence_score():
+    """도구 없는 provider용 프롬프트는 BUY/SELL/HOLD나 confidence_score를
+    요청해서는 안 된다. 이 두 단어가 프롬프트에 포함되면 모델이 매매 판단을
+    지어낼 수 있다 — 프롬프트를 제거하면 이 테스트가 깨진다.
+    """
+    prompt = services._build_toolless_prompt("삼성전자", "")
+    # JSON 포맷으로 매매 판단을 요청하는 표현이 없어야 한다.
+    # 설명 문구에 "BUY/SELL/HOLD"가 언급될 수 있으므로 JSON 키·값 형식으로만 확인한다.
+    assert '"decision"' not in prompt
+    assert '"confidence_score"' not in prompt
+    # JSON 포맷 내에서 BUY/SELL/HOLD 옵션 지정("BUY"|"SELL"|"HOLD")이 없어야 한다.
+    assert '"BUY"' not in prompt
+    assert '"SELL"' not in prompt
+
+
+def test_build_nat_prompt_includes_decision_and_confidence_score():
+    """NAT 프롬프트는 도구를 갖춘 경로 전용이므로 BUY/SELL/HOLD 판단과
+    confidence_score를 요청해야 한다. 이 두 항목이 빠지면 NAT 응답을
+    파싱하는 analysis_from_nat_text가 결과를 얻지 못한다 — nat 경로의
+    동작이 불변이어야 한다는 수용 기준(#162)을 이 테스트가 고정한다.
+    """
+    prompt = services._build_nat_prompt("삼성전자", "")
+    assert '"decision"' in prompt
+    assert '"confidence_score"' in prompt
+    assert '"source_signals"' in prompt
+
+
+@pytest.mark.asyncio
+async def test_toolless_provider_does_not_generate_decision(monkeypatch):
+    """도구 없는 provider(openai/anthropic/ollama)가 perform_stock_analysis를
+    통해 저장하는 AgentReport의 decision/confidence_score는 반드시 None이어야
+    한다. _build_toolless_prompt 대신 _build_nat_prompt를 쓰거나 파싱 후
+    fallback 값("HOLD"/0.5)을 채우면 이 테스트가 깨진다.
+    """
+    captured_prompts: list[str] = []
+
+    async def fake_llm_chat(provider, prompt, *, conversation_id=None):
+        captured_prompts.append(prompt)
+        return "plain analysis"
+
+    async def fake_run_mcp_tool(params, tool_name, arguments):
+        return "삼성전자 (005930, KOSPI)"
+
+    monkeypatch.setattr(services, "llm_chat", fake_llm_chat)
+    monkeypatch.setattr(services, "run_mcp_tool", fake_run_mcp_tool)
+
+    for provider in ("openai", "anthropic", "ollama"):
+        captured_prompts.clear()
+        session = FakeSession()
+        result = await services.perform_stock_analysis("삼성전자", provider, session)
+
+        # DB
+        assert session.report.decision is None, (
+            f"provider={provider}: decision은 None이어야 한다 (받은 값: {session.report.decision!r})"
+        )
+        assert session.report.confidence_score is None, (
+            f"provider={provider}: confidence_score는 None이어야 한다"
+        )
+        # API 응답
+        assert result.get("details") is None, (
+            f"provider={provider}: details는 None이어야 한다 (받은 값: {result.get('details')!r})"
+        )
+        # 프롬프트에 매매 판단 형식이 없어야 함
+        assert len(captured_prompts) == 1
+        assert '"decision"' not in captured_prompts[0], (
+            f"provider={provider}: 도구 없는 프롬프트에 '\"decision\"'이 포함되면 안 된다"
+        )
+
+
+@pytest.mark.asyncio
+async def test_nat_provider_decision_is_preserved(monkeypatch):
+    """provider=nat은 도구를 갖춘 경로이므로 BUY/SELL/HOLD 판단·신뢰도 점수를
+    생성하고 AgentReport에 저장해야 한다. (#162 수용 기준: provider=nat 경로의
+    동작은 불변.) _build_nat_prompt 대신 _build_toolless_prompt를 쓰거나
+    decision을 null로 저장하면 이 테스트가 깨진다.
+    """
+    nat_response = (
+        '{"summary":"삼성전자 분석",'
+        '"details":{"decision":"BUY","confidence_score":0.8,"reason":"수급 개선","target_stock":"삼성전자"},'
+        '"source_news":["헤드라인"],"source_signals":["signal"],"trading_trend":"외국인 순매수",'
+        '"urgency":"normal","urgency_reason":null,"telegram_alert":false}'
+    )
+
+    async def fake_llm_chat(provider, prompt, *, conversation_id=None):
+        return nat_response
+
+    async def fake_run_mcp_tool(params, tool_name, arguments):
+        return "삼성전자 (005930, KOSPI)"
+
+    monkeypatch.setattr(services, "llm_chat", fake_llm_chat)
+    monkeypatch.setattr(services, "run_mcp_tool", fake_run_mcp_tool)
+
+    session = FakeSession()
+    result = await services.perform_stock_analysis("삼성전자", "nat", session)
+
+    assert session.report.decision == "BUY"
+    assert session.report.confidence_score == pytest.approx(0.8)
+    assert result["details"]["decision"] == "BUY"
+    assert result["provider_supports_tools"] is True
+
+
+def test_analysis_from_toolless_text_always_returns_none_details():
+    """_analysis_from_toolless_text가 반환하는 dict의 details는 항상 None이어야
+    한다. JSON에 details 키가 있어도 무시해야 한다 — 모델이 프롬프트를 무시하고
+    details를 출력해도 파싱 단계에서 걸러내야 한다.
+    """
+    # 정상 JSON
+    result = services._analysis_from_toolless_text(
+        '{"summary":"요약","source_news":[],"trading_trend":null}', "삼성전자"
+    )
+    assert result["details"] is None
+
+    # JSON에 details가 있어도 무시
+    result = services._analysis_from_toolless_text(
+        '{"summary":"요약","details":{"decision":"BUY","confidence_score":0.9,'
+        '"reason":"강세","target_stock":"삼성전자"},"source_news":[]}',
+        "삼성전자",
+    )
+    assert result["details"] is None
+
+    # JSON 파싱 실패 (평문)
+    result = services._analysis_from_toolless_text("plain text response", "삼성전자")
+    assert result["details"] is None
+    assert result["summary"] == "plain text response"

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -1012,19 +1012,18 @@ def test_analysis_from_toolless_text_always_returns_none_details():
     """
     # 정상 JSON
     result = services._analysis_from_toolless_text(
-        '{"summary":"요약","source_news":[],"trading_trend":null}', "삼성전자"
+        '{"summary":"요약","source_news":[],"trading_trend":null}'
     )
     assert result["details"] is None
 
     # JSON에 details가 있어도 무시
     result = services._analysis_from_toolless_text(
         '{"summary":"요약","details":{"decision":"BUY","confidence_score":0.9,'
-        '"reason":"강세","target_stock":"삼성전자"},"source_news":[]}',
-        "삼성전자",
+        '"reason":"강세","target_stock":"삼성전자"},"source_news":[]}'
     )
     assert result["details"] is None
 
     # JSON 파싱 실패 (평문)
-    result = services._analysis_from_toolless_text("plain text response", "삼성전자")
+    result = services._analysis_from_toolless_text("plain text response")
     assert result["details"] is None
     assert result["summary"] == "plain text response"

--- a/frontend-react/src/components/RecordsPanel.tsx
+++ b/frontend-react/src/components/RecordsPanel.tsx
@@ -103,7 +103,10 @@ const RecordsPanel: React.FC<RecordsPanelProps> = ({ resources, loading, onSubmi
                     >
                       {badgeLabel}
                     </span>
-                    <span className="text-xs font-black text-slate-500">{item.decision}</span>
+                    <span className="text-xs font-black text-slate-500">
+                      {/* A (#162): decision=null은 도구 없는 provider — 판단 없음을 명시 */}
+                      {item.decision ?? '—'}
+                    </span>
                   </div>
                 </div>
                 <p className="mt-2 line-clamp-3 text-xs leading-relaxed text-slate-500">{item.summary}</p>

--- a/frontend-react/src/types.ts
+++ b/frontend-react/src/types.ts
@@ -75,8 +75,10 @@ export interface AgentReportItem {
   // string | null로 선언한다. UI 보간 시 ?? 폴백을 사용한다.
   provider: string | null;
   summary: string;
-  decision: string;
-  confidence_score: number;
+  // A (#162): provider_supports_tools=False인 provider는 매매 판단을 생성하지 않으므로
+  // null이다. null과 "HOLD"/0.0은 의미가 다르다 — null은 "판단 없음"이다.
+  decision: string | null;
+  confidence_score: number | null;
   reason: string;
   // provider가 도구(MCP/KIS/뉴스)를 호출할 수 있는 경로로 구성돼 있는지 여부.
   // provider 자체에서 파생된 "능력" 신호일 뿐, 이 리포트에서 실제로 도구가


### PR DESCRIPTION
## 배경

#162. `GET /api/v1/analyze`의 기본값(`provider=openai`)이 시장 데이터에 접근하지 못하는 모델로 `BUY`/`SELL` 판단과 신뢰도 점수를 만들어 DB에 저장하고 있었습니다. 저장된 뒤에는 도구를 써서 만든 리포트와 구분되지 않았습니다.

이슈가 제시한 A/B/C/D 중 **C + A 조합**으로 갔습니다 (이슈가 "현실적"이라고 적은 조합).

## C — 출처 명시

`AgentReport`에 `provider_supports_tools`를 추가하고 API 응답·프론트엔드에 노출했습니다.

**이 필드의 의미를 정확히 적었습니다.** provider 차원의 *능력* 신호이지 실제 도구 호출 관측이 아닙니다 — `openai`/`anthropic`/`ollama`가 `False`인 것은 `tools` 파라미터 없이 호출한다는 코드 사실로 증명되지만, `nat=True`는 "NAT 멀티에이전트로 라우팅됐다"는 뜻이지 그 안에서 실제로 도구가 호출됐다는 보장은 아닙니다(그건 #152 영역). 주석에 이 한계를 남겼습니다.

## A — 도구 없는 provider의 출력 범위 축소

`decision`·`confidence_score`를 `Optional`로 바꾸고, 도구 없는 provider는 **생성하지 않습니다**(null).

**null과 `"HOLD"`/`0.0`은 의미가 다릅니다.** null은 "판단 없음"이고 `"HOLD"`/`0.0`은 NAT이 판단한 관망 의견입니다. 빈 값으로 채우면 이 이슈가 고치려는 문제(지어낸 값과 구분 불가)를 그대로 반복하게 되므로 null로 뒀고, 프론트는 `—`로 표시합니다.

`provider=nat` 경로는 불변입니다.

## ⚠️ 검증 중 발견한 결함 — 마이그레이션이 인덱스를 잃고 있었습니다

SQLite는 `ALTER TABLE`로 NOT NULL 제거가 불가능해 테이블 재생성(CREATE new → INSERT SELECT → DROP old → RENAME)이 필요한데, **`DROP TABLE`이 그 테이블의 인덱스도 함께 지웁니다.** 재생성 후 다시 만들지 않아 `models.py`의 `index=True`로 선언된 `stock_code`·`stock_name` 인덱스가 영구히 사라지고 있었습니다. 테이블이 이미 존재하므로 `create_all()`도 다시 만들어 주지 않아 **조용한 성능 저하로만 남습니다.**

구 스키마 DB를 만들어 직접 재현했습니다:

| | 인덱스 | 행 | decision |
| --- | --- | --- | --- |
| 마이그레이션 전 | 2개 | 1 | NOT NULL |
| 수정 전 마이그레이션 후 | **0개** ❌ | 1 (보존) | nullable ✅ |
| 수정 후 마이그레이션 후 | **2개** ✅ | 1 (보존, `BUY`/`0.8` 그대로) | nullable ✅ |

`RENAME` 직후 `CREATE INDEX IF NOT EXISTS`를 실행하도록 고치고(`0d8dad2`), 회귀 가드 테스트를 추가했습니다. 재실행 멱등성도 확인했습니다(2회차에도 인덱스 2개 유지).

## 검증 (직접 실행)

- `pytest backend/` — **277 → 287 passed, 2 skipped** (실패 0건, +10건)
- `npm run typecheck` 에러 0 / `npm test` 8 passed / `npm run build` 성공
- 뮤테이션: `CREATE INDEX` 루프 제거 → **1 failed** ✅

## 수용 기준

| 기준 | 상태 |
| --- | --- |
| 도구를 쓰지 않은 분석 결과가 소비자에게 식별될 것 (또는 생성되지 않을 것) | ✅ 둘 다 — `provider_supports_tools` 노출 + `decision` 미생성 |
| 저장된 리포트에서 도구 검증 여부를 구분할 수 있을 것 | ✅ |
| `provider=nat` 경로 동작 불변 | ✅ |

## 범위 밖

D(OpenAI function calling으로 도구 부착)는 작업량이 커서 후속 이슈 **#201**로 분리했습니다.

Closes #162