### PR TITLE
fix: Portfolio 테이블 동기화 구현 — /api/v1/portfolio 빈 응답 해소 (#122)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -101,9 +101,10 @@ async def get_account_balance():
     return {"status": "success", "data": {"report": balance_text}}
 
 
-def _portfolio_return_rate(current_price: float, avg_price: float) -> float:
+def _portfolio_return_rate(current_price: float, avg_price: float) -> float | None:
+    # 매입가를 모르면 수익률도 모른다 — 0%로 단언하지 않는다(이슈 #122).
     if avg_price <= 0:
-        return 0.0
+        return None
     return round(((current_price - avg_price) / avg_price) * 100, 4)
 
 
@@ -132,8 +133,8 @@ async def get_visualization_portfolio(session: Session = Depends(get_session)):
         if portfolio.current_price is not None:
             # 현재가가 있는 종목: 평가금액과 수익률을 정확히 계산합니다.
             current_price: float | None = float(portfolio.current_price)
-            return_rate: float | None = _portfolio_return_rate(current_price, avg_price)
-            price_known = True
+            return_rate = _portfolio_return_rate(current_price, avg_price)
+            price_known = return_rate is not None
             market_value = current_price * quantity
             total_asset += market_value
             if avg_price > 0:

--- a/backend/main.py
+++ b/backend/main.py
@@ -101,10 +101,6 @@ async def get_account_balance():
     return {"status": "success", "data": {"report": balance_text}}
 
 
-def _portfolio_current_price(portfolio: Portfolio) -> float:
-    return float(portfolio.current_price if portfolio.current_price is not None else portfolio.avg_price)
-
-
 def _portfolio_return_rate(current_price: float, avg_price: float) -> float:
     if avg_price <= 0:
         return 0.0
@@ -121,21 +117,31 @@ async def get_visualization_portfolio(session: Session = Depends(get_session)):
     total_market_for_return = 0.0
 
     for portfolio in portfolios:
-        current_price = _portfolio_current_price(portfolio)
         avg_price = float(portfolio.avg_price)
         quantity = portfolio.quantity
-        market_value = current_price * quantity
-        total_asset += market_value
 
-        if avg_price > 0:
-            total_cost += avg_price * quantity
-            total_market_for_return += market_value
+        if portfolio.current_price is not None:
+            # 현재가가 있는 종목: 평가금액과 수익률을 정확히 계산합니다.
+            current_price: float | None = float(portfolio.current_price)
+            return_rate: float | None = _portfolio_return_rate(current_price, avg_price)
+            market_value = current_price * quantity
+            total_asset += market_value
+            if avg_price > 0:
+                total_cost += avg_price * quantity
+                total_market_for_return += market_value
+        else:
+            # 현재가가 없는 종목: 수익률을 알 수 없으므로 None을 반환합니다.
+            # None을 반환해 "실제 0%"와 구분합니다(이슈 #122).
+            # 총자산은 매입금액(avg_price × quantity) 기준 근사값을 사용합니다.
+            current_price = None
+            return_rate = None
+            total_asset += avg_price * quantity
 
         holdings.append({
             "name": portfolio.stock_name,
             "current_price": current_price,
             "avg_price": avg_price,
-            "return_rate": _portfolio_return_rate(current_price, avg_price),
+            "return_rate": return_rate,
             "quantity": quantity,
         })
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -109,12 +109,21 @@ def _portfolio_return_rate(current_price: float, avg_price: float) -> float:
 
 @app.get("/api/v1/portfolio", response_model=CommonResponse, tags=["Portfolio"])
 async def get_visualization_portfolio(session: Session = Depends(get_session)):
-    """Unity WebGL 시각화 화면에서 사용하는 포트폴리오 요약을 조회합니다."""
+    """Unity WebGL 시각화 화면에서 사용하는 포트폴리오 요약을 조회합니다.
+
+    Unity는 JsonUtility로 파싱하므로 nullable 값 타입(int?, float?)을 지원하지
+    않습니다. JSON null은 JsonUtility에서 예외 없이 기본값(0)으로 처리됩니다.
+    이를 방지하기 위해 각 nullable 필드에 대응하는 bool 플래그를 함께 내립니다:
+      - price_known: current_price와 return_rate가 실제 값인지 여부(이슈 #122)
+      - total_asset_is_estimate: total_asset이 현재가 없는 종목의 매입가 기준 추정값인지
+      - total_return_rate_known: total_return_rate가 실제 계산된 값인지 여부
+    """
     portfolios = session.exec(select(Portfolio)).all()
     holdings = []
     total_asset = 0.0
     total_cost = 0.0
     total_market_for_return = 0.0
+    any_price_unknown = False
 
     for portfolio in portfolios:
         avg_price = float(portfolio.avg_price)
@@ -124,6 +133,7 @@ async def get_visualization_portfolio(session: Session = Depends(get_session)):
             # 현재가가 있는 종목: 평가금액과 수익률을 정확히 계산합니다.
             current_price: float | None = float(portfolio.current_price)
             return_rate: float | None = _portfolio_return_rate(current_price, avg_price)
+            price_known = True
             market_value = current_price * quantity
             total_asset += market_value
             if avg_price > 0:
@@ -135,6 +145,8 @@ async def get_visualization_portfolio(session: Session = Depends(get_session)):
             # 총자산은 매입금액(avg_price × quantity) 기준 근사값을 사용합니다.
             current_price = None
             return_rate = None
+            price_known = False
+            any_price_unknown = True
             total_asset += avg_price * quantity
 
         holdings.append({
@@ -143,6 +155,9 @@ async def get_visualization_portfolio(session: Session = Depends(get_session)):
             "avg_price": avg_price,
             "return_rate": return_rate,
             "quantity": quantity,
+            # Unity JsonUtility가 null을 0으로 읽는 문제를 우회하기 위한 명시 플래그.
+            # price_known=False 이면 current_price·return_rate는 0이 아니라 "알 수 없음"이다.
+            "price_known": price_known,
         })
 
     # 종목별 return_rate와 같은 이유로 총수익률도 "모름"과 "실제 0%"를 구분한다(이슈 #122).
@@ -163,7 +178,12 @@ async def get_visualization_portfolio(session: Session = Depends(get_session)):
         "status": "success",
         "data": {
             "total_asset": total_asset,
+            # True이면 total_asset에 현재가 없는 종목의 매입가 추정분이 포함된다.
+            "total_asset_is_estimate": any_price_unknown,
             "total_return_rate": total_return_rate,
+            # Unity JsonUtility가 null→0으로 읽는 문제 우회. False이면 total_return_rate는
+            # 실제 계산값이 아니며 0으로 표시해서는 안 된다.
+            "total_return_rate_known": total_return_rate is not None,
             "holdings": holdings,
         },
     }

--- a/backend/main.py
+++ b/backend/main.py
@@ -145,9 +145,19 @@ async def get_visualization_portfolio(session: Session = Depends(get_session)):
             "quantity": quantity,
         })
 
-    total_return_rate = 0.0
+    # 종목별 return_rate와 같은 이유로 총수익률도 "모름"과 "실제 0%"를 구분한다(이슈 #122).
+    # 보유 종목은 있는데 현재가가 하나도 없으면 total_cost가 0으로 남는데, 이때 0.0을
+    # 돌려주면 소비자는 그것을 실제 수익률 0%로 읽는다. 현재 current_price 소스가 없어
+    # 항상 이 경우에 해당하므로(후속 이슈 참고), 여기서 0.0을 반환하면 종목별로 고친
+    # 구분이 계정 총계에서 그대로 무너진다.
+    total_return_rate: float | None
     if total_cost > 0:
         total_return_rate = round(((total_market_for_return - total_cost) / total_cost) * 100, 4)
