### PR TITLE
perf: 고아 tmp 스윕을 쓰기마다 대신 인스턴스당 1회로 (#181)

### DIFF
--- a/mcp-trading/order-dedup.js
+++ b/mcp-trading/order-dedup.js
@@ -150,6 +150,13 @@ export class OrderDedupStore {
     this.filePath = filePath;
     this.ttlMs = ttlMs;
     this.now = now;
+    // 고아 tmp 파일 스윕은 인스턴스당 1회만 수행한다. 고아 파일은 죽은
+    // 프로세스만 남기므로(살아 있는 프로세스의 실패는 #writeLedger의 catch가
+    // 이미 정리한다) 매 쓰기마다 재스캔해도 새 고아가 생기지 않는다. 모듈
+    // 스코프로 두지 않은 이유: 여러 인스턴스를 만드는 테스트에서 상태가
+    // 누수되고, 같은 프로세스 내에서 서로 다른 원장 경로를 쓰는 인스턴스가
+    // 있을 경우 각자 첫 쓰기에 자기 디렉터리를 한 번씩 정리해야 한다.
+    this.sweptOrphans = false;
   }
 
   reserve(key, request) {
@@ -261,19 +268,30 @@ export class OrderDedupStore {
     );
 
     // 이전 프로세스가 SIGKILL·OOM·전원차단으로 죽어 남긴 고아 임시 파일을
-    // 정리한다. 스윕 실패(readdir 실패 포함)는 전부 삼킨다 — 여기서 던지면
+    // 정리한다. 인스턴스당 한 번만 실행한다 — 고아는 죽은 프로세스만 남기므로
+    // 한 번 정리한 뒤에는 이 인스턴스가 살아 있는 동안 새 고아가 나타나지
+    // 않는다(살아 있는 프로세스의 실패는 #writeLedger의 catch가 이미 정리한다).
+    // 매 쓰기마다 동기 readdirSync로 디렉터리를 훑으면 이벤트 루프를 블로킹하고,
+    // 기본 경로(os.tmpdir())에서는 시스템 임시 디렉터리 전체를 주문마다 스캔한다.
+    // 플래그는 스윕 시도 전에 세운다 — readdir이 실패해도 재시도하지 않는다.
+    // 재시도를 허용하면 오류 환경(예: 권한 문제)에서 매 쓰기마다 다시 스캔해
+    // 원래 문제가 재발하고, 스윕 실패는 어차피 삼키므로 재시도 결과도 같다.
+    // 스윕 실패(readdir 실패 포함)는 전부 삼킨다 — 여기서 던지면
     // 청소 실패가 fail-closed를 오염시켜 정상 주문이 차단된다.
     const tmpPrefix = `.${path.basename(this.filePath)}.`;
-    try {
-      for (const name of fs.readdirSync(dir)) {
-        if (!name.startsWith(tmpPrefix) || !name.endsWith(".tmp")) continue;
-        const stale = path.join(dir, name);
-        if (stale === tmpPath) continue;
-        try {
-          if (Date.now() - fs.statSync(stale).mtimeMs > STALE_TMP_MS) fs.unlinkSync(stale);
-        } catch { /* 개별 파일 정리 실패는 무시한다 */ }
-      }
-    } catch { /* readdir 실패도 무시한다 */ }
+    if (!this.sweptOrphans) {
+      this.sweptOrphans = true;
+      try {
+        for (const name of fs.readdirSync(dir)) {
+          if (!name.startsWith(tmpPrefix) || !name.endsWith(".tmp")) continue;
+          const stale = path.join(dir, name);
+          if (stale === tmpPath) continue;
+          try {
+            if (Date.now() - fs.statSync(stale).mtimeMs > STALE_TMP_MS) fs.unlinkSync(stale);
+          } catch { /* 개별 파일 정리 실패는 무시한다 */ }
+        }
+      } catch { /* readdir 실패도 무시한다 */ }
+    }
 
     try {
       const fd = fs.openSync(tmpPath, "w", 0o600);

--- a/mcp-trading/tests/order-dedup.test.js
+++ b/mcp-trading/tests/order-dedup.test.js
@@ -987,6 +987,103 @@ test("OrderDedupStore keeps sweeping after one orphan fails to unlink", (t) => {
   );
 });
 
+// 스윕이 인스턴스당 1회만 실행되는지 검증한다(#181).
+// 잡는 뮤테이션 A(가드 제거): `if (!this.sweptOrphans)` 조건 없이 항상 스윕하면
+// reserve·markSucceeded·release 각 호출마다 readdirSync가 불려 callCount가 3이
+// 되어야 한다 — 이 테스트가 빨간불이 된다.
+test("OrderDedupStore calls readdirSync for the sweep exactly once across multiple writes", (t) => {
+  const filePath = tempLedgerPath(t);
+  const dir = path.dirname(filePath);
+
+  let sweepReaddirCalls = 0;
+  const originalReaddirSync = fs.readdirSync;
+  t.mock.method(fs, "readdirSync", (targetPath, ...args) => {
+    if (targetPath === dir) sweepReaddirCalls += 1;
+    return originalReaddirSync(targetPath, ...args);
+  });
+
+  const store = new OrderDedupStore({ filePath, ttlMs: 60_000, now: () => 1_000 });
+
+  // 주문 1건당 2~3회 쓰기(reserve → markSucceeded → release)가 발생한다.
+  store.reserve("k", { stockCode: "005930" });
+  store.markSucceeded("k", { ODNO: "1" });
+  store.release("k");
+
+  assert.equal(
+    sweepReaddirCalls,
+    1,
+    "여러 번 쓰기해도 스윕(readdirSync)은 정확히 1회만 호출되어야 합니다",
+  );
+});
+
+// 스윕 플래그가 모듈 스코프가 아닌 인스턴스 스코프임을 검증한다(#181).
+// 같은 프로세스에서 인스턴스를 여러 개 만들면 각각 첫 쓰기에 한 번씩 스윕해야
+// 한다. 잡는 뮤테이션: 플래그를 모듈 스코프 변수로 두면 두 번째 인스턴스는
+// 스윕하지 않아 callCount가 1에 그쳐 실패한다.
+test("each OrderDedupStore instance sweeps independently (instance-scoped flag, not module-scoped)", (t) => {
+  const filePathA = tempLedgerPath(t);
+  const filePathB = tempLedgerPath(t);
+  const dirA = path.dirname(filePathA);
+  const dirB = path.dirname(filePathB);
+
+  let sweepReaddirCalls = 0;
+  const originalReaddirSync = fs.readdirSync;
+  t.mock.method(fs, "readdirSync", (targetPath, ...args) => {
+    if (targetPath === dirA || targetPath === dirB) sweepReaddirCalls += 1;
+    return originalReaddirSync(targetPath, ...args);
+  });
+
+  const storeA = new OrderDedupStore({ filePath: filePathA, ttlMs: 60_000, now: () => 1_000 });
+  storeA.reserve("k1", { stockCode: "005930" });
+
+  const storeB = new OrderDedupStore({ filePath: filePathB, ttlMs: 60_000, now: () => 2_000_000 });
+  storeB.reserve("k2", { stockCode: "000660" });
+
+  assert.equal(
+    sweepReaddirCalls,
+    2,
+    "인스턴스마다 독립적으로 1회씩 스윕해야 합니다 (모듈 스코프가 아닌 인스턴스 스코프)",
+  );
+});
+
+// 첫 쓰기에서 고아가 실제로 정리되는지(기존 동작 유지)와 이후 쓰기에서는
+// readdirSync를 호출하지 않는지를 함께 검증한다(#181 회귀 방지).
+// 잡는 뮤테이션 B(스윕 자체 제거): 고아 파일이 그대로 남아야 하므로
+// 기존 "sweeps stale orphan tmp files" 테스트와 이 테스트 모두 실패한다.
+test("OrderDedupStore sweeps orphans on first write and skips readdirSync on subsequent writes", (t) => {
+  const filePath = tempLedgerPath(t);
+  const dir = path.dirname(filePath);
+
+  // 낡은 고아 tmp 파일을 명명 규칙에 맞게 생성한다.
+  const orphanPath = path.join(dir, `.${path.basename(filePath)}.77777.facade.tmp`);
+  fs.writeFileSync(orphanPath, "orphan");
+  const past = (Date.now() - 61_000) / 1000;
+  fs.utimesSync(orphanPath, past, past);
+
+  let sweepReaddirCalls = 0;
+  const originalReaddirSync = fs.readdirSync;
+  t.mock.method(fs, "readdirSync", (targetPath, ...args) => {
+    if (targetPath === dir) sweepReaddirCalls += 1;
+    return originalReaddirSync(targetPath, ...args);
+  });
+
+  const store = new OrderDedupStore({ filePath, ttlMs: 60_000 });
+
+  // 첫 번째 쓰기: 스윕으로 고아 정리
+  store.reserve("k", { stockCode: "005930" });
+  assert.equal(fs.existsSync(orphanPath), false, "첫 번째 쓰기에서 고아 파일이 정리되어야 합니다");
+  assert.equal(sweepReaddirCalls, 1, "첫 번째 쓰기에서 readdirSync가 1회 호출되어야 합니다");
+
+  // 두 번째·세 번째 쓰기: 스윕 없음
+  store.markSucceeded("k", { ODNO: "1" });
+  store.release("k");
+  assert.equal(
+    sweepReaddirCalls,
+    1,
+    "두 번째·세 번째 쓰기에서 readdirSync가 추가로 호출되면 안 됩니다",
+  );
+});
+
 test("OrderDedupStore stays silent when KIS_ORDER_DEDUP_TTL_MS is set but blank", (t) => {
   const originalEnvValue = process.env.KIS_ORDER_DEDUP_TTL_MS;
   t.after(() => {


### PR DESCRIPTION
## 배경

#181 (PR #178 리뷰의 🟡2 후속). `#writeLedger`의 고아 tmp 스윕이 **모든 쓰기마다** 동기 `readdirSync`로 디렉터리를 훑고 있었습니다. `#writeLedger`는 `reserve` + `markSucceeded`/`release`에서 호출되므로 **주문 1건당 2~3회** 스캔합니다.

고아 파일은 **죽은 프로세스만** 남깁니다 — 살아 있는 프로세스의 실패는 `#writeLedger`의 catch가 이미 정리합니다. 따라서 매 쓰기 스캔은 불필요합니다.

특히 기본 경로가 `os.tmpdir()`이라 **비-Docker 실행에서는 시스템 임시 디렉터리 전체**를 주문마다 동기 스캔하며 이벤트 루프를 블로킹합니다.

## 변경

스윕을 **인스턴스당 1회**로 제한했습니다. 이슈가 제시한 두 방안(1회 vs 60초 스로틀) 중 1회를 택했습니다 — 고아는 죽은 프로세스만 남기므로 스로틀의 추가 복잡도가 얻는 것이 없습니다.

**스윕 로직 자체는 한 줄도 바꾸지 않았습니다.** 무엇을 지우고 무엇을 남기는지, 실패를 삼키는 처리까지 그대로입니다. 이 PR은 *횟수*만 줄입니다.

두 가지 설계 판단을 주석에 남겼습니다:

- **모듈 스코프가 아니라 인스턴스 필드** — 모듈 스코프면 여러 인스턴스를 만드는 테스트에서 상태가 누수되고, 같은 프로세스에서 서로 다른 원장 경로를 쓰는 인스턴스가 각자 자기 디렉터리를 정리하지 못합니다.
- **플래그를 스윕 시도 *전에* 세움** — `readdir` 실패 시 재시도하지 않습니다. 재시도를 허용하면 권한 문제 같은 오류 환경에서 매 쓰기마다 다시 스캔해 원래 문제가 재발하고, 스윕 실패는 어차피 삼키므로 재시도 결과도 같습니다.

## 검증 (직접 실행)

`npm test` — **130 → 133 pass / 0 fail** (+3건).

뮤테이션:

| 뮤턴트 | 결과 |
| --- | --- |
| 1회 제한 가드 제거 (매번 스윕) | **2 failed** ✅ |
| 스윕 자체 제거 (고아 정리 안 함) | **5 failed** ✅ |
| 플래그를 인스턴스 간 공유로 (모듈 스코프처럼) | **5 failed** ✅ |

두 번째 뮤턴트가 **기존 고아 정리 동작이 유지되는지**를, 세 번째가 **인스턴스 독립성**을 각각 고정합니다.

Closes #181