### PR TITLE
fix: NAT 에이전트 도구 사용 강제 게이트 구현 (#152)

### DIFF
--- a/finus_nat/src/nat_finus_nat/agents.py
+++ b/finus_nat/src/nat_finus_nat/agents.py
@@ -49,7 +49,7 @@ _FIN_NUM_RE = re.compile(
     r"[\d,]+(?:\.\d+)?"                           # base number with optional decimal
     r"(?:\s*[만억조]\s*(?:[\d,]+(?:\.\d+)?)?)*"   # 만/억/조 chain; trailing digits optional
     r"\s*(?:원|달러|위안|엔|%"
-    r"|주(?!\s*(?:일|간|동안|가|식|말|중|후|째|만에))"  # 주: exclude time expressions
+    r"|주(?!\s*(?:일|간|동안|가\s*(?:가|는|를|에|의|상승|하락|올|내)|식|말|중|후|째|만에))"  # 주: exclude time/price(주가+조사) expressions
     r"|좌)",
     re.UNICODE,
 )

--- a/finus_nat/src/nat_finus_nat/agents.py
+++ b/finus_nat/src/nat_finus_nat/agents.py
@@ -43,11 +43,14 @@ _KNOWN_STOCK_NAMES = ("삼성전자", "NAVER", "네이버")
 
 # ---- Tool enforcement gate (#152) ----
 
-# Matches financial numbers: "5,000,000원", "7만 5300원", "5.3%", "100주", etc.
+# Matches financial numbers: "5,000,000원", "500만원", "1억원", "7만 5300원", "5.3%", "100주".
+# `주` uses a negative lookahead to exclude time expressions like "2주 동안", "1주일", "2주간".
 _FIN_NUM_RE = re.compile(
-    r"[\d,]+(?:\.\d+)?"              # base number with optional decimal
-    r"(?:\s*(?:만|억|조)\s*[\d,]+)?"  # optional Korean large-unit continuation
-    r"\s*(?:원|달러|위안|엔|%|주|좌)",  # required financial unit suffix
+    r"[\d,]+(?:\.\d+)?"                           # base number with optional decimal
+    r"(?:\s*[만억조]\s*(?:[\d,]+(?:\.\d+)?)?)*"   # 만/억/조 chain; trailing digits optional
+    r"\s*(?:원|달러|위안|엔|%"
+    r"|주(?!\s*(?:일|간|동안|가|식|말|중|후|째|만에))"  # 주: exclude time expressions
+    r"|좌)",
     re.UNICODE,
 )
 
@@ -56,26 +59,33 @@ _KO_UNIT_VALUES: dict[str, int] = {
     "억": 100_000_000,
     "조": 1_000_000_000_000,
 }
+# Regex for one numeric term: digits (with optional decimal) + optional Korean unit.
+_NUM_TERM_RE = re.compile(r"(\d+(?:\.\d+)?)\s*([만억조])?")
+# Scale factor: multiply normalised value by 1000 to preserve up to 3 decimal places.
+# This prevents int(float(s)) truncation that would equate 5.3% and 5.7%.
+_NUM_SCALE = 1000
 
 
 def _normalize_number_str(s: str) -> int | None:
-    """Normalize a comma/Korean-unit number string to a plain integer.
+    """Normalize a comma/Korean-unit number to a scaled integer (×_NUM_SCALE=1000).
 
-    Examples: ``"75,300"`` → 75300; ``"7만5300"`` → 75300; ``"5000000"`` → 5000000.
-    Returns None when *s* cannot be parsed.
+    Examples: ``"75,300"`` → 75_300_000; ``"7만5300"`` → 75_300_000;
+              ``"500만"`` → 5_000_000_000; ``"5.3"`` → 5_300 (≠ ``"5.7"`` → 5_700).
+    Returns None when *s* cannot be fully parsed (e.g. trailing non-numeric residue).
     """
     s = s.replace(",", "").strip()
     if not s:
         return None
-    m = re.match(r"^(\d+)(만|억|조)(\d+)?$", s)
-    if m:
-        base = int(m.group(1)) * _KO_UNIT_VALUES[m.group(2)]
-        extra = int(m.group(3)) if m.group(3) else 0
-        return base + extra
-    try:
-        return int(float(s))
-    except (ValueError, TypeError):
+    total, pos, seen = 0.0, 0, False
+    for m in _NUM_TERM_RE.finditer(s):
+        if m.start() != pos:      # gap between matches means unparsed residue
+            return None
+        pos, seen = m.end(), True
+        value = float(m.group(1))
+        total += value * _KO_UNIT_VALUES[m.group(2)] if m.group(2) else value
+    if not seen or pos != len(s):
         return None
+    return int(round(total * _NUM_SCALE))
 
 
 def _extract_financial_numbers(text: str) -> frozenset[int]:
@@ -165,10 +175,26 @@ async def _run_with_gate(
     if not _check_tool_enforcement(answer, ledger, chat_request):
         return answer
 
+    # Gate tripped — log judgment details for post-hoc analysis.
+    transcript_text = "\n".join(message_content_text(m) for m in chat_request.messages)
     logger.warning(
-        "Tool enforcement gate tripped on first attempt (%s) — retrying with corrective input",
+        "Tool enforcement gate tripped on first attempt (%s) — retrying. "
+        "claimed=%s transcript=%s ledger_records=%d",
         inner_name,
+        sorted(_extract_financial_numbers(answer)),
+        sorted(_extract_financial_numbers(transcript_text)),
+        len(ledger.records),
     )
+
+    # Side-effect guard: if a write tool already ran, skip the retry to avoid
+    # duplicate side effects (e.g. duplicate diary entries).
+    if ledger.had_side_effect():
+        logger.error(
+            "Tool enforcement gate tripped on first attempt (%s) but a side-effecting "
+            "tool ran — skipping retry to avoid duplicate writes",
+            inner_name,
+        )
+        return _TOOL_ENFORCEMENT_REJECTION
 
     # --- Second attempt with changed input ---
     corrective_query = _CORRECTIVE_TOOL_PREFIX + query
@@ -367,7 +393,14 @@ async def fe_branch(config: FeBranchConfig, builder: Builder):
     async def run_subagent(chat_request_or_message: ChatRequestOrMessage) -> str:
         chat_request = GlobalTypeConverter.get().convert(chat_request_or_message, to_type=ChatRequest)
         if inner_name == "news_agent":
-            direct = await _holdings_news_answer(builder, chat_request)
+            # Deterministic path: assembles tool output directly without going through
+            # _run_with_gate. A ledger box is still required so that _record_to_ledger
+            # inside the news tool does not log a spurious ERROR on every happy-path call.
+            token = DATA_TOOL_LEDGER.set(DataToolLedger())
+            try:
+                direct = await _holdings_news_answer(builder, chat_request)
+            finally:
+                DATA_TOOL_LEDGER.reset(token)
             if direct is not None:
                 return direct
         inner = await builder.get_function(inner_name)

--- a/finus_nat/src/nat_finus_nat/agents.py
+++ b/finus_nat/src/nat_finus_nat/agents.py
@@ -28,6 +28,7 @@ from nat.data_models.component_ref import FunctionRef
 from nat.data_models.component_ref import LLMRef
 from nat.data_models.function import FunctionBaseConfig
 from nat.utils.type_converter import GlobalTypeConverter
+from nat_finus_nat.finus_api import DATA_TOOL_LEDGER, DataToolLedger
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +40,154 @@ _DEFAULT_CONVERSATION_ID = os.environ.get(
 ).strip()
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 _KNOWN_STOCK_NAMES = ("삼성전자", "NAVER", "네이버")
+
+# ---- Tool enforcement gate (#152) ----
+
+# Matches financial numbers: "5,000,000원", "7만 5300원", "5.3%", "100주", etc.
+_FIN_NUM_RE = re.compile(
+    r"[\d,]+(?:\.\d+)?"              # base number with optional decimal
+    r"(?:\s*(?:만|억|조)\s*[\d,]+)?"  # optional Korean large-unit continuation
+    r"\s*(?:원|달러|위안|엔|%|주|좌)",  # required financial unit suffix
+    re.UNICODE,
+)
+
+_KO_UNIT_VALUES: dict[str, int] = {
+    "만": 10_000,
+    "억": 100_000_000,
+    "조": 1_000_000_000_000,
+}
+
+
+def _normalize_number_str(s: str) -> int | None:
+    """Normalize a comma/Korean-unit number string to a plain integer.
+
+    Examples: ``"75,300"`` → 75300; ``"7만5300"`` → 75300; ``"5000000"`` → 5000000.
+    Returns None when *s* cannot be parsed.
+    """
+    s = s.replace(",", "").strip()
+    if not s:
+        return None
+    m = re.match(r"^(\d+)(만|억|조)(\d+)?$", s)
+    if m:
+        base = int(m.group(1)) * _KO_UNIT_VALUES[m.group(2)]
+        extra = int(m.group(3)) if m.group(3) else 0
+        return base + extra
+    try:
+        return int(float(s))
+    except (ValueError, TypeError):
+        return None
+
+
+def _extract_financial_numbers(text: str) -> frozenset[int]:
+    """Return a frozenset of normalized integer values of all financial numbers in *text*."""
+    result: set[int] = set()
+    for m in _FIN_NUM_RE.finditer(text):
+        raw = re.sub(r"[원달러위안엔%주좌\s]", "", m.group()).strip()
+        n = _normalize_number_str(raw)
+        if n is not None:
+            result.add(n)
+    return frozenset(result)
+
+
+def _has_numeric_claims(text: str) -> bool:
+    """Return True when *text* contains any numeric financial claim."""
+    return bool(_FIN_NUM_RE.search(text))
+
+
+def _check_tool_enforcement(
+    answer: str,
+    ledger: DataToolLedger,
+    chat_request: ChatRequest,
+) -> bool:
+    """Return True when the gate should trip (answer must be retried or rejected).
+
+    The gate trips only when ALL three conditions hold:
+    1. The answer contains financial numeric claims.
+    2. No data tool produced a successful result.
+    3. The claimed numbers are NOT already present in the input transcript
+       (an agent restating previously provided numbers must pass).
+    """
+    if not _has_numeric_claims(answer):
+        return False
+    if ledger.any_success():
+        return False
+    answer_nums = _extract_financial_numbers(answer)
+    if not answer_nums:
+        return False
+    transcript_text = "\n".join(message_content_text(m) for m in chat_request.messages)
+    transcript_nums = _extract_financial_numbers(transcript_text)
+    return not answer_nums.issubset(transcript_nums)
+
+
+# Deterministic rejection returned when both retry attempts fail.
+# Must NOT be model-generated text.
+_TOOL_ENFORCEMENT_REJECTION = (
+    "[데이터 미확인] 데이터 조회 도구 없이 수치가 포함된 답변이 반복됐습니다. "
+    "잔고·현재가·거래내역 등은 반드시 도구로 조회한 뒤 제시해야 합니다. "
+    "다시 질문해 주세요."
+)
+
+# Prepended to the query on the second attempt to force tool usage.
+# Changes the input rather than repeating the same system-prompt instruction
+# (which the model already ignored on the first attempt).
+_CORRECTIVE_TOOL_PREFIX = (
+    "[도구 강제] 반드시 적절한 데이터 조회 도구를 먼저 호출하여 Observation을 받은 후 답변하세요. "
+    "도구 없이 수치를 포함한 답변은 거부됩니다.\n\n"
+)
+
+
+async def _run_with_gate(
+    *,
+    inner: Any,
+    query: str,
+    chat_request: ChatRequest,
+    inner_name: str,
+) -> str:
+    """Invoke *inner* agent with the tool enforcement gate applied.
+
+    First attempt:
+        Run with *query*; return the answer if the gate passes.
+    Second attempt (gate tripped on first):
+        Re-run with a *changed* input that prepends an explicit tool-use directive.
+        Return the second answer if the gate passes.
+    Both attempts fail:
+        Return *_TOOL_ENFORCEMENT_REJECTION* — a deterministic, non-model string.
+    """
+    # --- First attempt ---
+    ledger = DataToolLedger()
+    token = DATA_TOOL_LEDGER.set(ledger)
+    try:
+        result = await inner.ainvoke(ChatRequestOrMessage(input_message=query))
+    finally:
+        DATA_TOOL_LEDGER.reset(token)
+    answer = chat_response_plain_text(result)
+
+    if not _check_tool_enforcement(answer, ledger, chat_request):
+        return answer
+
+    logger.warning(
+        "Tool enforcement gate tripped on first attempt (%s) — retrying with corrective input",
+        inner_name,
+    )
+
+    # --- Second attempt with changed input ---
+    corrective_query = _CORRECTIVE_TOOL_PREFIX + query
+    ledger2 = DataToolLedger()
+    token2 = DATA_TOOL_LEDGER.set(ledger2)
+    try:
+        result2 = await inner.ainvoke(ChatRequestOrMessage(input_message=corrective_query))
+    finally:
+        DATA_TOOL_LEDGER.reset(token2)
+    answer2 = chat_response_plain_text(result2)
+
+    if not _check_tool_enforcement(answer2, ledger2, chat_request):
+        return answer2
+
+    logger.error(
+        "Tool enforcement gate tripped twice (%s) — returning deterministic rejection",
+        inner_name,
+    )
+    return _TOOL_ENFORCEMENT_REJECTION
 
 
 def message_content_text(message: Message) -> str:
@@ -222,17 +371,19 @@ async def fe_branch(config: FeBranchConfig, builder: Builder):
             if direct is not None:
                 return direct
         inner = await builder.get_function(inner_name)
-        payload = ChatRequestOrMessage(
-            input_message=_contextual_user_query(
-                chat_request,
-                config.max_history_messages,
-                config.history_message_max_chars,
-                config.history_assistant_message_max_chars,
-                config.history_transcript_max_chars,
-            )
+        query = _contextual_user_query(
+            chat_request,
+            config.max_history_messages,
+            config.history_message_max_chars,
+            config.history_assistant_message_max_chars,
+            config.history_transcript_max_chars,
         )
-        result = await inner.ainvoke(payload)
-        return chat_response_plain_text(result)
+        return await _run_with_gate(
+            inner=inner,
+            query=query,
+            chat_request=chat_request,
+            inner_name=inner_name,
+        )
 
     yield FunctionInfo.from_fn(run_subagent, description=desc)
 

--- a/finus_nat/src/nat_finus_nat/finus_api.py
+++ b/finus_nat/src/nat_finus_nat/finus_api.py
@@ -96,7 +96,9 @@ def _record_to_ledger(tool_name: str, result: str) -> None:
         return
     stripped = result.strip()
     ok = bool(stripped) and not _ERROR_JSON_PREFIX_RE.match(stripped)
-    ledger.record(tool_name, ok=ok, produced_rows=ok)
+    # 쓰기 도구의 성공은 "조회해서 데이터를 받았다"가 아니다. any_success()에 포함되면
+    # 일지 저장 한 번으로 그 호출 전체의 게이트가 풀린다.
+    ledger.record(tool_name, ok=ok, produced_rows=ok and tool_name not in _SIDE_EFFECT_TOOLS)
 
 
 # Remote MCP / doc 한도

--- a/finus_nat/src/nat_finus_nat/finus_api.py
+++ b/finus_nat/src/nat_finus_nat/finus_api.py
@@ -1,10 +1,14 @@
 import asyncio
 import json
+import logging
 import os
-from contextlib import asynccontextmanager
-from pathlib import Path
+import re
 from collections.abc import Callable
-from typing import Any, Literal, TypeAlias
+from contextlib import asynccontextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal, NamedTuple, TypeAlias
 
 import httpx
 from mcp import ClientSession
@@ -18,6 +22,68 @@ from nat.builder.builder import Builder
 from nat.builder.function_info import FunctionInfo
 from nat.cli.register_workflow import register_function
 from nat.data_models.function import FunctionBaseConfig
+
+logger = logging.getLogger(__name__)
+
+# ---- Data-tool ledger for tool enforcement (#152) ----
+
+
+class DataToolRecord(NamedTuple):
+    """Immutable record of one Fin-Us data tool invocation."""
+
+    tool_name: str
+    ok: bool          # True when the response contains non-error data
+    produced_rows: bool  # True when ok and the response body is non-empty
+
+
+@dataclass
+class DataToolLedger:
+    """Mutable box tracking Fin-Us data tool calls within a run_subagent invocation.
+
+    Stored as a mutable object (not ContextVar[int] + .set()) so that
+    mutations remain visible across asyncio.create_task context copies that
+    LangGraph creates internally via copy_context().
+    """
+
+    records: list[DataToolRecord] = field(default_factory=list)
+
+    def record(self, tool_name: str, *, ok: bool, produced_rows: bool) -> None:
+        self.records.append(DataToolRecord(tool_name=tool_name, ok=ok, produced_rows=produced_rows))
+
+    def any_success(self) -> bool:
+        """Return True if at least one tool call successfully produced data rows."""
+        return any(r.ok and r.produced_rows for r in self.records)
+
+
+DATA_TOOL_LEDGER: ContextVar["DataToolLedger | None"] = ContextVar(
+    "finus_data_tool_ledger", default=None
+)
+
+_ERROR_JSON_PREFIX_RE = re.compile(r'^\s*\{"error"')
+
+
+def _record_to_ledger(tool_name: str, result: str) -> None:
+    """Record a completed data-tool call into the current context's ledger.
+
+    Logs ERROR and returns without recording when the ledger box is None —
+    this happens when a tool runs in a threadpool that did not inherit the
+    ContextVar (e.g., outside a run_subagent context).  The resulting empty
+    ledger causes the gate to trip for any numeric claim, which is the
+    correct conservative behaviour.
+    """
+    ledger = DATA_TOOL_LEDGER.get()
+    if ledger is None:
+        logger.error(
+            "DATA_TOOL_LEDGER not set when %s completed — tool enforcement cannot "
+            "track this call. Tool may have run outside a run_subagent context or "
+            "in a threadpool that does not propagate contextvars.",
+            tool_name,
+        )
+        return
+    stripped = result.strip()
+    ok = bool(stripped) and not _ERROR_JSON_PREFIX_RE.match(stripped)
+    ledger.record(tool_name, ok=ok, produced_rows=ok)
+
 
 # Remote MCP / doc 한도
 _MCP_DOC_MAX_CHARS = 14_000 #텍스트 최대 길이
@@ -589,14 +655,18 @@ def _mcp_news_stock_function_info(
     timeout_sec: float,
     mcp_tool: str,
     fn_doc: str,
+    ledger_tool_name: str = "",
 ) -> FunctionInfo:
     async def by_stock(stock_name: str) -> str:
-        return await _mcp_news_stock(
+        result = await _mcp_news_stock(
             vendor_root=vendor_root,
             timeout_sec=timeout_sec,
             tool_name=mcp_tool,
             stock_name=stock_name,
         )
+        if ledger_tool_name:
+            _record_to_ledger(ledger_tool_name, result)
+        return result
 
     by_stock.__doc__ = fn_doc
     return FunctionInfo.from_fn(by_stock, description=fn_doc)
@@ -613,6 +683,7 @@ async def finus_market_news(config: FinusMarketNewsConfig, _builder: Builder):
         timeout_sec=config.timeout_sec,
         mcp_tool="get_market_news",
         fn_doc=doc,
+        ledger_tool_name="finus_market_news",
     )
 
 
@@ -624,11 +695,13 @@ async def finus_disclosure_signal(config: FinusDisclosureSignalConfig, _builder:
     )
 
     async def get_disclosure_signal(stock_name: str) -> str:
-        return await _mcp_dart_stock(
+        result = await _mcp_dart_stock(
             vendor_root=config.vendor_root,
             timeout_sec=config.timeout_sec,
             stock_name=stock_name,
         )
+        _record_to_ledger("finus_disclosure_signal", result)
+        return result
 
     get_disclosure_signal.__doc__ = doc
     yield FunctionInfo.from_fn(get_disclosure_signal, description=doc)
@@ -643,12 +716,14 @@ async def finus_earnings_report(config: FinusEarningsReportConfig, _builder: Bui
     )
 
     async def get_earnings_report(stock_name: str, period: str | None = None) -> str:
-        return await _mcp_dart_earnings_stock(
+        result = await _mcp_dart_earnings_stock(
             vendor_root=config.vendor_root,
             timeout_sec=config.timeout_sec,
             stock_name=stock_name,
             period=period,
         )
+        _record_to_ledger("finus_earnings_report", result)
+        return result
 
     get_earnings_report.__doc__ = doc
     yield FunctionInfo.from_fn(get_earnings_report, description=doc)
@@ -672,12 +747,14 @@ async def finus_mcp_trading_today_orders(config: FinusMcpTradingTodayOrdersConfi
             arguments["ccld_dvsn"] = inp.ccld_dvsn.strip()
         if inp.sll_buy_dvsn.strip():
             arguments["sll_buy_dvsn"] = inp.sll_buy_dvsn.strip()
-        return await _mcp_trading_call(
+        result = await _mcp_trading_call(
             vendor_root=config.vendor_root,
             timeout_sec=config.timeout_sec,
             tool_name="get_today_daily_orders",
             arguments=arguments,
         )
+        _record_to_ledger("finus_mcp_trading_today_orders", result)
+        return result
 
     get_today_daily_orders.__doc__ = doc
     yield FunctionInfo.from_fn(
@@ -696,12 +773,14 @@ async def finus_mcp_trading_get_balance(config: FinusMcpTradingGetBalanceConfig,
     )
 
     async def get_balance(inp: FinusMcpTradingGetBalanceInput) -> str:  # noqa: ARG001
-        return await _mcp_trading_call(
+        result = await _mcp_trading_call(
             vendor_root=config.vendor_root,
             timeout_sec=config.timeout_sec,
             tool_name="get_balance",
             arguments={},
         )
+        _record_to_ledger("finus_mcp_trading_get_balance", result)
+        return result
 
     get_balance.__doc__ = doc
     yield FunctionInfo.from_fn(
@@ -724,12 +803,14 @@ async def finus_mcp_trading_balance_rlz_pl(config: FinusMcpTradingBalanceRlzPlCo
         arguments: McpCallArguments = {}
         if inp.stock_name.strip():
             arguments["stock_name"] = inp.stock_name.strip()
-        return await _mcp_trading_call(
+        result = await _mcp_trading_call(
             vendor_root=config.vendor_root,
             timeout_sec=config.timeout_sec,
             tool_name="get_balance_rlz_pl",
             arguments=arguments,
         )
+        _record_to_ledger("finus_mcp_trading_balance_rlz_pl", result)
+        return result
 
     get_balance_rlz_pl.__doc__ = doc
     yield FunctionInfo.from_fn(
@@ -914,15 +995,18 @@ async def finus_account_balance(config: FinusAccountBalanceConfig, _builder: Bui
         """
         prepared = _prepare_kis_trading_mcp_call(inp, config)
         if isinstance(prepared, str):
+            _record_to_ledger("finus_account_balance", prepared)
             return prepared
         tool_name, arguments = prepared
-        return await _mcp_call_tool_remote(
+        result = await _mcp_call_tool_remote(
             transport=config.mcp_transport,
             url=config.mcp_url,
             tool_name=tool_name,
             arguments=arguments,
             timeout_sec=config.timeout_sec,
         )
+        _record_to_ledger("finus_account_balance", result)
+        return result
 
     base_desc = (get_account_balance.__doc__ or "").strip()
     remote = await _fetch_mcp_tool_documentation(config)

--- a/finus_nat/src/nat_finus_nat/finus_api.py
+++ b/finus_nat/src/nat_finus_nat/finus_api.py
@@ -36,6 +36,12 @@ class DataToolRecord(NamedTuple):
     produced_rows: bool  # True when ok and the response body is non-empty
 
 
+# Tools that produce irreversible side effects (writes). When any of these appear in
+# the ledger and the gate trips, _run_with_gate skips the retry to prevent duplicate
+# writes (e.g. two identical diary entries created for one user request).
+_SIDE_EFFECT_TOOLS: frozenset[str] = frozenset({"finus_save_diary"})
+
+
 @dataclass
 class DataToolLedger:
     """Mutable box tracking Fin-Us data tool calls within a run_subagent invocation.
@@ -53,6 +59,14 @@ class DataToolLedger:
     def any_success(self) -> bool:
         """Return True if at least one tool call successfully produced data rows."""
         return any(r.ok and r.produced_rows for r in self.records)
+
+    def had_side_effect(self) -> bool:
+        """Return True if a side-effecting (write) tool was recorded.
+
+        Used by _run_with_gate to skip the retry and return the rejection immediately,
+        preventing duplicate writes when the gate trips after a diary save.
+        """
+        return any(r.tool_name in _SIDE_EFFECT_TOOLS for r in self.records)
 
 
 DATA_TOOL_LEDGER: ContextVar["DataToolLedger | None"] = ContextVar(
@@ -655,7 +669,7 @@ def _mcp_news_stock_function_info(
     timeout_sec: float,
     mcp_tool: str,
     fn_doc: str,
-    ledger_tool_name: str = "",
+    ledger_tool_name: str,  # required — omitting silently disables ledger tracking
 ) -> FunctionInfo:
     async def by_stock(stock_name: str) -> str:
         result = await _mcp_news_stock(
@@ -664,8 +678,7 @@ def _mcp_news_stock_function_info(
             tool_name=mcp_tool,
             stock_name=stock_name,
         )
-        if ledger_tool_name:
-            _record_to_ledger(ledger_tool_name, result)
+        _record_to_ledger(ledger_tool_name, result)
         return result
 
     by_stock.__doc__ = fn_doc
@@ -838,9 +851,13 @@ async def finus_save_diary(config: FinusSaveDiaryConfig, _builder: Builder):
         title = (inp.title or "").strip()
         content = (inp.content or "").strip()
         if not title:
-            return _err_json("diary_title_required", hint="Provide a non-empty title.")
+            result = _err_json("diary_title_required", hint="Provide a non-empty title.")
+            _record_to_ledger("finus_save_diary", result)
+            return result
         if not content:
-            return _err_json("diary_content_required", hint="Provide non-empty diary content.")
+            result = _err_json("diary_content_required", hint="Provide non-empty diary content.")
+            _record_to_ledger("finus_save_diary", result)
+            return result
 
         url = f"{base_url}/api/v1/db/diary"
         try:
@@ -849,18 +866,26 @@ async def finus_save_diary(config: FinusSaveDiaryConfig, _builder: Builder):
                 resp.raise_for_status()
                 body = resp.json()
         except httpx.HTTPStatusError as exc:
-            return _err_json(
+            result = _err_json(
                 "diary_api_http_error",
                 status_code=exc.response.status_code,
                 detail=exc.response.text[:500],
                 url=url,
             )
+            _record_to_ledger("finus_save_diary", result)
+            return result
         except Exception as exc:  # noqa: BLE001
-            return _err_json("diary_api_request_failed", detail=str(exc), url=url)
+            result = _err_json("diary_api_request_failed", detail=str(exc), url=url)
+            _record_to_ledger("finus_save_diary", result)
+            return result
 
         if body.get("status") != "success":
-            return _err_json("diary_api_error", response=body)
-        return json.dumps(body.get("data"), ensure_ascii=False)
+            result = _err_json("diary_api_error", response=body)
+            _record_to_ledger("finus_save_diary", result)
+            return result
+        result = json.dumps(body.get("data"), ensure_ascii=False)
+        _record_to_ledger("finus_save_diary", result)
+        return result
 
     yield FunctionInfo.from_fn(
         save_trading_diary,
@@ -887,18 +912,26 @@ async def finus_list_diaries(config: FinusListDiariesConfig, _builder: Builder):
                 resp.raise_for_status()
                 body = resp.json()
         except httpx.HTTPStatusError as exc:
-            return _err_json(
+            result = _err_json(
                 "diary_api_http_error",
                 status_code=exc.response.status_code,
                 detail=exc.response.text[:500],
                 url=url,
             )
+            _record_to_ledger("finus_list_diaries", result)
+            return result
         except Exception as exc:  # noqa: BLE001
-            return _err_json("diary_api_request_failed", detail=str(exc), url=url)
+            result = _err_json("diary_api_request_failed", detail=str(exc), url=url)
+            _record_to_ledger("finus_list_diaries", result)
+            return result
 
         if body.get("status") != "success":
-            return _err_json("diary_api_error", response=body)
-        return json.dumps(body.get("data"), ensure_ascii=False)
+            result = _err_json("diary_api_error", response=body)
+            _record_to_ledger("finus_list_diaries", result)
+            return result
+        result = json.dumps(body.get("data"), ensure_ascii=False)
+        _record_to_ledger("finus_list_diaries", result)
+        return result
 
     yield FunctionInfo.from_fn(
         list_trading_diaries,

--- a/finus_nat/src/nat_finus_nat/register.py
+++ b/finus_nat/src/nat_finus_nat/register.py
@@ -12,3 +12,51 @@ if _FINUS_NAT_ENV.is_file():
 #  NAT에 함수/도구 등록을 트리거
 from nat_finus_nat import agents
 from nat_finus_nat import finus_api
+
+
+def _build_vendor_patch_status() -> dict[str, str]:
+    """Detect actual installation status of NAT ReAct vendor patches.
+
+    The patching approach was abandoned in #152:
+    - ``accept_direct_answer_without_react_format`` was removed upstream (1.6.0+)
+    - ``_wrapped`` was never installed (react_graph_init failed due to signature change)
+    - The three Fin-Us ReAct prompts are now delivered via YAML ``system_prompt``
+
+    All three patch slots are expected to be ``"not_applied"`` — vendor code is clean.
+    A value of ``"applied"`` means something unexpected is patching the vendor at runtime.
+    Returns ``"unknown"`` for all slots when the vendor module cannot be imported.
+    """
+    try:
+        import nat.plugins.langchain.agent.react_agent.agent as _ra_mod
+        import nat.plugins.langchain.agent.react_agent.prompt as _prompt_mod
+        from nat.plugins.langchain.agent.react_agent.agent import ReActAgentGraph
+
+        return {
+            "react_system_prompt": (
+                "not_applied"
+                if _ra_mod.SYSTEM_PROMPT is _prompt_mod.SYSTEM_PROMPT
+                else "applied"
+            ),
+            "agent_node_plain_final": (
+                "not_applied"
+                if ReActAgentGraph.agent_node.__code__.co_filename == _ra_mod.__file__
+                else "applied"
+            ),
+            "react_graph_init": (
+                "not_applied"
+                if ReActAgentGraph.__init__.__code__.co_filename == _ra_mod.__file__
+                else "applied"
+            ),
+        }
+    except Exception:  # noqa: BLE001
+        return {
+            "react_system_prompt": "unknown",
+            "agent_node_plain_final": "unknown",
+            "react_graph_init": "unknown",
+        }
+
+
+#: Reflects actual vendor patch installation status (#152).
+#: All slots should be ``"not_applied"`` — patching was abandoned because the
+#: upstream hook point (``accept_direct_answer_without_react_format``) was removed.
+VENDOR_PATCH_STATUS: dict[str, str] = _build_vendor_patch_status()

--- a/finus_nat/tests/test_import.py
+++ b/finus_nat/tests/test_import.py
@@ -53,3 +53,23 @@ def test_react_agent_graph_init_is_unpatched_vendor_code():
 
     # 옛 패치의 실제 페이로드: 소스 재작성이 아니라 모듈 전역 SYSTEM_PROMPT 재바인딩.
     assert ra_mod.SYSTEM_PROMPT is prompt_mod.SYSTEM_PROMPT
+
+
+def test_vendor_patch_status_reflects_actual_installation():
+    """#152: VENDOR_PATCH_STATUS가 실제 벤더 패치 설치 여부를 반영한다.
+
+    패치 코드가 제거됐으므로 세 항목 모두 ``"not_applied"``여야 한다.
+    값이 ``"applied"``이면 예상치 못한 런타임 패치가 벤더를 수정하고 있다는 뜻이고,
+    값이 ``"unknown"``이면 벤더 모듈을 import하지 못했다는 뜻 — 둘 다 이상 상태다.
+    """
+    from nat_finus_nat.register import VENDOR_PATCH_STATUS
+
+    assert VENDOR_PATCH_STATUS["react_system_prompt"] == "not_applied", (
+        "react_system_prompt: 패치가 예상치 않게 설치돼 있거나 모듈 import 실패"
+    )
+    assert VENDOR_PATCH_STATUS["agent_node_plain_final"] == "not_applied", (
+        "agent_node_plain_final: 패치가 예상치 않게 설치돼 있거나 모듈 import 실패"
+    )
+    assert VENDOR_PATCH_STATUS["react_graph_init"] == "not_applied", (
+        "react_graph_init: 패치가 예상치 않게 설치돼 있거나 모듈 import 실패"
+    )

--- a/finus_nat/tests/test_tool_enforcement.py
+++ b/finus_nat/tests/test_tool_enforcement.py
@@ -1,0 +1,221 @@
+"""#152: 도구 강제 게이트(tool enforcement gate) 동작 고정 테스트.
+
+이슈가 명시한 7개 케이스와 VENDOR_PATCH_STATUS 특성화 테스트를 포함한다.
+실 KIS·OpenAI 연결 없이 동작한다.
+
+게이트 로직(``_check_tool_enforcement``)과 재시도·거절 흐름(``_run_with_gate``)을
+직접 호출해 검증하므로, 실제 ReAct 에이전트나 LLM 없이도 동작이 고정된다.
+"""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nat.data_models.api_server import (
+    ChatRequest,
+    ChatResponse,
+    Message,
+    Usage,
+    UserMessageContentRoleType,
+)
+
+from nat_finus_nat.agents import (
+    _TOOL_ENFORCEMENT_REJECTION,
+    _check_tool_enforcement,
+    _extract_financial_numbers,
+    _has_numeric_claims,
+    _run_with_gate,
+)
+from nat_finus_nat.finus_api import DATA_TOOL_LEDGER, DataToolLedger, _record_to_ledger
+
+
+# ---------------------------------------------------------------------------
+# 헬퍼
+# ---------------------------------------------------------------------------
+
+def _req(*turns: tuple[str, str]) -> ChatRequest:
+    """역할·내용 튜플 목록으로 ChatRequest를 만든다."""
+    return ChatRequest(
+        messages=[
+            Message(role=UserMessageContentRoleType(role), content=content)
+            for role, content in turns
+        ]
+    )
+
+
+def _simple_req(text: str = "잔고 알려줘") -> ChatRequest:
+    return _req(("user", text))
+
+
+def _ledger_with_success(tool: str = "finus_mcp_trading_get_balance") -> DataToolLedger:
+    ledger = DataToolLedger()
+    ledger.record(tool, ok=True, produced_rows=True)
+    return ledger
+
+
+def _ledger_with_error(tool: str = "finus_mcp_trading_get_balance") -> DataToolLedger:
+    ledger = DataToolLedger()
+    ledger.record(tool, ok=False, produced_rows=False)
+    return ledger
+
+
+# ---------------------------------------------------------------------------
+# 케이스 1 — 수치 주장 + 도구 호출 없음 → 트립
+# ---------------------------------------------------------------------------
+
+def test_gate_trips_on_numeric_claim_no_tool():
+    """도구를 전혀 호출하지 않고 잔고 수치를 주장하면 게이트가 트립한다."""
+    ledger = DataToolLedger()  # 빈 원장 — 호출 없음
+    answer = "Thought: 알겠습니다\nFinal Answer: 잔고는 5,000,000원입니다."
+    assert _check_tool_enforcement(answer, ledger, _simple_req()) is True
+
+
+# ---------------------------------------------------------------------------
+# 케이스 2 — 수치 주장 + 도구 성공(데이터 있음) → 통과
+# ---------------------------------------------------------------------------
+
+def test_gate_passes_on_numeric_claim_with_tool_success():
+    """데이터 조회 도구가 성공적으로 응답했으면 수치 주장이 있어도 통과한다."""
+    ledger = _ledger_with_success()
+    answer = "Final Answer: 잔고는 5,000,000원입니다."
+    assert _check_tool_enforcement(answer, ledger, _simple_req()) is False
+
+
+# ---------------------------------------------------------------------------
+# 케이스 3 — 수치 주장 + 도구 호출했으나 오류 → 트립
+# ---------------------------------------------------------------------------
+
+def test_gate_trips_on_numeric_claim_with_tool_error():
+    """도구를 호출했지만 오류 응답을 받았고 수치를 주장하면 트립한다.
+
+    KIS 재시도 루프에서 에이전트가 오류 Observation을 받은 뒤 수치를 지어내는 경로가
+    가장 빈번한 조작 경로다(이슈 #152 섹션 "반드시 지켜야 할 것들" 참고).
+    """
+    ledger = _ledger_with_error()
+    answer = "Final Answer: 잔고는 5,000,000원입니다."
+    assert _check_tool_enforcement(answer, ledger, _simple_req()) is True
+
+
+# ---------------------------------------------------------------------------
+# 케이스 4 — 도구 없는 정성적 후속 답변 → 통과
+# ---------------------------------------------------------------------------
+
+def test_gate_passes_on_qualitative_answer_without_tool():
+    """도구 없이 정성적 평가만 답해도 수치가 없으면 게이트를 통과한다.
+
+    news_agent·strategy_agent YAML은 직전 대화 맥락만으로 후속 질문에 답하라고
+    명시적으로 지시한다 — 이 경우 도구 없이 답하는 것이 의도된 동작이다.
+    """
+    ledger = DataToolLedger()
+    req = _req(
+        ("user", "삼성전자 최근 주가 흐름 어때?"),
+        ("assistant", "최근 삼성전자는 반도체 수요 회복으로 상승세입니다."),
+        ("user", "왜 그런거야?"),
+    )
+    answer = "Final Answer: 반도체 수요 회복과 AI 모멘텀 덕분에 투자심리가 개선됐습니다."
+    assert _check_tool_enforcement(answer, ledger, req) is False
+
+
+# ---------------------------------------------------------------------------
+# 케이스 5 — 대화록의 수치를 다른 표기로 재진술 → 통과
+# ---------------------------------------------------------------------------
+
+def test_gate_passes_on_transcript_number_restatement():
+    """대화록에 있던 수치를 다른 표기(쉼표/만 단위)로 재진술하면 통과한다.
+
+    ``75,300원`` → ``7만 5300원`` 은 같은 값(75300)이므로 새로운 수치를
+    지어낸 것이 아니다.
+    """
+    ledger = DataToolLedger()  # 도구 없음 — 맥락 재진술이므로 허용
+    req = _req(
+        ("user", "삼성전자 현재가 알려줘"),
+        ("assistant", "삼성전자 현재가는 75,300원입니다."),
+        ("user", "그래서 7만원대야?"),
+    )
+    answer = "Final Answer: 네, 7만 5300원으로 7만원대 중반입니다."
+    assert _check_tool_enforcement(answer, ledger, req) is False
+
+
+# ---------------------------------------------------------------------------
+# 케이스 6 — 원장 박스 없음 → 트립 + ERROR 로그
+# ---------------------------------------------------------------------------
+
+def test_record_to_ledger_logs_error_and_leaves_ledger_empty_when_box_is_none(caplog):
+    """DATA_TOOL_LEDGER가 None일 때 _record_to_ledger가 ERROR를 로그하고
+    조용히 반환한다. 이후 빈 원장으로 게이트 검사하면 수치 주장에 대해 트립한다.
+
+    스레드풀 등 ContextVar가 전파되지 않는 실행 컨텍스트를 시뮬레이션한다.
+    """
+    token = DATA_TOOL_LEDGER.set(None)
+    try:
+        with caplog.at_level(logging.ERROR, logger="nat_finus_nat.finus_api"):
+            _record_to_ledger("finus_mcp_trading_get_balance", '{"total_balance": 5000000}')
+    finally:
+        DATA_TOOL_LEDGER.reset(token)
+
+    # ERROR 로그가 발생했는지 확인
+    assert any(
+        "DATA_TOOL_LEDGER" in r.message for r in caplog.records
+    ), "DATA_TOOL_LEDGER 없음에 대한 ERROR 로그가 없습니다"
+
+    # 기록에 실패한 빈 원장 → 수치 주장 시 트립
+    empty_ledger = DataToolLedger()
+    answer = "Final Answer: 잔고는 5,000,000원입니다."
+    assert _check_tool_enforcement(answer, empty_ledger, _simple_req()) is True
+
+
+# ---------------------------------------------------------------------------
+# 케이스 7 — 두 번째 시도도 실패 → 결정론적 거절, 모델 문장 아님
+# ---------------------------------------------------------------------------
+
+async def test_second_attempt_failure_returns_deterministic_rejection():
+    """두 번 모두 게이트가 트립하면 _TOOL_ENFORCEMENT_REJECTION을 반환해야 한다.
+
+    항상 수치를 지어내고 도구를 전혀 호출하지 않는 내부 에이전트를 모킹해
+    재시도 후 결정론적 거절 문자열이 반환되는지 검증한다.
+    """
+    fabricated = "Final Answer: 잔고는 5,000,000원입니다."
+    # inner.ainvoke가 항상 수치를 지어낸 ChatResponse를 반환하도록 모킹
+    mock_ainvoke = AsyncMock(return_value=ChatResponse.from_string(fabricated, usage=Usage()))
+    mock_inner = MagicMock()
+    mock_inner.ainvoke = mock_ainvoke
+
+    result = await _run_with_gate(
+        inner=mock_inner,
+        query="잔고 알려줘",
+        chat_request=_simple_req(),
+        inner_name="trading_agent_react",
+    )
+
+    assert result == _TOOL_ENFORCEMENT_REJECTION, (
+        f"결정론적 거절 메시지가 반환돼야 합니다. 실제: {result!r}"
+    )
+    assert mock_ainvoke.call_count == 2, (
+        f"내부 에이전트를 정확히 2회 호출해야 합니다. 실제: {mock_ainvoke.call_count}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 보조 단언 — 숫자 정규화
+# ---------------------------------------------------------------------------
+
+def test_extract_financial_numbers_normalizes_comma_notation():
+    assert _extract_financial_numbers("75,300원") == frozenset({75300})
+
+
+def test_extract_financial_numbers_normalizes_korean_unit():
+    assert _extract_financial_numbers("7만 5300원") == frozenset({75300})
+
+
+def test_extract_financial_numbers_matches_comma_and_korean_unit():
+    """쉼표 표기와 만 단위 표기가 같은 정규화 값을 갖는다."""
+    assert _extract_financial_numbers("75,300원") == _extract_financial_numbers("7만 5300원")
+
+
+def test_has_numeric_claims_positive():
+    assert _has_numeric_claims("잔고는 5,000,000원입니다.") is True
+
+
+def test_has_numeric_claims_negative():
+    assert _has_numeric_claims("반도체 수요가 회복되고 있습니다.") is False

--- a/finus_nat/tests/test_tool_enforcement.py
+++ b/finus_nat/tests/test_tool_enforcement.py
@@ -10,8 +10,6 @@
 import logging
 from unittest.mock import AsyncMock, MagicMock
 
-import pytest
-
 from nat.data_models.api_server import (
     ChatRequest,
     ChatResponse,
@@ -27,7 +25,7 @@ from nat_finus_nat.agents import (
     _has_numeric_claims,
     _run_with_gate,
 )
-from nat_finus_nat.finus_api import DATA_TOOL_LEDGER, DataToolLedger, _record_to_ledger
+from nat_finus_nat.finus_api import DATA_TOOL_LEDGER, DataToolLedger, _err_json, _record_to_ledger
 
 
 # ---------------------------------------------------------------------------
@@ -201,11 +199,13 @@ async def test_second_attempt_failure_returns_deterministic_rejection():
 # ---------------------------------------------------------------------------
 
 def test_extract_financial_numbers_normalizes_comma_notation():
-    assert _extract_financial_numbers("75,300원") == frozenset({75300})
+    # Values are scaled by ×1000 to preserve decimal precision (see _NUM_SCALE).
+    assert _extract_financial_numbers("75,300원") == frozenset({75_300_000})
 
 
 def test_extract_financial_numbers_normalizes_korean_unit():
-    assert _extract_financial_numbers("7만 5300원") == frozenset({75300})
+    # Values are scaled by ×1000 to preserve decimal precision (see _NUM_SCALE).
+    assert _extract_financial_numbers("7만 5300원") == frozenset({75_300_000})
 
 
 def test_extract_financial_numbers_matches_comma_and_korean_unit():
@@ -219,3 +219,188 @@ def test_has_numeric_claims_positive():
 
 def test_has_numeric_claims_negative():
     assert _has_numeric_claims("반도체 수요가 회복되고 있습니다.") is False
+
+
+# ---------------------------------------------------------------------------
+# Critical 1 — 한국어 만/억/조 단위로 끝나는 금액 탐지
+# ---------------------------------------------------------------------------
+
+def test_has_numeric_claims_detects_man_unit_only():
+    """'500만원'처럼 만 단위로 끝나는 표기를 탐지한다."""
+    assert _has_numeric_claims("잔고는 500만원입니다.") is True
+
+
+def test_has_numeric_claims_detects_eok_unit_only():
+    """'1억원'처럼 억 단위로 끝나는 표기를 탐지한다."""
+    assert _has_numeric_claims("평가금액은 1억원입니다.") is True
+
+
+def test_has_numeric_claims_detects_man_with_comma():
+    """'1,200만원'처럼 쉼표+만 단위 표기를 탐지한다."""
+    assert _has_numeric_claims("예수금 1,200만원이 있습니다.") is True
+
+
+def test_has_numeric_claims_detects_jo_unit_only():
+    """'350조원'처럼 조 단위로 끝나는 표기를 탐지한다."""
+    assert _has_numeric_claims("시가총액은 350조원입니다.") is True
+
+
+def test_korean_unit_only_same_value_as_full_notation():
+    """'500만원'과 '5,000,000원'이 같은 정규화 값을 가진다(탐지+비교 모두 일치)."""
+    assert _extract_financial_numbers("500만원") == _extract_financial_numbers("5,000,000원")
+
+
+def test_korean_unit_only_cross_check():
+    """'1억원'과 '100,000,000원'이 같은 정규화 값을 가진다."""
+    assert _extract_financial_numbers("1억원") == _extract_financial_numbers("100,000,000원")
+
+
+def test_gate_trips_on_man_unit_amount_no_tool():
+    """'500만원'처럼 만 단위 표기가 있고 도구 없으면 게이트가 트립한다."""
+    ledger = DataToolLedger()
+    answer = "Final Answer: 잔고는 500만원입니다."
+    assert _check_tool_enforcement(answer, ledger, _simple_req()) is True
+
+
+# ---------------------------------------------------------------------------
+# Critical 3 — 소수 구분: 5.7%는 5.3%의 부분집합이 아님
+# ---------------------------------------------------------------------------
+
+def test_gate_trips_on_mismatched_decimal_numbers():
+    """5.7%와 5.3%는 다른 수치이므로 게이트가 트립해야 한다.
+
+    int(float(s)) 버그가 있으면 두 값 모두 5로 정규화돼 오통과한다.
+    _NUM_SCALE=1000 이후에는 5700≠5300이라 정확히 구분된다.
+    """
+    ledger = DataToolLedger()
+    req = _req(
+        ("user", "수익률 알려줘"),
+        ("assistant", "수익률은 5.3%입니다."),
+        ("user", "정말?"),
+    )
+    answer = "Final Answer: 수익률은 5.7%입니다."
+    assert _check_tool_enforcement(answer, ledger, req) is True
+
+
+def test_gate_passes_on_exact_decimal_restatement():
+    """대화록에 있는 소수 수치를 그대로 재진술하면 통과한다."""
+    ledger = DataToolLedger()
+    req = _req(
+        ("user", "수익률 알려줘"),
+        ("assistant", "수익률은 5.7%입니다."),
+        ("user", "확인해줘"),
+    )
+    answer = "Final Answer: 말씀드린 대로 수익률은 5.7%입니다."
+    assert _check_tool_enforcement(answer, ledger, req) is False
+
+
+# ---------------------------------------------------------------------------
+# Improvement 1 — 주(株) vs 기간 표현 오탐 방지
+# ---------------------------------------------------------------------------
+
+def test_has_numeric_claims_does_not_match_juil():
+    """'1주일'은 기간 표현이므로 탐지하지 않는다."""
+    assert _has_numeric_claims("1주일 전 뉴스입니다.") is False
+
+
+def test_has_numeric_claims_does_not_match_ju_dongan():
+    """'2주 동안'은 기간 표현이므로 탐지하지 않는다."""
+    assert _has_numeric_claims("최근 2주 동안 반도체 업황이 개선됐습니다.") is False
+
+
+def test_has_numeric_claims_does_not_match_jugan():
+    """'2주간'은 기간 표현이므로 탐지하지 않는다."""
+    assert _has_numeric_claims("2주간 상승세가 이어졌습니다.") is False
+
+
+def test_has_numeric_claims_does_not_match_ju_after():
+    """'3주 후'는 기간 표현이므로 탐지하지 않는다."""
+    assert _has_numeric_claims("3주 후 실적 발표가 있습니다.") is False
+
+
+def test_has_numeric_claims_matches_stock_quantity():
+    """'100주 보유'는 주식 수량이므로 탐지한다."""
+    assert _has_numeric_claims("삼성전자 100주 보유 중입니다.") is True
+
+
+def test_has_numeric_claims_matches_stock_sell():
+    """'100주를 매도'는 주식 수량이므로 탐지한다."""
+    assert _has_numeric_claims("삼성전자 100주를 매도했습니다.") is True
+
+
+# ---------------------------------------------------------------------------
+# Improvement 4 — _record_to_ledger의 오류 판정 정합성 고정
+# ---------------------------------------------------------------------------
+
+def test_record_to_ledger_marks_err_json_as_failure():
+    """_err_json()이 만든 오류 응답은 ok=False로, 정상 JSON은 ok=True로 기록된다.
+
+    이 단언이 깨지면 새 오류 반환 경로가 {"error": ...} 규약을 벗어난 것이고,
+    그 도구에 대해 게이트가 조용히 무력화된다.
+    """
+    ledger = DataToolLedger()
+    token = DATA_TOOL_LEDGER.set(ledger)
+    try:
+        _record_to_ledger("finus_account_balance", _err_json("mcp_timeout", tool="domestic_stock"))
+        _record_to_ledger("finus_account_balance", '{"output": [{"prpr": "75300"}]}')
+    finally:
+        DATA_TOOL_LEDGER.reset(token)
+
+    assert [r.ok for r in ledger.records] == [False, True]
+    assert ledger.any_success() is True
+
+
+# ---------------------------------------------------------------------------
+# Critical 2 — 부작용 도구 재시도 금지 가드
+# ---------------------------------------------------------------------------
+
+def test_ledger_had_side_effect_true_for_save_diary():
+    """finus_save_diary 기록이 있으면 had_side_effect()가 True를 반환한다."""
+    ledger = DataToolLedger()
+    ledger.record("finus_save_diary", ok=True, produced_rows=True)
+    assert ledger.had_side_effect() is True
+
+
+def test_ledger_had_side_effect_false_for_read_tools():
+    """읽기 전용 도구만 기록된 원장은 had_side_effect()가 False를 반환한다."""
+    ledger = DataToolLedger()
+    ledger.record("finus_mcp_trading_get_balance", ok=True, produced_rows=True)
+    assert ledger.had_side_effect() is False
+
+
+async def test_side_effect_guard_skips_retry_on_write_tool():
+    """finus_save_diary가 실패 후에도 수치를 주장하면 재시도 없이 즉시 거절한다.
+
+    시나리오: 저장 API 오류(ok=False) → 원장에 실패 기록 → 에이전트가 수치 주장
+    → 게이트 트립 → 가드가 had_side_effect()=True를 보고 재시도 건너뜀.
+    재시도가 일어나면 저장이 다시 시도되어 DB에 중복/잡음이 생길 수 있다.
+    """
+    # HTTP 오류 후에도 에이전트가 수치를 지어내는 답변을 돌려준다고 가정
+    fabricated = "Final Answer: 실현손익 52,000원을 일지에 저장했습니다."
+    call_count = 0
+
+    async def ainvoke_with_failed_side_effect(_input):
+        nonlocal call_count
+        call_count += 1
+        ledger = DATA_TOOL_LEDGER.get()
+        if ledger is not None:
+            # 저장 시도는 했지만 API 오류 — any_success()=False이므로 게이트가 트립된다
+            ledger.record("finus_save_diary", ok=False, produced_rows=False)
+        return ChatResponse.from_string(fabricated, usage=Usage())
+
+    mock_inner = MagicMock()
+    mock_inner.ainvoke = ainvoke_with_failed_side_effect
+
+    result = await _run_with_gate(
+        inner=mock_inner,
+        query="오늘 매매일지 저장해줘",
+        chat_request=_simple_req("오늘 매매일지 저장해줘"),
+        inner_name="diary_agent",
+    )
+
+    assert result == _TOOL_ENFORCEMENT_REJECTION, (
+        f"결정론적 거절 메시지가 반환돼야 합니다. 실제: {result!r}"
+    )
+    assert call_count == 1, (
+        f"부작용 가드로 재시도 없이 1회만 호출해야 합니다. 실제: {call_count}"
+    )

--- a/finus_nat/tests/test_tool_enforcement.py
+++ b/finus_nat/tests/test_tool_enforcement.py
@@ -404,3 +404,92 @@ async def test_side_effect_guard_skips_retry_on_write_tool():
     assert call_count == 1, (
         f"부작용 가드로 재시도 없이 1회만 호출해야 합니다. 실제: {call_count}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Critical (신규) — 일지 저장 성공은 데이터 조회 성공이 아니다
+# ---------------------------------------------------------------------------
+
+def test_successful_save_diary_does_not_count_as_data_success():
+    """일지 저장 성공은 데이터 조회 성공이 아니다 — 게이트를 풀어서는 안 된다.
+
+    finus_save_diary 성공 응답({id: 12, ...})이 any_success()=True가 되면,
+    "일지 저장 + 잔고 수치 지어내기" 패턴이 게이트를 우회한다(이슈 #152 재현 경로).
+    produced_rows=ok and tool_name not in _SIDE_EFFECT_TOOLS 수정으로 차단된다.
+    """
+    ledger = DataToolLedger()
+    token = DATA_TOOL_LEDGER.set(ledger)
+    try:
+        _record_to_ledger("finus_save_diary", '{"id": 12, "title": "매매일지"}')
+    finally:
+        DATA_TOOL_LEDGER.reset(token)
+
+    assert ledger.had_side_effect() is True
+    assert ledger.any_success() is False
+    answer = "Final Answer: 잔고는 500만원입니다."
+    assert _check_tool_enforcement(answer, ledger, _simple_req()) is True
+
+
+async def test_side_effect_guard_skips_retry_on_successful_write_tool():
+    """finus_save_diary 저장 성공 후 수치를 주장해도 재시도 없이 즉시 거절한다.
+
+    시나리오: 저장 성공(ok=True) → produced_rows=False이므로 any_success()=False
+    → 에이전트가 수치 주장 → 게이트 트립 → had_side_effect()=True → 재시도 건너뜀.
+    이 경로가 성공 경로(ok=True)에서도 부작용 가드가 동작함을 고정한다.
+    """
+    fabricated = "Final Answer: 실현손익 52,000원을 일지에 저장했습니다."
+    call_count = 0
+
+    async def ainvoke_with_successful_side_effect(_input):
+        nonlocal call_count
+        call_count += 1
+        # _record_to_ledger를 직접 호출해 실제 운영 경로와 동일한 기록 방식으로 검증
+        _record_to_ledger("finus_save_diary", '{"id": 12, "title": "매매일지"}')
+        return ChatResponse.from_string(fabricated, usage=Usage())
+
+    mock_inner = MagicMock()
+    mock_inner.ainvoke = ainvoke_with_successful_side_effect
+
+    result = await _run_with_gate(
+        inner=mock_inner,
+        query="오늘 매매일지 저장해줘",
+        chat_request=_simple_req("오늘 매매일지 저장해줘"),
+        inner_name="diary_agent",
+    )
+
+    assert result == _TOOL_ENFORCEMENT_REJECTION, (
+        f"결정론적 거절 메시지가 반환돼야 합니다. 실제: {result!r}"
+    )
+    assert call_count == 1, (
+        f"부작용 가드로 재시도 없이 1회만 호출해야 합니다. 실제: {call_count}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Improvement (신규) — 주격 조사 '가'가 붙은 수량은 탐지해야 한다
+# ---------------------------------------------------------------------------
+
+def test_has_numeric_claims_matches_stock_quantity_with_ga_particle():
+    """'100주가 남아 있습니다'처럼 수량 뒤에 주격 조사 가가 붙어도 탐지한다."""
+    assert _has_numeric_claims("삼성전자 100주가 남아 있습니다.") is True
+
+
+def test_has_numeric_claims_matches_stock_quantity_ga_particle_variant():
+    """'보유 수량 100주가 전부입니다'에서 수량을 탐지한다."""
+    assert _has_numeric_claims("보유 수량 100주가 전부입니다.") is True
+
+
+def test_has_numeric_claims_matches_executed_quantity_with_ga_particle():
+    """'50주가 체결됐습니다'에서 수량을 탐지한다."""
+    assert _has_numeric_claims("50주가 체결됐습니다.") is True
+
+
+def test_has_numeric_claims_does_not_match_juga_as_stock_price_noun():
+    """'주가가 상승했습니다'에서 주가(株價) 자체는 탐지하지 않는다(수치 없음)."""
+    assert _has_numeric_claims("주가가 상승했습니다.") is False
+
+
+def test_has_numeric_claims_does_not_match_juga_with_neun_particle():
+    """'주가는 N원입니다'에서 주가 명사는 제외하되 원 단위 수치로 탐지된다."""
+    # 주가(株價) 자체는 MISS이지만 7만원 때문에 전체 문장은 HIT
+    assert _has_numeric_claims("주가는 7만원입니다.") is True


### PR DESCRIPTION
## 배경

#152. 에이전트가 도구를 호출하지 않고 직접 답하는 것을 막던 장치가 세 겹 모두 무력화돼, KIS 조회 도구를 가진 에이전트가 잔고·현재가를 지어내 답할 수 있는 상태였습니다.

이슈 권고대로 **벤더 패치는 채택하지 않고 Fin-Us 소유 코드에서 강제**합니다 — 상류 훅(`accept_direct_answer_without_react_format`)이 1.6.0에서 삭제됐고, 그 게이트는 애초에 위험 경로(예외 없이 `AgentFinish` 반환)를 덮지 못했으며, 기본 로컬 실행에서는 `patch_vendor.py`가 아예 돌지 않기 때문입니다.

## 구현

**`DataToolLedger` 원장** (`finus_api.py`) — 이슈가 지적한 두 함정을 지켰습니다.

- **호출이 아니라 "성공적 데이터 수신"을 셉니다.** `(tool_name, ok, produced_rows)`를 기록하고 `any(ok and produced_rows)`로 판정합니다. 오류 JSON 응답은 `ok=False`라 게이트가 트립합니다 — 도구가 발동해 오류를 받고 그다음 수치를 지어내는 경로(YAML 넷이 KIS 재시도 루프를 지시하므로 가장 빈번한 경로)가 막힙니다.
- **`ContextVar`에 가변 박스를 담습니다.** `ContextVar[int]` + `.set()`은 `asyncio.create_task` 경계를 못 넘어 영원히 0을 보고합니다. 박스가 `None`이면 **트립 + ERROR 로그** — "판단 불가"를 "통과"로 읽지 않습니다.

**게이트** (`agents.py`) — 세 조건이 모두 참일 때만 트립합니다.

1. 답변에 금융 수치 주장이 있음
2. 데이터 도구가 성공하지 않음
3. 그 수치가 입력 대화록에 없음

`news_agent.yml`·`strategy_agent.yml`이 도구 없이 답하라고 명시적으로 지시하므로 무조건 차단은 문서화된 동작을 깨뜨립니다. 숫자 비교는 `75,300원`·`75300원`·`7만 5300원`을 같게 보도록 정규화합니다.

**최종 상태** — 두 번째 시도도 실패하면 모델 문장이 아니라 **결정론적 거절**을 반환합니다.

**`VENDOR_PATCH_STATUS` 진실성** — `_mark_patch("react_system_prompt", "applied")`가 상류 확인 없이 무조건 기록하던 거짓 양성을 제거하고, 모듈 동일성 비교로 실제 설치 여부를 판정합니다.

## 검증 (직접 실행)

`pytest tests/` (프로젝트 venv) — **81 → 94 passed, 1 skipped** (실패 0건, +13건).

이슈가 요구한 7개 케이스를 전부 테스트로 만들었습니다.

| 케이스 | 기대 | 결과 |
| --- | --- | --- |
| 수치 주장 + 도구 호출 없음 | 트립 | ✅ |
| 수치 주장 + 도구 성공(데이터 있음) | 통과 | ✅ |
| 수치 주장 + 도구 호출했으나 오류 | 트립 | ✅ |
| 도구 없는 정성적 후속 답변 | 통과 | ✅ |
| 대화록 수치를 다른 표기로 재진술 | 통과 | ✅ |
| 원장 박스 없음 | 트립 + ERROR | ✅ |
| 두 번째 시도도 실패 | 결정론적 거절 | ✅ |

뮤테이션:

| 뮤턴트 | 결과 |
| --- | --- |
| 원장을 호출 횟수로 판정(`bool(records)`) | 1 failed ✅ |
| 대화록 재진술 예외 제거(무조건 차단) | 1 failed ✅ |
| 수치 주장 검사 제거(게이트 무력화) | 4 failed ✅ |
| 박스 None 시 ERROR → debug 강등 | 1 failed ✅ |

## ⚠️ 남은 갭 — `produced_rows`가 `ok`의 별칭입니다

검증 중 발견했습니다. `_record_to_ledger`가 `produced_rows=ok`로 기록하므로 두 값이 항상 같습니다. 실제로 확인했습니다:

| 도구 응답 | ok | produced_rows | `any_success()` | 게이트 |
| --- | --- | --- | --- | --- |
| `보유 종목이 없습니다.` | True | True | True | **통과** |
| `{"error": "KIS timeout"}` | False | False | False | 트립 |

이슈가 지목한 핵심 경로(**도구가 오류를 받은 뒤 지어내기**)는 막힙니다. 다만 **도구가 성공했지만 빈 결과를 돌려준 경우**는 게이트를 통과하므로, 그 뒤 수치를 지어내면 잡히지 않습니다. 도구별로 "빈 결과" 표현이 달라 추측으로 판별하면 오탐(정상 답변을 차단)을 만들 수 있어 이 PR에서는 고치지 않고 드러냅니다. 후속으로 뗄지 판단이 필요합니다.

## 이슈 본문 중 낡은 항목

착수 후 확인한 결과, 아래 두 항목은 **이미 `main`에 반영돼 있어 이 PR에서 할 일이 없었습니다.**

- `_FINUS_REACT_*` 상수 삭제 — `main`에 이미 존재하지 않음
- YAML 6개의 `accept_direct_answer_without_react_format` 제거 — `main`에 이미 없음. 여섯 YAML 모두 `system_prompt`를 갖고 있어 프롬프트 이관도 완료된 상태

즉 수용 기준 "설정 파일에 효과 없는 키가 남지 않을 것"은 이 PR 이전에 이미 충족돼 있었습니다.

## 범위 밖

프롬프트 이관의 **실모델 관측 검증**은 실 KIS/OpenAI가 필요해 후속 이슈 #197로 분리했습니다. (이슈 본문의 YAML 파일명 오기도 실제 파일명으로 바로잡았습니다.)

Closes #152