+    elif portfolios:
+        total_return_rate = None
+    else:
+        # 보유 종목 자체가 없으면 수익률을 "모른다"고 할 것이 없다. 기존 동작을 유지한다.
+        total_return_rate = 0.0
 
     return {
         "status": "success",

--- a/backend/main.py
+++ b/backend/main.py
@@ -115,7 +115,9 @@ async def get_visualization_portfolio(session: Session = Depends(get_session)):
     Unity는 JsonUtility로 파싱하므로 nullable 값 타입(int?, float?)을 지원하지
     않습니다. JSON null은 JsonUtility에서 예외 없이 기본값(0)으로 처리됩니다.
     이를 방지하기 위해 각 nullable 필드에 대응하는 bool 플래그를 함께 내립니다:
-      - price_known: current_price와 return_rate가 실제 값인지 여부(이슈 #122)
+      - price_known: current_price가 실제 값인지 여부(이슈 #122)
+      - return_rate_known: return_rate가 실제 계산된 값인지 여부(이슈 #122)
+        ※ current_price는 알지만 avg_price <= 0이면 price_known=True·return_rate_known=False
       - total_asset_is_estimate: total_asset이 현재가 없는 종목의 매입가 기준 추정값인지
       - total_return_rate_known: total_return_rate가 실제 계산된 값인지 여부
     """
@@ -134,7 +136,7 @@ async def get_visualization_portfolio(session: Session = Depends(get_session)):
             # 현재가가 있는 종목: 평가금액과 수익률을 정확히 계산합니다.
             current_price: float | None = float(portfolio.current_price)
             return_rate = _portfolio_return_rate(current_price, avg_price)
-            price_known = return_rate is not None
+            price_known = True  # current_price가 실제 값임을 보장 — 수익률 계산 가능 여부와 독립
             market_value = current_price * quantity
             total_asset += market_value
             if avg_price > 0:
@@ -157,8 +159,11 @@ async def get_visualization_portfolio(session: Session = Depends(get_session)):
             "return_rate": return_rate,
             "quantity": quantity,
             # Unity JsonUtility가 null을 0으로 읽는 문제를 우회하기 위한 명시 플래그.
-            # price_known=False 이면 current_price·return_rate는 0이 아니라 "알 수 없음"이다.
+            # price_known=False 이면 current_price는 0이 아니라 "알 수 없음"이다.
+            # return_rate_known=False 이면 return_rate는 0이 아니라 "알 수 없음"이다.
+            # current_price는 알지만 avg_price <= 0이면 price_known=True·return_rate_known=False.
             "price_known": price_known,
+            "return_rate_known": return_rate is not None,
         })
 
     # 종목별 return_rate와 같은 이유로 총수익률도 "모름"과 "실제 0%"를 구분한다(이슈 #122).

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -120,6 +120,8 @@ def extract_stocks_from_balance(balance_text: str) -> list[str]:
 
     [보유 종목 리스트] 섹션이 없으면 [] 반환(마커 부재 === 파싱 불가).
     잘림 안내 문구는 STOCK_LINE_RE에 매치되지 않아 파싱 단계에서 걸러집니다.
+
+    현재는 테스트에서만 사용하며 프로덕션 경로는 _parse_balance_holdings를 직접 호출한다.
     """
     return [h.name for h in _parse_balance_holdings(balance_text)]
 
@@ -314,6 +316,7 @@ def _sync_portfolio_from_balance(
             len(balance_text),
         )
         return
+
 
     # 호출처에서 이미 파싱한 결과가 있으면 재파싱을 건너뛴다(경고 중복 방지).
     if holdings is None:
@@ -604,8 +607,8 @@ async def _monitor_market_task(
             # extract_stocks_from_balance도 내부에서 _parse_balance_holdings를 호출하는데,
             # _sync_portfolio_from_balance가 같은 텍스트를 또 파싱하면 경고가 두 번씩
             # 찍히고 "저장합니다"라는 문구가 실제로 저장하지 않는 호출에서도 나옵니다.
-            _holdings = _parse_balance_holdings(balance_text)
-            owned_stocks = [h.name for h in _holdings]
+            holdings = _parse_balance_holdings(balance_text)
+            owned_stocks = [h.name for h in holdings]
 
             # Portfolio 테이블 동기화 — 잔고 조회 성공 시에만 실행.
             # 잘린 잔고에서 전량 교체하면 보유 종목이 사라지므로,
@@ -613,7 +616,7 @@ async def _monitor_market_task(
             # 동기화 실패는 감시 루프에 영향을 주지 않아야 하므로 예외를 격리합니다.
             try:
                 with Session(engine) as sync_session:
-                    _sync_portfolio_from_balance(balance_text, sync_session, holdings=_holdings)
+                    _sync_portfolio_from_balance(balance_text, sync_session, holdings=holdings)
             except Exception as e:
                 logger.error("Portfolio 동기화 중 오류 (감시는 계속): %s", e, exc_info=True)
 

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -2,11 +2,11 @@ import os
 import logging
 import re
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from zoneinfo import ZoneInfo
 from typing import Any, Callable
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
-from sqlmodel import Session
+from sqlmodel import Session, select
 from .catalyst_repo import CatalystEventInput, SqliteCatalystEventRepo
 from .ws_manager import manager
 from .database import engine
@@ -18,6 +18,7 @@ from .services import (
     check_signal_significance,
     generate_morning_briefing,
 )
+from .models import Portfolio
 from .watchlist_repo import SqliteWatchlistRepo
 from .telegram_notifier import telegram_notifier
 from .telegram_notifier import should_send_telegram_alert
@@ -193,6 +194,134 @@ def is_balance_truncated(balance_text: str) -> bool:
     종목명으로 오인식되지 않도록), 잘림 여부는 이 함수로 별도 확인해야 한다.
     """
     return _BALANCE_TRUNCATION_MARKER in balance_text
+
+
+# balance.js formatBalanceReport()의 종목 줄 형식에서 수량과 평단가를 추출하는 정규식.
+#
+# 수량(hldg_qty): "- 삼성전자 (005930) · 3주" 줄 끝의 "N주" 부분.
+# 코드 닫는 괄호 직후 공백+중점+공백("· ")을 앵커로 사용한다. formatQuantity가
+# toLocaleString("ko-KR")로 쉼표를 삽입하므로 "1,234주" 형태도 허용한다.
+# · 는 U+00B7(MIDDLE DOT)로, balance.js 템플릿 리터럴에서 그대로 쓰는 문자다.
+_QTY_RE = re.compile(r"\)\s*·\s*([\d,]+)주")
+
+# 평단가(pchs_avg_pric): "  평단가 67,000원 → ..." 줄.
+# formatAmount가 toLocaleString("ko-KR")로 쉼표를 삽입하고 "원"을 붙인다.
+# "-원" 형태(parseNumber가 null을 반환하는 경우)는 [\d,]+에 매치되지 않아
+# 기본값 0.0이 사용된다.
+_AVG_PRICE_RE = re.compile(r"평단가\s+([\d,]+)원")
+
+
+@dataclass(frozen=True)
+class _BalanceHolding:
+    """_parse_balance_holdings의 파싱 결과 단위."""
+    code: str
+    name: str
+    quantity: int
+    avg_price: float
+
+
+def _parse_balance_holdings(balance_text: str) -> list[_BalanceHolding]:
+    """get_balance 텍스트에서 보유 종목의 코드·이름·수량·평단가를 파싱합니다.
+
+    mcp-trading/balance.js의 formatBalanceReport()가 생성하는 3줄 블록 형식에
+    의존합니다:
+      줄1: "- {prdt_name} ({pdno}) · {hldg_qty}주"
+      줄2: "  평단가 {pchs_avg_pric}원 → 평가금액 {evlu_amt}원"
+      줄3: "  손익 ... · 수익률 ..."
+
+    current_price는 이 포맷에 포함되지 않아 파싱하지 않습니다.
+    inquire-balance(TTTC8434R) output1에 현재가 필드가 없기 때문입니다
+    (이슈 #122 후속 이슈 참고).
+
+    잘림 가드는 호출처(_sync_portfolio_from_balance)가 담당하므로 이 함수는
+    잘린 응답도 있는 그대로 파싱합니다.
+    """
+    holdings: list[_BalanceHolding] = []
+    if "[보유 종목 리스트]" not in balance_text:
+        return holdings
+
+    section = balance_text.split("[보유 종목 리스트]")[1]
+    lines = section.split("\n")
+
+    for i, line in enumerate(lines):
+        if not line.startswith("- "):
+            continue
+
+        match = STOCK_LINE_RE.match(line)
+        if match is None:
+            continue  # 형식 위반 줄 — extract_stocks_from_balance와 동일하게 건너뜀
+
+        name = match.group("name").strip()
+        code = match.group("code")
+        if not name:
+            continue
+
+        # 수량: "- 삼성전자 (005930) · 3주" → 3
+        qty_match = _QTY_RE.search(line)
+        quantity = 0
+        if qty_match:
+            try:
+                quantity = int(qty_match.group(1).replace(",", ""))
+            except ValueError:
+                pass
+
+        # 평단가: 다음 줄 "  평단가 67,000원 → ..." → 67000.0
+        avg_price = 0.0
+        if i + 1 < len(lines):
+            avg_match = _AVG_PRICE_RE.search(lines[i + 1])
+            if avg_match:
+                try:
+                    avg_price = float(avg_match.group(1).replace(",", ""))
+                except ValueError:
+                    pass
+
+        holdings.append(_BalanceHolding(code=code, name=name, quantity=quantity, avg_price=avg_price))
+
+    return holdings
+
+
+def _sync_portfolio_from_balance(balance_text: str, session: Session) -> None:
+    """get_balance 응답을 바탕으로 Portfolio 테이블을 동기화합니다.
+
+    전략: 전량 교체 (기존 행 전체 삭제 후 신규 삽입). 매 잔고 조회마다 실행되어
+    보유하지 않게 된 종목을 자동으로 제거합니다.
+
+    잔고가 잘린 경우(is_balance_truncated) 전량 교체를 수행하면 아직 파악되지 않은
+    보유 종목이 삭제될 수 있으므로, 동기화를 건너뛰고 기존 데이터를 보존합니다.
+
+    current_price는 get_balance(inquire-balance, TTTC8434R) output1에 현재가 필드가
+    없어 항상 null로 둡니다. null 수익률이 "실제 0%"와 혼동되지 않도록
+    /api/v1/portfolio 응답에서 return_rate: null로 구분됩니다(이슈 #122).
+    current_price 확보 방안은 후속 이슈를 참고하세요.
+    """
+    if is_balance_truncated(balance_text):
+        logger.warning(
+            "잔고 연속조회가 잘려 Portfolio 동기화를 건너뜁니다. 기존 데이터를 유지합니다."
+        )
+        return
+
+    holdings = _parse_balance_holdings(balance_text)
+
+    # 전량 교체: 기존 행 전체 삭제
+    existing = session.exec(select(Portfolio)).all()
+    for row in existing:
+        session.delete(row)
+    session.flush()
+
+    # 신규 삽입
+    now = datetime.now(timezone.utc)
+    for h in holdings:
+        session.add(Portfolio(
+            stock_code=h.code,
+            stock_name=h.name,
+            quantity=h.quantity,
+            avg_price=h.avg_price,
+            current_price=None,
+            updated_at=now,
+        ))
+
+    session.commit()
+    logger.info("Portfolio 동기화 완료: %d개 종목", len(holdings))
 
 
 def _infer_catalyst_event_type(description: str) -> str:
@@ -455,6 +584,16 @@ async def _monitor_market_task(
                 _last_balance_error = None
 
             owned_stocks = extract_stocks_from_balance(balance_text)
+
+            # Portfolio 테이블 동기화 — 잔고 조회 성공 시에만 실행.
+            # 잘린 잔고에서 전량 교체하면 보유 종목이 사라지므로,
+            # _sync_portfolio_from_balance가 내부에서 잘림을 감지해 건너뜁니다.
+            # 동기화 실패는 감시 루프에 영향을 주지 않아야 하므로 예외를 격리합니다.
+            try:
+                with Session(engine) as sync_session:
+                    _sync_portfolio_from_balance(balance_text, sync_session)
+            except Exception as e:
+                logger.error("Portfolio 동기화 중 오류 (감시는 계속): %s", e, exc_info=True)
 
             if is_balance_truncated(balance_text):
                 # 잘림 사유(max_pages/time_budget/error/...)마다 운영 대응이 다르므로,

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -115,54 +115,13 @@ STOCK_LINE_RE = re.compile(r"^- (?P<name>.+) \((?P<code>[0-9A-Z]{6,})\)")
 def extract_stocks_from_balance(balance_text: str) -> list[str]:
     """mcp-trading의 get_balance 결과에서 종목명 리스트를 추출합니다.
 
-    [보유 종목 리스트] 섹션 이후 "- "로 시작하는 줄 중 STOCK_LINE_RE에 매치되는
-    줄에서만 종목명을 추출합니다. 매치되지 않는 줄(코드 괄호 누락 등 계약 위반)은
-    호출당 1회 집계 경고 로그를 남기고 건너뜁니다(줄마다 로그를 남기면 템플릿
-    변경 시 종목 수만큼 WARNING이 반복 발생한다).
+    _parse_balance_holdings에 파싱을 위임하고 이름만 모아 반환합니다.
+    형식 위반 줄 경고와 파싱 실패 경고는 _parse_balance_holdings가 담당합니다.
 
-    mcp-trading/balance.js의 formatTruncationNote가 그 섹션 뒤에 덧붙이는 잘림
-    안내 문구는 "- "로 시작하지 않으므로, 정규식 매치 이전에 startswith("- ")
-    가드와 정규식 거부 중 어느 쪽이든 걸러집니다.
+    [보유 종목 리스트] 섹션이 없으면 [] 반환(마커 부재 === 파싱 불가).
+    잘림 안내 문구는 STOCK_LINE_RE에 매치되지 않아 파싱 단계에서 걸러집니다.
     """
-    stocks: list[str] = []
-    malformed: list[str] = []
-    if "[보유 종목 리스트]" in balance_text:
-        lines = balance_text.split("[보유 종목 리스트]")[1].strip().split("\n")
-        for line in lines:
-            if line.startswith("- "):
-                # "- 종목명 (코드) · 수량주" 형식을 정규식으로 앵커링해 검증한다.
-                # 이 파서는 mcp-trading/balance.js 의 formatBalanceReport() 출력 형식에 의존한다.
-                # 종목 한 건은 3줄 블록(헤더 줄 + 공백 2칸 들여쓰기 2줄)이며, 들여쓴 줄은
-                # "- " 로 시작하지 않으므로 이 조건에 걸리지 않는다.
-                #
-                # STOCK_LINE_RE의 greedy .+는 다음 두 가지를 의도적으로 처리한다.
-                # 1) 종목코드는 항상 줄의 마지막 "(코드)" 그룹에 있으므로 greedy 매칭으로
-                #    마지막 " (코드) · " 직전까지를 이름으로 잡는다. split("(")[0]을 쓰면
-                #    종목명 자체에 괄호가 있을 때 첫 "(" 에서 잘려 오인식한다.
-                #    예: "CJ4우(전환) (00104K) · 1주" → name 그룹 "CJ4우(전환)"
-                #    (split만 쓰면 "CJ4우"로 잘못 잘림). mcp-trading/data/stocks.json 기준
-                #    종목명 4,353개 중 348개가 "(" 를 포함하므로 드문 경우가 아니다.
-                # 2) ^- 가 "- " 접두사를 소비하므로 종목명 중간의 "- " 가 있어도
-                #    name 그룹에 그대로 보존된다. 예: "- 한국 - 전력 (015760) · 1주"는
-                #    name "한국 - 전력"(정상). stocks.json 기준으로는 "- "를 포함하는
-                #    종목명이 0건이지만, prdt_name은 마스터가 아닌 KIS output1 응답에서
-                #    오므로 완전히 배제할 수는 없다.
-                #
-                # 매치 실패(코드 괄호 누락 등 계약 위반 줄)는 malformed에 모아 호출 후
-                # 1회 집계 경고로 남긴다.
-                match = STOCK_LINE_RE.match(line)
-                if match is None:
-                    malformed.append(line)
-                    continue
-                name = match.group("name").strip()
-                if name:
-                    stocks.append(name)
-    if malformed:
-        logger.warning(
-            "예상치 못한 잔고 종목 줄 형식 %d건을 건너뛰었습니다(예시 최대 3건): %r",
-            len(malformed), malformed[:3],
-        )
-    return stocks
+    return [h.name for h in _parse_balance_holdings(balance_text)]
 
 
 # mcp-trading/balance.js의 formatTruncationNote()가 잘림 시 항상 덧붙이는 문구 중,
@@ -186,6 +145,14 @@ def extract_stocks_from_balance(balance_text: str) -> list[str]:
 # 직접 단언해 고정하고, backend/tests/test_balance_parser.py가 픽스처로 재현한다.
 _BALANCE_TRUNCATION_MARKER = "조회가 중단되어"
 
+# balance.js formatBalanceReport()가 보유 종목 섹션을 구분하는 헤더 리터럴.
+# balance.js:273-274를 보면, 보유 종목이 0건이어도 이 마커와 "보유 종목이 없습니다."를
+# 항상 출력한다. 따라서 이 마커가 없다는 것은 "보유 0건"이 아니라 "응답을 읽지 못함"이다.
+# run_mcp_tool은 MCP content가 비면 예외 대신 빈 문자열을 반환하므로(services.py),
+# 이 경로는 실재한다. _sync_portfolio_from_balance가 이 마커 부재를 계약 위반으로
+# 처리해 전량 교체를 막는다.
+_BALANCE_HOLDINGS_MARKER = "[보유 종목 리스트]"
+
 
 def is_balance_truncated(balance_text: str) -> bool:
     """get_balance 응답에 mcp-trading/balance.js의 잘림 안내 문구가 포함되어 있는지 확인합니다.
@@ -206,9 +173,13 @@ _QTY_RE = re.compile(r"\)\s*·\s*([\d,]+)주")
 
 # 평단가(pchs_avg_pric): "  평단가 67,000원 → ..." 줄.
 # formatAmount가 toLocaleString("ko-KR")로 쉼표를 삽입하고 "원"을 붙인다.
+# 평단가는 매수 단가의 가중평균이라 정수가 아닌 것이 정상이다(예: "66,666.67원").
+# mcp-trading/tests/balance.test.js가 "평단가 66,666.67원"을 리터럴로 단언하므로
+# 소수점 허용은 가정이 아니라 계약이다. (?:\.\d+)?로 정수·소수 양쪽을 잡는다.
 # "-원" 형태(parseNumber가 null을 반환하는 경우)는 [\d,]+에 매치되지 않아
 # 기본값 0.0이 사용된다.
-_AVG_PRICE_RE = re.compile(r"평단가\s+([\d,]+)원")
+# _QTY_RE(수량)는 hldg_qty가 항상 정수이므로 소수점 허용이 필요 없다.
+_AVG_PRICE_RE = re.compile(r"평단가\s+([\d,]+(?:\.\d+)?)원")
 
 
 @dataclass(frozen=True)
@@ -233,15 +204,20 @@ def _parse_balance_holdings(balance_text: str) -> list[_BalanceHolding]:
     inquire-balance(TTTC8434R) output1에 현재가 필드가 없기 때문입니다
     (이슈 #122 후속 이슈 참고).
 
-    잘림 가드는 호출처(_sync_portfolio_from_balance)가 담당하므로 이 함수는
-    잘린 응답도 있는 그대로 파싱합니다.
+    잘림 가드와 마커 부재 가드는 호출처(_sync_portfolio_from_balance)가 담당하므로
+    이 함수는 있는 그대로 파싱합니다. _BALANCE_HOLDINGS_MARKER가 없으면 [] 반환.
+
+    형식 위반 줄(코드 괄호 누락 등)은 모아서 호출당 1회 경고 로그를 남깁니다.
+    수량·평단가 파싱이 실패한 줄도 경고를 남기고 기본값(0)을 사용합니다.
+    extract_stocks_from_balance는 이 함수에 파싱을 위임합니다.
     """
     holdings: list[_BalanceHolding] = []
-    if "[보유 종목 리스트]" not in balance_text:
+    if _BALANCE_HOLDINGS_MARKER not in balance_text:
         return holdings
 
-    section = balance_text.split("[보유 종목 리스트]")[1]
+    section = balance_text.split(_BALANCE_HOLDINGS_MARKER)[1]
     lines = section.split("\n")
+    malformed: list[str] = []
 
     for i, line in enumerate(lines):
         if not line.startswith("- "):
@@ -249,7 +225,8 @@ def _parse_balance_holdings(balance_text: str) -> list[_BalanceHolding]:
 
         match = STOCK_LINE_RE.match(line)
         if match is None:
-            continue  # 형식 위반 줄 — extract_stocks_from_balance와 동일하게 건너뜀
+            malformed.append(line)
+            continue
 
         name = match.group("name").strip()
         code = match.group("code")
@@ -263,9 +240,11 @@ def _parse_balance_holdings(balance_text: str) -> list[_BalanceHolding]:
             try:
                 quantity = int(qty_match.group(1).replace(",", ""))
             except ValueError:
-                pass
+                logger.warning("[%s] 수량 파싱 실패(ValueError). quantity=0으로 저장합니다: %r", name, line)
+        else:
+            logger.warning("[%s] 수량 정규식이 매치되지 않아 quantity=0으로 저장합니다: %r", name, line)
 
-        # 평단가: 다음 줄 "  평단가 67,000원 → ..." → 67000.0
+        # 평단가: 다음 줄 "  평단가 67,000원 → ..." → 67000.0 (소수 포함)
         avg_price = 0.0
         if i + 1 < len(lines):
             avg_match = _AVG_PRICE_RE.search(lines[i + 1])
@@ -273,10 +252,23 @@ def _parse_balance_holdings(balance_text: str) -> list[_BalanceHolding]:
                 try:
                     avg_price = float(avg_match.group(1).replace(",", ""))
                 except ValueError:
-                    pass
+                    logger.warning(
+                        "[%s] 평단가 파싱 실패(ValueError). avg_price=0으로 저장합니다: %r",
+                        name, lines[i + 1],
+                    )
+            else:
+                logger.warning(
+                    "[%s] 평단가 정규식이 매치되지 않아 avg_price=0으로 저장합니다: %r",
+                    name, lines[i + 1] if i + 1 < len(lines) else "(다음 줄 없음)",
+                )
 
         holdings.append(_BalanceHolding(code=code, name=name, quantity=quantity, avg_price=avg_price))
 
+    if malformed:
+        logger.warning(
+            "예상치 못한 잔고 종목 줄 형식 %d건을 건너뛰었습니다(예시 최대 3건): %r",
+            len(malformed), malformed[:3],
+        )
     return holdings
 
 
@@ -297,6 +289,20 @@ def _sync_portfolio_from_balance(balance_text: str, session: Session) -> None:
     if is_balance_truncated(balance_text):
         logger.warning(
             "잔고 연속조회가 잘려 Portfolio 동기화를 건너뜁니다. 기존 데이터를 유지합니다."
+        )
+        return
+
+    # 마커가 없으면 "보유 0건"이 아니라 "응답을 읽지 못함"이다.
+    # balance.js는 보유 종목이 없어도 마커와 "보유 종목이 없습니다."를 항상 출력한다
+    # (balance.js:273-274). run_mcp_tool은 MCP content가 비면 예외 대신 ""를
+    # 반환하므로(services.py) 이 경로는 실재한다. 전량 교체는 되돌릴 수 없으므로
+    # 기존 데이터를 보존하고 error 로그로 운영자에게 알린다.
+    if _BALANCE_HOLDINGS_MARKER not in balance_text:
+        logger.error(
+            "잔고 응답에서 %r 섹션을 찾지 못해 Portfolio 동기화를 건너뜁니다 "
+            "(응답 길이 %d). 기존 데이터를 유지합니다.",
+            _BALANCE_HOLDINGS_MARKER,
+            len(balance_text),
         )
         return
 

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -272,7 +272,12 @@ def _parse_balance_holdings(balance_text: str) -> list[_BalanceHolding]:
     return holdings
 
 
-def _sync_portfolio_from_balance(balance_text: str, session: Session) -> None:
+def _sync_portfolio_from_balance(
+    balance_text: str,
+    session: Session,
+    *,
+    holdings: list[_BalanceHolding] | None = None,
+) -> None:
     """get_balance 응답을 바탕으로 Portfolio 테이블을 동기화합니다.
 
     전략: 전량 교체 (기존 행 전체 삭제 후 신규 삽입). 매 잔고 조회마다 실행되어
@@ -285,6 +290,10 @@ def _sync_portfolio_from_balance(balance_text: str, session: Session) -> None:
     없어 항상 null로 둡니다. null 수익률이 "실제 0%"와 혼동되지 않도록
     /api/v1/portfolio 응답에서 return_rate: null로 구분됩니다(이슈 #122).
     current_price 확보 방안은 후속 이슈를 참고하세요.
+
+    holdings: 호출처에서 이미 _parse_balance_holdings를 실행한 경우 그 결과를 전달하면
+    재파싱을 건너뜁니다. None이면 balance_text에서 직접 파싱합니다.
+    잘림·마커 가드는 holdings 인자 유무에 관계없이 항상 balance_text를 검사합니다.
     """
     if is_balance_truncated(balance_text):
         logger.warning(
@@ -306,7 +315,9 @@ def _sync_portfolio_from_balance(balance_text: str, session: Session) -> None:
         )
         return
 
-    holdings = _parse_balance_holdings(balance_text)
+    # 호출처에서 이미 파싱한 결과가 있으면 재파싱을 건너뛴다(경고 중복 방지).
+    if holdings is None:
+        holdings = _parse_balance_holdings(balance_text)
 
     # 전량 교체: 기존 행 전체 삭제
     existing = session.exec(select(Portfolio)).all()
@@ -589,7 +600,12 @@ async def _monitor_market_task(
                 _balance_failure_streak = 0
                 _last_balance_error = None
 
-            owned_stocks = extract_stocks_from_balance(balance_text)
+            # 같은 텍스트를 두 번 파싱하지 않도록 먼저 한 번만 파싱합니다.
+            # extract_stocks_from_balance도 내부에서 _parse_balance_holdings를 호출하는데,
+            # _sync_portfolio_from_balance가 같은 텍스트를 또 파싱하면 경고가 두 번씩
+            # 찍히고 "저장합니다"라는 문구가 실제로 저장하지 않는 호출에서도 나옵니다.
+            _holdings = _parse_balance_holdings(balance_text)
+            owned_stocks = [h.name for h in _holdings]
 
             # Portfolio 테이블 동기화 — 잔고 조회 성공 시에만 실행.
             # 잘린 잔고에서 전량 교체하면 보유 종목이 사라지므로,
@@ -597,7 +613,7 @@ async def _monitor_market_task(
             # 동기화 실패는 감시 루프에 영향을 주지 않아야 하므로 예외를 격리합니다.
             try:
                 with Session(engine) as sync_session:
-                    _sync_portfolio_from_balance(balance_text, sync_session)
+                    _sync_portfolio_from_balance(balance_text, sync_session, holdings=_holdings)
             except Exception as e:
                 logger.error("Portfolio 동기화 중 오류 (감시는 계속): %s", e, exc_info=True)
 

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -42,7 +42,9 @@ def test_get_visualization_portfolio_empty(client: TestClient):
         "status": "success",
         "data": {
             "total_asset": 0,
+            "total_asset_is_estimate": False,
             "total_return_rate": 0.0,
+            "total_return_rate_known": True,
             "holdings": [],
         },
         "message": None,
@@ -79,7 +81,9 @@ def test_get_visualization_portfolio_maps_holdings(
     assert response.json()["status"] == "success"
     assert response.json()["data"] == {
         "total_asset": 1720000.0,
+        "total_asset_is_estimate": False,
         "total_return_rate": 1.1765,
+        "total_return_rate_known": True,
         "holdings": [
             {
                 "name": "삼성전자",
@@ -87,6 +91,7 @@ def test_get_visualization_portfolio_maps_holdings(
                 "avg_price": 70000.0,
                 "return_rate": 10.0,
                 "quantity": 10,
+                "price_known": True,
             },
             {
                 "name": "SK하이닉스",
@@ -94,6 +99,7 @@ def test_get_visualization_portfolio_maps_holdings(
                 "avg_price": 200000.0,
                 "return_rate": -5.0,
                 "quantity": 5,
+                "price_known": True,
             },
         ],
     }
@@ -130,10 +136,13 @@ def test_get_visualization_portfolio_handles_missing_prices(
         # 카카오 current_price=None → total_asset에 avg_price*qty(126,000)로 포함.
         # 평단가없음 current_price=1000 → total_asset에 1000*2(2,000)로 포함.
         "total_asset": 128000.0,
+        # 카카오의 current_price=None으로 인해 total_asset이 추정값이다.
+        "total_asset_is_estimate": True,
         # 카카오는 current_price 없어 return_rate 미반영.
         # 평단가없음은 avg_price=0 이라 수익률 계산에서 제외.
         # → total_cost=0. 보유 종목은 있으므로 "모름"이고 실제 0%가 아니다 → null.
         "total_return_rate": None,
+        "total_return_rate_known": False,
         "holdings": [
             {
                 "name": "카카오",
@@ -143,6 +152,7 @@ def test_get_visualization_portfolio_handles_missing_prices(
                 "avg_price": 42000.0,
                 "return_rate": None,
                 "quantity": 3,
+                "price_known": False,
             },
             {
                 "name": "평단가없음",
@@ -150,6 +160,7 @@ def test_get_visualization_portfolio_handles_missing_prices(
                 "avg_price": 0.0,
                 "return_rate": 0.0,
                 "quantity": 2,
+                "price_known": True,
             },
         ],
     }

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -139,7 +139,8 @@ def test_get_visualization_portfolio_handles_missing_prices(
         # 카카오의 current_price=None으로 인해 total_asset이 추정값이다.
         "total_asset_is_estimate": True,
         # 카카오는 current_price 없어 return_rate 미반영.
-        # 평단가없음은 avg_price=0 이라 수익률 계산에서 제외.
+        # 평단가없음은 avg_price=0 이라 수익률 계산 불가 → return_rate=None, price_known=False.
+        # 매입가를 모르면 수익률도 모른다 — 0%로 단언하지 않는다(이슈 #122).
         # → total_cost=0. 보유 종목은 있으므로 "모름"이고 실제 0%가 아니다 → null.
         "total_return_rate": None,
         "total_return_rate_known": False,
@@ -158,9 +159,11 @@ def test_get_visualization_portfolio_handles_missing_prices(
                 "name": "평단가없음",
                 "current_price": 1000.0,
                 "avg_price": 0.0,
-                "return_rate": 0.0,
+                # avg_price=0 → _portfolio_return_rate가 None 반환 → price_known=False.
+                # 0.00%로 단언하면 이슈 #122가 해소한 문제가 avg_price 경로에서 재현된다.
+                "return_rate": None,
                 "quantity": 2,
-                "price_known": True,
+                "price_known": False,
             },
         ],
     }

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -92,6 +92,7 @@ def test_get_visualization_portfolio_maps_holdings(
                 "return_rate": 10.0,
                 "quantity": 10,
                 "price_known": True,
+                "return_rate_known": True,
             },
             {
                 "name": "SK하이닉스",
@@ -100,6 +101,7 @@ def test_get_visualization_portfolio_maps_holdings(
                 "return_rate": -5.0,
                 "quantity": 5,
                 "price_known": True,
+                "return_rate_known": True,
             },
         ],
     }
@@ -139,7 +141,8 @@ def test_get_visualization_portfolio_handles_missing_prices(
         # 카카오의 current_price=None으로 인해 total_asset이 추정값이다.
         "total_asset_is_estimate": True,
         # 카카오는 current_price 없어 return_rate 미반영.
-        # 평단가없음은 avg_price=0 이라 수익률 계산 불가 → return_rate=None, price_known=False.
+        # 평단가없음은 current_price=1000을 알지만 avg_price=0 이라 수익률 계산 불가.
+        # → price_known=True(현재가 실제 값), return_rate_known=False(수익률 계산 불가).
         # 매입가를 모르면 수익률도 모른다 — 0%로 단언하지 않는다(이슈 #122).
         # → total_cost=0. 보유 종목은 있으므로 "모름"이고 실제 0%가 아니다 → null.
         "total_return_rate": None,
@@ -154,16 +157,19 @@ def test_get_visualization_portfolio_handles_missing_prices(
                 "return_rate": None,
                 "quantity": 3,
                 "price_known": False,
+                "return_rate_known": False,
             },
             {
                 "name": "평단가없음",
                 "current_price": 1000.0,
                 "avg_price": 0.0,
-                # avg_price=0 → _portfolio_return_rate가 None 반환 → price_known=False.
+                # current_price는 있으므로 price_known=True.
+                # avg_price=0 → _portfolio_return_rate가 None 반환 → return_rate_known=False.
                 # 0.00%로 단언하면 이슈 #122가 해소한 문제가 avg_price 경로에서 재현된다.
                 "return_rate": None,
                 "quantity": 2,
-                "price_known": False,
+                "price_known": True,
+                "return_rate_known": False,
             },
         ],
     }
@@ -195,6 +201,63 @@ def test_get_visualization_portfolio_total_return_rate_is_null_when_no_current_p
     assert all(h["return_rate"] is None for h in data["holdings"])
     # 총자산은 매입금액 근사값으로 계산된다: 70000*10 + 42000*3
     assert data["total_asset"] == 826000.0
+
+
+def test_get_visualization_portfolio_price_known_independent_of_return_rate(
+    client: TestClient,
+    session: Session,
+):
+    """current_price를 알지만 avg_price=0인 종목은 price_known=True·return_rate_known=False여야 한다.
+
+    리뷰어 실측 케이스(avg_price=0.0, current_price=50000.0, quantity=10 + 정상 종목 1건).
+    이전 구현(price_known = return_rate is not None)에서는 현재가를 아는데도 price_known=False가
+    됐고, GetWeight에서 avg_price(0) × quantity / total_asset = 0%로 계산돼 총자산의 대부분을
+    차지하는 종목이 비중 차트에서 사라졌다(이슈 #122 연관 결함).
+
+    이 테스트가 잡는 mutation:
+    - price_known = True 를 return_rate is not None으로 되돌리면 price_known=False가 돼 실패한다.
+    - return_rate_known을 price_known과 동일하게 묶으면 return_rate_known=False가 돼 실패한다.
+    """
+    session.add(
+        Portfolio(
+            stock_code="000000",
+            stock_name="평단가손실",
+            quantity=10,
+            avg_price=0,
+            current_price=50000,
+        )
+    )
+    session.add(
+        Portfolio(
+            stock_code="005930",
+            stock_name="정상",
+            quantity=1,
+            avg_price=70000,
+            current_price=77000,
+        )
+    )
+    session.commit()
+
+    response = client.get("/api/v1/portfolio")
+    assert response.status_code == 200
+    data = response.json()["data"]
+
+    # 577,000 = 50,000×10 + 77,000×1
+    assert data["total_asset"] == 577000.0
+
+    holdings_by_name = {h["name"]: h for h in data["holdings"]}
+
+    # 평단가손실: current_price 실제 값 → price_known=True. avg_price=0 → return_rate_known=False.
+    lost = holdings_by_name["평단가손실"]
+    assert lost["price_known"] is True, "현재가를 아는 종목은 price_known=True여야 합니다"
+    assert lost["return_rate_known"] is False, "avg_price=0이면 수익률을 계산할 수 없습니다"
+    assert lost["current_price"] == 50000.0
+    assert lost["return_rate"] is None
+
+    # 정상 종목: 둘 다 True
+    normal = holdings_by_name["정상"]
+    assert normal["price_known"] is True
+    assert normal["return_rate_known"] is True
 
 
 def test_get_visualization_portfolio_empty_keeps_zero_total_return_rate(client: TestClient):

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -131,9 +131,9 @@ def test_get_visualization_portfolio_handles_missing_prices(
         # 평단가없음 current_price=1000 → total_asset에 1000*2(2,000)로 포함.
         "total_asset": 128000.0,
         # 카카오는 current_price 없어 return_rate 미반영.
-        # 평단가없음은 avg_price=0 이라 return_rate=0.0이지만 수익률 계산 제외.
-        # → total_cost=0 → total_return_rate=0.0.
-        "total_return_rate": 0.0,
+        # 평단가없음은 avg_price=0 이라 수익률 계산에서 제외.
+        # → total_cost=0. 보유 종목은 있으므로 "모름"이고 실제 0%가 아니다 → null.
+        "total_return_rate": None,
         "holdings": [
             {
                 "name": "카카오",
@@ -153,6 +153,42 @@ def test_get_visualization_portfolio_handles_missing_prices(
             },
         ],
     }
+
+
+def test_get_visualization_portfolio_total_return_rate_is_null_when_no_current_price(
+    client: TestClient,
+    session: Session,
+):
+    """보유 종목은 있는데 현재가가 하나도 없으면 총수익률은 0.0이 아니라 null이어야 한다.
+
+    현재 Portfolio 동기화는 current_price를 채울 소스가 없어 항상 null로 저장한다.
+    이때 total_return_rate로 0.0을 돌려주면 소비자는 그것을 실제 수익률 0%로 읽고,
+    종목별 return_rate를 null로 만들어 얻은 구분이 계정 총계에서 그대로 무너진다.
+
+    이 테스트가 잡는 mutation: total_cost == 0 분기에서 None 대신 0.0 반환.
+    """
+    session.add(
+        Portfolio(stock_code="005930", stock_name="삼성전자", quantity=10, avg_price=70000, current_price=None)
+    )
+    session.add(
+        Portfolio(stock_code="035720", stock_name="카카오", quantity=3, avg_price=42000, current_price=None)
+    )
+    session.commit()
+
+    data = client.get("/api/v1/portfolio").json()["data"]
+
+    assert data["total_return_rate"] is None, "현재가를 모르는데 0%로 단언하면 안 됩니다"
+    assert all(h["return_rate"] is None for h in data["holdings"])
+    # 총자산은 매입금액 근사값으로 계산된다: 70000*10 + 42000*3
+    assert data["total_asset"] == 826000.0
+
+
+def test_get_visualization_portfolio_empty_keeps_zero_total_return_rate(client: TestClient):
+    """보유 종목이 아예 없으면 "모른다"고 할 것이 없으므로 기존대로 0.0을 유지한다."""
+    data = client.get("/api/v1/portfolio").json()["data"]
+
+    assert data["holdings"] == []
+    assert data["total_return_rate"] == 0.0
 
 
 def test_create_and_get_diary(client: TestClient):

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -127,14 +127,21 @@ def test_get_visualization_portfolio_handles_missing_prices(
 
     assert response.status_code == 200
     assert response.json()["data"] == {
+        # 카카오 current_price=None → total_asset에 avg_price*qty(126,000)로 포함.
+        # 평단가없음 current_price=1000 → total_asset에 1000*2(2,000)로 포함.
         "total_asset": 128000.0,
+        # 카카오는 current_price 없어 return_rate 미반영.
+        # 평단가없음은 avg_price=0 이라 return_rate=0.0이지만 수익률 계산 제외.
+        # → total_cost=0 → total_return_rate=0.0.
         "total_return_rate": 0.0,
         "holdings": [
             {
                 "name": "카카오",
-                "current_price": 42000.0,
+                # current_price=None → null. avg_price 대체값 42000을 반환하던
+                # 기존 동작은 "실제 0%" 수익률과 구분이 불가능해 이슈 #122에서 수정됨.
+                "current_price": None,
                 "avg_price": 42000.0,
-                "return_rate": 0.0,
+                "return_rate": None,
                 "quantity": 3,
             },
             {

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -1336,3 +1336,255 @@ async def test_monitor_market_task_reescalates_error_after_six_cycles(monkeypatc
     errors = [r for r in caplog.records if r.levelno == logging.ERROR]
     # streak=1 → error, streak=2~5 → debug, streak=6 (% 6 == 0) → error
     assert len(errors) == 2
+
+
+# ---------------------------------------------------------------------------
+# Portfolio 동기화 테스트 (이슈 #122)
+# ---------------------------------------------------------------------------
+
+def _make_balance_text(*holdings):
+    """(name, code, qty, avg_price) 튜플 목록으로 get_balance 텍스트 픽스처를 합성합니다.
+
+    mcp-trading/balance.js의 formatBalanceReport()가 생성하는 형식을 그대로 재현합니다.
+    formatAmount(pchs_avg_pric) = "N,NNN원", formatQuantity(hldg_qty) = "N"(또는 "N,NNN").
+    """
+    lines = []
+    for name, code, qty, avg_price in holdings:
+        avg_str = f"{int(avg_price):,}"
+        evlu = int(avg_price * qty)
+        lines.append(
+            f"- {name} ({code}) · {qty}주\n"
+            f"  평단가 {avg_str}원 → 평가금액 {evlu:,}원\n"
+            f"  손익 +0원 · 수익률 ⚪ 0.00%"
+        )
+    stock_list = "\n\n".join(lines) if lines else "보유 종목이 없습니다."
+    return (
+        "[계좌 잔고 현황]\n"
+        "- 총 평가금액: 0원\n"
+        "\n"
+        f"[보유 종목 리스트]\n{stock_list}"
+    )
+
+
+@pytest.fixture(name="portfolio_session")
+def portfolio_session_fixture():
+    """Portfolio 동기화 단위 테스트용 인메모리 SQLite 세션."""
+    from sqlmodel import SQLModel, create_engine
+    from sqlmodel.pool import StaticPool
+    from sqlmodel import Session as _Session
+    eng = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    SQLModel.metadata.create_all(eng)
+    with _Session(eng) as session:
+        yield session
+
+
+def test_parse_balance_holdings_extracts_name_code_qty_avg():
+    """_parse_balance_holdings가 이름·코드·수량·평단가를 올바르게 파싱합니다.
+
+    이 테스트가 잡는 mutation: _QTY_RE 또는 _AVG_PRICE_RE를 제거해
+    quantity=0 또는 avg_price=0.0만 반환하는 회귀.
+    """
+    from ..scheduler import _parse_balance_holdings
+
+    text = _make_balance_text(
+        ("삼성전자", "005930", 10, 70000),
+        ("SK하이닉스", "000660", 5, 200000),
+    )
+    holdings = _parse_balance_holdings(text)
+
+    assert len(holdings) == 2
+    assert holdings[0].name == "삼성전자"
+    assert holdings[0].code == "005930"
+    assert holdings[0].quantity == 10
+    assert holdings[0].avg_price == 70000.0
+    assert holdings[1].name == "SK하이닉스"
+    assert holdings[1].code == "000660"
+    assert holdings[1].quantity == 5
+    assert holdings[1].avg_price == 200000.0
+
+
+def test_parse_balance_holdings_with_real_fixture():
+    """REAL_BALANCE_TEXT(balance.js 실제 출력 픽스처)에서 올바르게 파싱됩니다."""
+    from ..scheduler import _parse_balance_holdings
+    from .test_balance_parser import REAL_BALANCE_TEXT
+
+    holdings = _parse_balance_holdings(REAL_BALANCE_TEXT)
+
+    assert len(holdings) == 2
+    assert holdings[0].name == "삼성전자"
+    assert holdings[0].code == "005930"
+    assert holdings[0].quantity == 3
+    assert holdings[0].avg_price == 67000.0
+    assert holdings[1].name == "NAVER"
+    assert holdings[1].code == "035420"
+    assert holdings[1].quantity == 1
+    assert holdings[1].avg_price == 201000.0
+
+
+def test_parse_balance_holdings_empty_returns_empty_list():
+    from ..scheduler import _parse_balance_holdings
+
+    assert _parse_balance_holdings("보유 종목이 없습니다.") == []
+    assert _parse_balance_holdings(_make_balance_text()) == []
+
+
+def test_sync_portfolio_writes_holdings(portfolio_session):
+    """_sync_portfolio_from_balance가 Portfolio 행을 실제로 씁니다.
+
+    이 테스트가 잡는 mutation: _sync_portfolio_from_balance 호출을 제거하거나
+    session.add() 없이 반환하는 회귀 → rows가 비어 assert len==1이 실패한다.
+    """
+    from sqlmodel import select
+    from ..models import Portfolio
+    from ..scheduler import _sync_portfolio_from_balance
+
+    text = _make_balance_text(("삼성전자", "005930", 10, 70000))
+    _sync_portfolio_from_balance(text, portfolio_session)
+
+    rows = portfolio_session.exec(select(Portfolio)).all()
+    assert len(rows) == 1
+    assert rows[0].stock_code == "005930"
+    assert rows[0].stock_name == "삼성전자"
+    assert rows[0].quantity == 10
+    assert rows[0].avg_price == 70000.0
+    # current_price는 get_balance output1에 현재가 필드가 없어 항상 null(이슈 #122)
+    assert rows[0].current_price is None
+
+
+def test_sync_portfolio_removes_stale_holdings(portfolio_session):
+    """보유하지 않게 된 종목이 동기화 후 제거됩니다.
+
+    이 테스트가 잡는 mutation: delete 없이 add만 하는 회귀 → stale 행이
+    남아 assert len==1이 실패한다.
+    """
+    from sqlmodel import select
+    from ..models import Portfolio
+    from ..scheduler import _sync_portfolio_from_balance
+
+    # 초기: 삼성전자 + SK하이닉스
+    portfolio_session.add(Portfolio(stock_code="005930", stock_name="삼성전자", quantity=10, avg_price=70000))
+    portfolio_session.add(Portfolio(stock_code="000660", stock_name="SK하이닉스", quantity=5, avg_price=200000))
+    portfolio_session.commit()
+
+    # 이후 잔고에 삼성전자만 남음
+    text = _make_balance_text(("삼성전자", "005930", 10, 70000))
+    _sync_portfolio_from_balance(text, portfolio_session)
+
+    rows = portfolio_session.exec(select(Portfolio)).all()
+    assert len(rows) == 1
+    assert rows[0].stock_code == "005930"
+
+
+def test_sync_portfolio_skips_when_balance_truncated(portfolio_session):
+    """잔고 연속조회가 잘리면 기존 Portfolio 데이터를 파괴하지 않습니다.
+
+    이 테스트가 잡는 mutation: is_balance_truncated 가드를 제거하면 잘린 잔고로
+    전량 교체가 일어나 기존 종목이 사라져 assert len==2가 실패한다.
+    """
+    from sqlmodel import select
+    from ..models import Portfolio
+    from ..scheduler import _sync_portfolio_from_balance
+    from .test_balance_parser import TRUNCATION_NOTES_BY_REASON
+
+    # 기존 데이터: 삼성전자 + SK하이닉스
+    portfolio_session.add(Portfolio(stock_code="005930", stock_name="삼성전자", quantity=10, avg_price=70000))
+    portfolio_session.add(Portfolio(stock_code="000660", stock_name="SK하이닉스", quantity=5, avg_price=200000))
+    portfolio_session.commit()
+
+    # 잘린 잔고: 삼성전자만 있는 척
+    truncated_text = (
+        _make_balance_text(("삼성전자", "005930", 10, 70000)).rstrip()
+        + TRUNCATION_NOTES_BY_REASON["max_pages"]
+    )
+    _sync_portfolio_from_balance(truncated_text, portfolio_session)
+
+    rows = portfolio_session.exec(select(Portfolio)).all()
+    # 잘린 잔고 → 동기화 건너뜀 → 기존 2개 유지
+    assert len(rows) == 2
+
+
+@pytest.mark.asyncio
+async def test_monitor_market_task_syncs_portfolio_when_balance_succeeds(monkeypatch):
+    """잔고 조회 성공 시 monitor_market_task가 Portfolio 동기화를 호출합니다.
+
+    이 테스트가 잡는 mutation: _monitor_market_task에서 _sync_portfolio_from_balance
+    호출을 제거하는 회귀 → sync_calls가 비어 assert len==1이 실패한다.
+    """
+    from ..scheduler import SignalSource, monitor_market_task
+
+    state = RedisSchedulerState(FakeRedis())
+    sync_calls = []
+
+    @asynccontextmanager
+    async def fake_redis_state():
+        yield state
+
+    async def mock_run_mcp_tool(params, name, args):
+        if name == "get_balance":
+            return _make_balance_text(("삼성전자", "005930", 10, 70000))
+        return "news"
+
+    def mock_sync_portfolio(balance_text, session):
+        sync_calls.append(balance_text)
+
+    async def mock_check_significance(stock, current, last, *, source, provider):
+        return False
+
+    monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
+    monkeypatch.setattr(
+        "backend.scheduler.SIGNAL_SOURCES",
+        [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
+    )
+    monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
+    monkeypatch.setattr("backend.scheduler._sync_portfolio_from_balance", mock_sync_portfolio)
+    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", MagicMock(return_value=asyncio.Future()))
+
+    await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
+
+    assert len(sync_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_monitor_market_task_does_not_sync_when_balance_fails(monkeypatch):
+    """잔고 조회 실패 시 Portfolio 동기화를 호출하지 않습니다 (기존 데이터 보호).
+
+    이 테스트가 잡는 mutation: balance_ok 가드를 제거해 실패 시에도
+    _sync_portfolio_from_balance가 호출되는 회귀 → sync_calls가 비어야 하는데
+    1개가 들어가 assert sync_calls==[] 가 실패한다.
+    """
+    from ..scheduler import SignalSource, monitor_market_task
+
+    state = RedisSchedulerState(FakeRedis())
+    sync_calls = []
+
+    @asynccontextmanager
+    async def fake_redis_state():
+        yield state
+
+    async def mock_run_mcp_tool(params, name, args):
+        if name == "get_balance":
+            raise RuntimeError("KIS 장애")
+        return "news"
+
+    def mock_sync_portfolio(balance_text, session):
+        sync_calls.append(balance_text)
+
+    async def mock_check_significance(stock, current, last, *, source, provider):
+        return False
+
+    monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
+    monkeypatch.setattr(
+        "backend.scheduler.SIGNAL_SOURCES",
+        [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
+    )
+    monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
+    monkeypatch.setattr("backend.scheduler._sync_portfolio_from_balance", mock_sync_portfolio)
+    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", MagicMock(return_value=asyncio.Future()))
+
+    await monitor_market_task(watchlist_repo=FakeWatchlistRepo(["카카오"]))
+
+    assert sync_calls == []

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -1749,6 +1749,9 @@ def test_portfolio_endpoint_includes_price_known_flag(client):
         assert "price_known" in holding, "price_known 플래그가 응답에 없습니다"
         # current_price가 None이므로 price_known은 False여야 한다
         assert holding["price_known"] is False
+        assert "return_rate_known" in holding, "return_rate_known 플래그가 응답에 없습니다"
+        # current_price가 None이면 수익률도 계산 불가
+        assert holding["return_rate_known"] is False
         assert "total_asset_is_estimate" in data
         assert data["total_asset_is_estimate"] is True
         assert "total_return_rate_known" in data

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -1533,7 +1533,7 @@ async def test_monitor_market_task_syncs_portfolio_when_balance_succeeds(monkeyp
             return _make_balance_text(("삼성전자", "005930", 10, 70000))
         return "news"
 
-    def mock_sync_portfolio(balance_text, session):
+    def mock_sync_portfolio(balance_text, session, **kwargs):
         sync_calls.append(balance_text)
 
     async def mock_check_significance(stock, current, last, *, source, provider):
@@ -1576,7 +1576,7 @@ async def test_monitor_market_task_does_not_sync_when_balance_fails(monkeypatch)
             raise RuntimeError("KIS 장애")
         return "news"
 
-    def mock_sync_portfolio(balance_text, session):
+    def mock_sync_portfolio(balance_text, session, **kwargs):
         sync_calls.append(balance_text)
 
     async def mock_check_significance(stock, current, last, *, source, provider):

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -1710,3 +1710,51 @@ def test_sync_portfolio_allows_genuinely_empty_holdings(portfolio_session):
 
     rows = portfolio_session.exec(select(Portfolio)).all()
     assert len(rows) == 0, "실제 보유 0건이면 기존 데이터를 삭제해야 합니다"
+
+
+# ---------------------------------------------------------------------------
+# Critical 3: price_known 플래그 테스트
+# ---------------------------------------------------------------------------
+
+def test_portfolio_endpoint_includes_price_known_flag(client):
+    """/api/v1/portfolio 응답의 각 holding에 price_known 플래그가 포함됩니다.
+
+    이 테스트가 잡는 mutation: holdings.append에서 "price_known" 키를 제거하면
+    응답에 없어 assert "price_known" in holding이 실패한다.
+    """
+    from sqlmodel import Session, select
+    from ..database import engine
+    from ..models import Portfolio
+    from datetime import datetime, timezone
+
+    with Session(engine) as session:
+        for row in session.exec(select(Portfolio)).all():
+            session.delete(row)
+        session.add(Portfolio(
+            stock_code="005930",
+            stock_name="삼성전자",
+            quantity=10,
+            avg_price=70000,
+            current_price=None,
+            updated_at=datetime.now(timezone.utc),
+        ))
+        session.commit()
+
+    try:
+        resp = client.get("/api/v1/portfolio")
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert len(data["holdings"]) == 1
+        holding = data["holdings"][0]
+        assert "price_known" in holding, "price_known 플래그가 응답에 없습니다"
+        # current_price가 None이므로 price_known은 False여야 한다
+        assert holding["price_known"] is False
+        assert "total_asset_is_estimate" in data
+        assert data["total_asset_is_estimate"] is True
+        assert "total_return_rate_known" in data
+        assert data["total_return_rate_known"] is False
+    finally:
+        with Session(engine) as session:
+            for row in session.exec(select(Portfolio)).all():
+                session.delete(row)
+            session.commit()

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -1346,11 +1346,18 @@ def _make_balance_text(*holdings):
     """(name, code, qty, avg_price) 튜플 목록으로 get_balance 텍스트 픽스처를 합성합니다.
 
     mcp-trading/balance.js의 formatBalanceReport()가 생성하는 형식을 그대로 재현합니다.
-    formatAmount(pchs_avg_pric) = "N,NNN원", formatQuantity(hldg_qty) = "N"(또는 "N,NNN").
+    formatAmount(pchs_avg_pric) = toLocaleString("ko-KR"): 정수는 "N,NNN원",
+    소수는 "N,NNN.NN원" 형태. avg_price가 정수가 아니면 소수점을 그대로 보존한다.
+    mcp-trading/tests/balance.test.js가 "평단가 66,666.67원"을 단언하므로 소수 케이스도
+    픽스처가 통과시켜야 한다(Critical 1 참고).
     """
     lines = []
     for name, code, qty, avg_price in holdings:
-        avg_str = f"{int(avg_price):,}"
+        # formatAmount(toLocaleString("ko-KR")): 정수면 정수 포맷, 소수면 소수 포맷
+        if avg_price == int(avg_price):
+            avg_str = f"{int(avg_price):,}"
+        else:
+            avg_str = f"{avg_price:,}"
         evlu = int(avg_price * qty)
         lines.append(
             f"- {name} ({code}) · {qty}주\n"
@@ -1588,3 +1595,118 @@ async def test_monitor_market_task_does_not_sync_when_balance_fails(monkeypatch)
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo(["카카오"]))
 
     assert sync_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Critical 1: 소수점 평단가 파싱 테스트
+# ---------------------------------------------------------------------------
+
+def test_parse_balance_holdings_accepts_fractional_avg_price():
+    """balance.js formatAmount는 정수가 아닌 평단가에 소수점을 붙인다.
+    mcp-trading/tests/balance.test.js가 "평단가 66,666.67원"을 리터럴로 단언하므로
+    이것은 가정이 아니라 계약이다.
+
+    이 테스트가 잡는 mutation: _AVG_PRICE_RE를 원래 r"평단가\\s+([\\d,]+)원"으로
+    되돌리면 "66,666"까지 먹고 다음 글자가 "."라 매치 실패 → avg_price=0.0으로 red.
+    """
+    from ..scheduler import _parse_balance_holdings
+
+    text = (
+        "[보유 종목 리스트]\n"
+        "- 삼성전자 (005930) · 3주\n"
+        "  평단가 66,666.67원 → 평가금액 190,000원\n"
+        "  손익 -10,000원 · 수익률 🔵 ▼ -5.00%"
+    )
+    holdings = _parse_balance_holdings(text)
+    assert len(holdings) == 1
+    assert holdings[0].avg_price == pytest.approx(66666.67)
+
+
+def test_make_balance_text_fixture_passes_fractional_avg_price():
+    """_make_balance_text 픽스처 자체가 소수 평단가를 올바르게 렌더링하는지 확인합니다.
+    픽스처가 int(avg_price)만 쓰면 "66,666원"이 돼 매치되고 파싱값이 66666.0으로
+    틀린 반올림이 일어납니다.
+
+    이 테스트가 잡는 mutation: _make_balance_text에서 avg_str을 f"{int(avg_price):,}"
+    로 되돌리면 "66,666.67" 대신 "66,666"이 생성 → 파싱값이 66666.0 ≠ approx(66666.67)
+    으로 red.
+    """
+    from ..scheduler import _parse_balance_holdings
+
+    text = _make_balance_text(("삼성전자", "005930", 3, 66666.67))
+    assert "66,666.67원" in text, f"픽스처에 소수 평단가가 없습니다: {text!r}"
+    holdings = _parse_balance_holdings(text)
+    assert len(holdings) == 1
+    assert holdings[0].avg_price == pytest.approx(66666.67)
+
+
+# ---------------------------------------------------------------------------
+# Critical 2: 마커 부재 시 동기화 건너뜀 테스트
+# ---------------------------------------------------------------------------
+
+def test_sync_portfolio_skips_when_marker_absent(portfolio_session):
+    """[보유 종목 리스트] 마커가 없는 응답에서 기존 Portfolio 데이터를 파괴하지 않습니다.
+
+    이 테스트가 잡는 mutation: _BALANCE_HOLDINGS_MARKER 가드를 제거하면 빈 holdings로
+    전량 교체가 일어나 기존 1개 행이 사라져 assert len==1이 실패한다.
+    """
+    from sqlmodel import select
+    from ..models import Portfolio
+    from ..scheduler import _sync_portfolio_from_balance
+
+    portfolio_session.add(Portfolio(stock_code="005930", stock_name="삼성전자", quantity=10, avg_price=70000))
+    portfolio_session.commit()
+
+    # 마커 없는 응답 — "보유 0건"이 아니라 "응답을 읽지 못함"
+    no_marker_text = "응답을 가져왔지만 종목 섹션이 없습니다."
+    _sync_portfolio_from_balance(no_marker_text, portfolio_session)
+
+    rows = portfolio_session.exec(select(Portfolio)).all()
+    assert len(rows) == 1, "마커 부재 시 기존 데이터가 보존되어야 합니다"
+
+
+def test_sync_portfolio_skips_empty_balance_text(portfolio_session):
+    """빈 문자열(run_mcp_tool이 MCP content 없을 때 반환하는 값)에서
+    기존 Portfolio 데이터를 파괴하지 않습니다.
+
+    이 테스트가 잡는 mutation: _BALANCE_HOLDINGS_MARKER 가드를 제거하면 ""를 성공
+    응답으로 처리해 전량 교체 → 기존 데이터 소실 → assert len==1이 실패한다.
+    """
+    from sqlmodel import select
+    from ..models import Portfolio
+    from ..scheduler import _sync_portfolio_from_balance
+
+    portfolio_session.add(Portfolio(stock_code="005930", stock_name="삼성전자", quantity=10, avg_price=70000))
+    portfolio_session.commit()
+
+    _sync_portfolio_from_balance("", portfolio_session)
+
+    rows = portfolio_session.exec(select(Portfolio)).all()
+    assert len(rows) == 1, "빈 응답 시 기존 데이터가 보존되어야 합니다"
+
+
+def test_sync_portfolio_allows_genuinely_empty_holdings(portfolio_session):
+    """마커는 있지만 보유 종목이 없는 응답("보유 종목이 없습니다.")은
+    실제 0건으로 처리해 기존 데이터를 전량 삭제합니다.
+
+    마커 가드가 "실제 0건"을 막아서는 안 됩니다.
+    """
+    from sqlmodel import select
+    from ..models import Portfolio
+    from ..scheduler import _sync_portfolio_from_balance
+
+    portfolio_session.add(Portfolio(stock_code="005930", stock_name="삼성전자", quantity=10, avg_price=70000))
+    portfolio_session.commit()
+
+    # balance.js가 보유 0건일 때 실제로 생성하는 텍스트(balance.js:273-274)
+    empty_holdings_text = (
+        "[계좌 잔고 현황]\n"
+        "- 총 평가금액: 0원\n"
+        "\n"
+        "[보유 종목 리스트]\n"
+        "보유 종목이 없습니다."
+    )
+    _sync_portfolio_from_balance(empty_holdings_text, portfolio_session)
+
+    rows = portfolio_session.exec(select(Portfolio)).all()
+    assert len(rows) == 0, "실제 보유 0건이면 기존 데이터를 삭제해야 합니다"

--- a/frontend/Assets/Scripts/PanelController.cs
+++ b/frontend/Assets/Scripts/PanelController.cs
@@ -166,13 +166,14 @@ public class PanelController : MonoBehaviour
             return;
 
         stockName.text = holding.name;
-        // price_known=false이면 API가 현재가·수익률을 알 수 없다고 명시한 것이다.
+        // price_known=false이면 current_price를 알 수 없다.
+        // return_rate_known=false이면 return_rate를 알 수 없다(현재가는 알더라도 avg_price <= 0이면 수익률 계산 불가).
         // JsonUtility가 JSON null을 0으로 변환하므로 플래그로 구분해 "—"를 표시한다.
         currentPrice.text = holding.price_known
             ? $"현재가: {holding.current_price:N0}원"
             : "현재가: —";
         avgPrice.text = $"평단가: {holding.avg_price:N0}원";
-        returnRate.text = holding.price_known
+        returnRate.text = holding.return_rate_known
             ? $"수익률: {holding.return_rate:F2}%"
             : "수익률: —";
         quantity.text = $"보유 수량: {holding.quantity:N0}주";

--- a/frontend/Assets/Scripts/PanelController.cs
+++ b/frontend/Assets/Scripts/PanelController.cs
@@ -166,9 +166,15 @@ public class PanelController : MonoBehaviour
             return;
 
         stockName.text = holding.name;
-        currentPrice.text = $"현재가: {holding.current_price:N0}원";
+        // price_known=false이면 API가 현재가·수익률을 알 수 없다고 명시한 것이다.
+        // JsonUtility가 JSON null을 0으로 변환하므로 플래그로 구분해 "—"를 표시한다.
+        currentPrice.text = holding.price_known
+            ? $"현재가: {holding.current_price:N0}원"
+            : "현재가: —";
         avgPrice.text = $"평단가: {holding.avg_price:N0}원";
-        returnRate.text = $"수익률: {holding.return_rate:F2}%";
+        returnRate.text = holding.price_known
+            ? $"수익률: {holding.return_rate:F2}%"
+            : "수익률: —";
         quantity.text = $"보유 수량: {holding.quantity:N0}주";
     }
 
@@ -180,8 +186,14 @@ public class PanelController : MonoBehaviour
         if (!EnsureBindings())
             return false;
 
-        totalAsset.text = $"총자산: {portfolioData.total_asset:N0}원";
-        totalReturnRate.text = $"총수익률: {portfolioData.total_return_rate:F2}%";
+        // total_asset_is_estimate=true이면 현재가 없는 종목이 매입가 기준으로 잡혀 있다.
+        totalAsset.text = portfolioData.total_asset_is_estimate
+            ? $"총자산: {portfolioData.total_asset:N0}원 (추정)"
+            : $"총자산: {portfolioData.total_asset:N0}원";
+        // total_return_rate_known=false이면 현재가가 없어 수익률을 계산할 수 없다.
+        totalReturnRate.text = portfolioData.total_return_rate_known
+            ? $"총수익률: {portfolioData.total_return_rate:F2}%"
+            : "총수익률: —";
         return true;
     }
 

--- a/frontend/Assets/Scripts/PortfolioData.cs
+++ b/frontend/Assets/Scripts/PortfolioData.cs
@@ -17,12 +17,19 @@ public class Holding
 
     public float GetWeight(double total_asset)
     {
-        if (!price_known || total_asset == 0)
+        if (total_asset == 0)
             return 0f;
+        if (!price_known)
+        {
+            // 현재가 미상 종목: total_asset도 avg_price × quantity 기준 근사값을 포함하므로
+            // 같은 기준으로 비중을 계산한다. avg_price=0이면 기여분이 없으므로 0을 반환.
+            return (float)((double)avg_price * quantity / total_asset * 100.0);
+        }
         // 정수 오버플로 방지: current_price(float)를 double로 승격한 뒤 계산한다.
         return (float)((double)current_price * quantity / total_asset * 100.0);
     }
 }
+
 
 [System.Serializable]
 public class PortfolioData

--- a/frontend/Assets/Scripts/PortfolioData.cs
+++ b/frontend/Assets/Scripts/PortfolioData.cs
@@ -2,7 +2,10 @@
 public class Holding
 {
     public string name;
-    public int current_price;
+    // models.py: current_price Optional[float] — DB 스키마가 소수를 허용하므로
+    // float으로 받아 소수 부분 손실을 방지한다.
+    // (한국 주식 현재가는 실제로 항상 원 단위 정수이지만 스키마 타입을 따른다.)
+    public float current_price;
     // API는 float(가중평균 매수단가)를 반환한다. int로 받으면 소수 부분이 잘린다.
     public float avg_price;
     public float return_rate;
@@ -12,18 +15,22 @@ public class Holding
     // price_known=false이면 current_price·return_rate는 0이 아니라 미확인 값이다.
     public bool price_known;
 
-    public float GetWeight(long total_asset)
+    public float GetWeight(double total_asset)
     {
         if (!price_known || total_asset == 0)
             return 0f;
-        return (float)(current_price * quantity) / total_asset * 100f;
+        // 정수 오버플로 방지: current_price(float)를 double로 승격한 뒤 계산한다.
+        return (float)((double)current_price * quantity / total_asset * 100.0);
     }
 }
 
 [System.Serializable]
 public class PortfolioData
 {
-    public long total_asset;
+    // avg_price(가중평균 매수단가)는 소수다. 현재가 미상 종목의 total_asset 기여분은
+    // avg_price × quantity로 계산되므로 total_asset도 소수가 될 수 있다.
+    // long으로 선언하면 Unity JsonUtility가 소수 JSON 값을 파싱하지 못한다.
+    public double total_asset;
     // true이면 total_asset에 현재가 없는 종목의 매입가 추정분이 포함된다.
     public bool total_asset_is_estimate;
     public float total_return_rate;

--- a/frontend/Assets/Scripts/PortfolioData.cs
+++ b/frontend/Assets/Scripts/PortfolioData.cs
@@ -11,25 +11,23 @@ public class Holding
     public float return_rate;
     public int quantity;
     // Unity JsonUtility는 nullable 값 타입을 지원하지 않아 null → 0으로 처리한다.
-    // API가 current_price·return_rate를 모를 때 0이 아니라 "알 수 없음"임을 나타내는 플래그.
-    // price_known=false이면 current_price·return_rate는 0이 아니라 미확인 값이다.
+    // price_known=false이면 current_price는 0이 아니라 미확인 값이다.
     public bool price_known;
+    // return_rate_known=false이면 return_rate는 0이 아니라 계산 불가 상태다.
+    // current_price는 알지만 avg_price <= 0이면 price_known=true·return_rate_known=false가 된다.
+    public bool return_rate_known;
 
     public float GetWeight(double total_asset)
     {
         if (total_asset == 0)
             return 0f;
-        if (!price_known)
-        {
-            // 현재가 미상 종목: total_asset도 avg_price × quantity 기준 근사값을 포함하므로
-            // 같은 기준으로 비중을 계산한다. avg_price=0이면 기여분이 없으므로 0을 반환.
-            return (float)((double)avg_price * quantity / total_asset * 100.0);
-        }
-        // 정수 오버플로 방지: current_price(float)를 double로 승격한 뒤 계산한다.
-        return (float)((double)current_price * quantity / total_asset * 100.0);
+        // 비중은 현재가만 알면 계산된다 — 수익률을 모르는 것과 무관하다.
+        // 현재가 미상이면 total_asset도 avg_price × quantity 기준 근사값을 포함하므로
+        // 같은 기준으로 비중을 계산한다. avg_price=0이면 기여분이 없으므로 0을 반환.
+        double basis = price_known ? (double)current_price : (double)avg_price;
+        return (float)(basis * quantity / total_asset * 100.0);
     }
 }
-
 
 [System.Serializable]
 public class PortfolioData

--- a/frontend/Assets/Scripts/PortfolioData.cs
+++ b/frontend/Assets/Scripts/PortfolioData.cs
@@ -3,12 +3,19 @@ public class Holding
 {
     public string name;
     public int current_price;
-    public int avg_price;
+    // API는 float(가중평균 매수단가)를 반환한다. int로 받으면 소수 부분이 잘린다.
+    public float avg_price;
     public float return_rate;
     public int quantity;
+    // Unity JsonUtility는 nullable 값 타입을 지원하지 않아 null → 0으로 처리한다.
+    // API가 current_price·return_rate를 모를 때 0이 아니라 "알 수 없음"임을 나타내는 플래그.
+    // price_known=false이면 current_price·return_rate는 0이 아니라 미확인 값이다.
+    public bool price_known;
 
     public float GetWeight(long total_asset)
     {
+        if (!price_known || total_asset == 0)
+            return 0f;
         return (float)(current_price * quantity) / total_asset * 100f;
     }
 }
@@ -17,6 +24,11 @@ public class Holding
 public class PortfolioData
 {
     public long total_asset;
+    // true이면 total_asset에 현재가 없는 종목의 매입가 추정분이 포함된다.
+    public bool total_asset_is_estimate;
     public float total_return_rate;
+    // Unity JsonUtility는 null → 0으로 처리한다.
+    // false이면 total_return_rate는 0%가 아니라 계산 불가 상태다.
+    public bool total_return_rate_known;
     public Holding[] holdings;
 }


### PR DESCRIPTION
## 배경

#122. `Portfolio` 테이블에 INSERT/UPDATE 하는 프로덕션 코드가 존재하지 않아 `GET /api/v1/portfolio`(Unity 시각화용)가 항상 빈 응답을 반환하고 있었습니다.

## 변경

`_monitor_market_task`의 `get_balance` **성공 경로에서만** Portfolio를 동기화합니다. 전략은 전량 교체로, 보유하지 않게 된 종목이 자동으로 제거됩니다.

세 가지 가드를 넣었습니다.

- **잔고 조회 실패 시 동기화 안 함** — PR #190이 세운 fail-open 격리 구조를 그대로 따라 성공 분기(`else`) 안에서만 실행합니다. 실패했을 때 전량 교체하면 기존 데이터가 사라집니다.
- **잘린 잔고에서는 동기화 건너뜀** — `is_balance_truncated`가 참이면 아직 파악되지 않은 보유 종목이 있을 수 있어 전량 교체가 위험합니다. 기존 데이터를 보존하고 경고만 남깁니다.
- **동기화 실패가 감시를 막지 않음** — 예외를 격리해 뉴스·공시 감시는 계속됩니다.

## current_price — 채우지 않았습니다

이슈가 지적한 대로 `get_balance`(`inquire-balance`, `TTTC8434R`)의 `output1`에 현재가 필드가 있는지가 미결입니다. 저장소 내 유일한 근거인 `balance-rlz-pl-report.js`의 `row.prpr`은 **다른 TR**(`TTTC8494R`)의 응답이라 증명이 되지 못하고, 실계좌 호출로 실측할 수 없었습니다.

증명되지 않았으므로 `current_price`는 **null로 두었습니다.** 종목별 시세 조회(`get_stock_quote`) 추가는 넣지 않았습니다 — `/watch list`가 유량 제한 때문에 종목당 1.1초 슬립을 넣고 있어 10분 주기 작업에 얹는 것은 별도 비용 검토가 필요한 제품 결정입니다. 후속 이슈 **#196**으로 분리했습니다.

## ⚠️ 대신 정직성을 지켰습니다 — 0%로 단언하지 않습니다

`current_price`가 null이면 기존 `_portfolio_current_price()`가 `avg_price`로 대체해 수익률이 **전 종목 0%**로 나왔습니다. 이슈가 지적한 그대로입니다. 빈 응답은 최소한 비어 있음이 명백한데, 0%는 실제 값처럼 보이므로 지금보다 더 나쁩니다.

- 종목별 `current_price`·`return_rate` → **null** (대체값 폐기)
- 계정 `total_return_rate` → 보유 종목은 있는데 현재가가 하나도 없으면 **null**
- `total_asset`은 매입금액 근사값으로 계산하고 그 사실을 주석에 명시

**두 번째 항목은 검증 중 추가로 발견해 고쳤습니다**(`7a9be57`). 종목별 `return_rate`만 null로 바꾸고 `total_return_rate`는 `total_cost == 0`일 때 여전히 `0.0`을 돌려주고 있었습니다. `current_price`가 항상 null인 현재 상태에서는 **총수익률이 늘 0.0으로 나와** 종목별로 얻은 구분이 계정 총계에서 그대로 무너집니다. 보유 종목이 아예 없는 경우는 "모른다"고 할 것이 없어 기존대로 `0.0`을 유지합니다.

## 검증 (직접 실행)

`pytest backend/` — **277 → 287 passed, 2 skipped** (실패 0건, +10건).

뮤테이션 5종 전부 red 확인:

| 뮤턴트 | 결과 |
| --- | --- |
| 잘림 가드 제거 (잘린 잔고로도 전량 교체) | 1 failed ✅ |
| 동기화 호출 제거 | 1 failed ✅ |
| 낡은 종목 삭제 제거 | 1 failed ✅ |
| `total_return_rate`를 0.0으로 되돌림 | 2 failed ✅ |
| 종목별 `return_rate`를 0.0으로 되돌림 | 2 failed ✅ |

## 확인한 것 / 확인 못 한 것

- 확인: 잔고 텍스트 파싱 형식(`balance.js` `formatBalanceReport`의 3줄 블록), 기존 가드 함수(`is_balance_truncated`) 재사용, 프론트엔드는 `/api/v1/portfolio`를 사용하지 않음(Unity 전용)
- **확인 못 함**: `inquire-balance` `output1`의 실제 필드 목록 (실계좌 호출 필요) → #196

Closes #122