### PR TITLE
fix: urgency 검증 실패가 요약·출처를 버리고 원본 JSON을 노출하던 문제 (#211)

### DIFF
--- a/backend/services.py
+++ b/backend/services.py
@@ -284,12 +284,32 @@ def _analysis_from_toolless_text(raw: str) -> dict[str, Any]:
     """
     text = (raw or "").strip()
     for data in _json_objects_from_text(text):
+        # ValidationError를 유발하는 AnalysisReport() 생성만 try 안에 둔다.
+        # 정규화는 TypeError를 낼 수 있어 except ValidationError에 잡히지 않으므로
+        # try 밖에서 먼저 처리한다 (Nitpick #2).
+        raw_urgency = data.get("urgency")
+        # JSON 후보의 값은 임의 타입이다 — list/dict를 frozenset에 넣으면
+        # TypeError로 죽으므로 str로 좁힌 뒤 비교한다. 문자열이 아니면 알 수 없는 값이다.
+        # 도구 없는 경로는 판단을 만들지 않으므로, 알 수 없는 urgency는 후보 전체를
+        # 버리는 대신 안전한 방향(normal)으로 낮춘다. 필드 하나 때문에
+        # summary·source_news까지 잃고 원본 JSON이 화면에 노출되는 것을 막는다.
+        urgency = (
+            raw_urgency
+            if isinstance(raw_urgency, str) and raw_urgency in _URGENCY_LEVELS
+            else "normal"
+        )
+        # 알 수 없는 urgency를 버릴 때 로그를 남겨 프롬프트 드리프트를 감지할 수 있게 한다.
+        if raw_urgency is not None and urgency != raw_urgency:
+            logger.warning(
+                "toolless 응답의 urgency=%r가 스키마 값이 아니라 %r로 정규화했습니다. "
+                "프롬프트 드리프트를 의심하세요.",
+                raw_urgency,
+                urgency,
+            )
+        # urgency를 신뢰할 수 없어 낮춘 경우, 그 값을 설명하던 reason도 함께 버린다.
+        # 남기면 "Urgency: normal - 즉시 대응 필요" 같은 모순된 문구가 소비자에게 나간다.
+        normalized = urgency != raw_urgency
         try:
-            raw_urgency = data.get("urgency")
-            # 도구 없는 경로는 애초에 판단을 만들지 않으므로, 알 수 없는 urgency는
-            # 후보 전체를 버리는 대신 안전한 방향(normal)으로 낮춘다. 필드 하나 때문에
-            # summary·source_news까지 잃고 원본 JSON이 화면에 노출되는 것을 막는다.
-            urgency = raw_urgency if raw_urgency in _URGENCY_LEVELS else "normal"
             report = AnalysisReport(
                 summary=str(data.get("summary") or text[:8000] or "빈 응답"),
                 details=None,  # 도구 없는 provider는 매매 판단을 생성하지 않는다
@@ -299,8 +319,8 @@ def _analysis_from_toolless_text(raw: str) -> dict[str, Any]:
                 ),
                 trading_trend=data.get("trading_trend"),
                 urgency=urgency,
-                urgency_reason=data.get("urgency_reason"),
-                telegram_alert=bool(data.get("telegram_alert", False)),
+                urgency_reason=None if normalized else data.get("urgency_reason"),
+                telegram_alert=bool(data.get("telegram_alert", False)) and not normalized,
             )
         except ValidationError:
             continue  # 관련 없는 JSON 객체 — 다음 후보로

--- a/backend/services.py
+++ b/backend/services.py
@@ -308,7 +308,8 @@ def _analysis_from_toolless_text(raw: str) -> dict[str, Any]:
             )
         # urgency를 신뢰할 수 없어 낮춘 경우, 그 값을 설명하던 reason도 함께 버린다.
         # 남기면 "Urgency: normal - 즉시 대응 필요" 같은 모순된 문구가 소비자에게 나간다.
-        normalized = urgency != raw_urgency
+        # raw_urgency is None 은 "키가 없거나 null" — 하향이 아니므로 normalized=False.
+        normalized = raw_urgency is not None and urgency != raw_urgency
         try:
             report = AnalysisReport(
                 summary=str(data.get("summary") or text[:8000] or "빈 응답"),

--- a/backend/services.py
+++ b/backend/services.py
@@ -3,7 +3,7 @@ import httpx
 import logging
 import re
 from datetime import date
-from typing import Any, Literal, Optional
+from typing import Any, Literal, Optional, get_args
 from urllib.parse import quote as _url_quote
 from fastapi import HTTPException
 from anthropic import AsyncAnthropic
@@ -11,6 +11,7 @@ from openai import AsyncOpenAI
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
+from pydantic import ValidationError
 from sqlmodel import Session
 from .config import (
     OPENAI_API_KEY, OPENAI_CHAT_MODEL,
@@ -19,7 +20,6 @@ from .config import (
     NAT_BASE_URL, NAT_CHAT_MODEL, NAT_CONVERSATION_ID,
     NEWS_MCP_PARAMS, TRADING_MCP_PARAMS,
 )
-from pydantic import ValidationError
 from .schemas import TradingSignal, AnalysisReport
 from .models import AgentReport
 
@@ -31,6 +31,12 @@ _NAT_RESPONSE_LOG_PREVIEW_CHARS = 800
 # 악의적이거나 비정상적인 LLM 출력이 이 값들을 주입할 수 있으므로 파싱 단계에서
 # 걷어낸다. 실제 값은 perform_stock_analysis가 provider_supports_tools()로 채운다.
 _DERIVED_PROVENANCE_FIELDS = frozenset({"provider", "provider_supports_tools"})
+
+# schemas.AnalysisReport.urgency의 Literal 값에서 파생 — 스키마와 두 곳이 갈라지는 것을 막는다.
+# AnalysisReport.urgency: Literal["low", "normal", "high", "critical"]
+_URGENCY_LEVELS: frozenset[str] = frozenset(
+    get_args(AnalysisReport.model_fields["urgency"].annotation)
+)
 
 # 입력이 이미 종목코드 형태인지 판정하는 범위. mcp-trading/stock-master.js의
 # resolveStock() Step 3 에코 판정(CODE_SHAPE_PATTERN — 마스터에 없는 6~7자 영숫자를
@@ -279,6 +285,11 @@ def _analysis_from_toolless_text(raw: str) -> dict[str, Any]:
     text = (raw or "").strip()
     for data in _json_objects_from_text(text):
         try:
+            raw_urgency = data.get("urgency")
+            # 도구 없는 경로는 애초에 판단을 만들지 않으므로, 알 수 없는 urgency는
+            # 후보 전체를 버리는 대신 안전한 방향(normal)으로 낮춘다. 필드 하나 때문에
+            # summary·source_news까지 잃고 원본 JSON이 화면에 노출되는 것을 막는다.
+            urgency = raw_urgency if raw_urgency in _URGENCY_LEVELS else "normal"
             report = AnalysisReport(
                 summary=str(data.get("summary") or text[:8000] or "빈 응답"),
                 details=None,  # 도구 없는 provider는 매매 판단을 생성하지 않는다
@@ -287,18 +298,19 @@ def _analysis_from_toolless_text(raw: str) -> dict[str, Any]:
                     data.get("source_signals") or data.get("source_news")
                 ),
                 trading_trend=data.get("trading_trend"),
-                urgency=data.get("urgency", "normal"),
+                urgency=urgency,
                 urgency_reason=data.get("urgency_reason"),
                 telegram_alert=bool(data.get("telegram_alert", False)),
             )
         except ValidationError:
-            continue  # 관련 없는 JSON 객체(urgency 리터럴 위반 등) — 다음 후보로
+            continue  # 관련 없는 JSON 객체 — 다음 후보로
         return report.model_dump()
     # JSON 파싱 실패 또는 유효한 후보 없음: 원문을 요약으로 사용
     return AnalysisReport(
         summary=text[:8000] if text else "빈 응답",
         details=None,
         source_news=[],
+        source_signals=[],
     ).model_dump()
 
 

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -1027,3 +1027,54 @@ def test_analysis_from_toolless_text_always_returns_none_details():
     result = services._analysis_from_toolless_text("plain text response")
     assert result["details"] is None
     assert result["summary"] == "plain text response"
+
+
+# ── #211: urgency 정규화 — 재현 케이스 4종 ───────────────────────────────────
+
+
+def test_analysis_from_toolless_text_urgency_valid_high_preserves_summary_and_news():
+    """urgency가 유효값("high")이면 summary·source_news가 그대로 보존된다.
+
+    urgency 정규화를 제거(원래대로 data.get("urgency","normal"))해도 이 케이스는
+    통과하므로, 뮤테이션 가드로서 아래 null/medium 케이스와 함께 동작한다.
+    """
+    raw = '{"summary":"삼성전자 요약","source_news":["뉴스1"],"urgency":"high"}'
+    result = services._analysis_from_toolless_text(raw)
+    assert result["summary"] == "삼성전자 요약"
+    assert result["source_news"] == ["뉴스1"]
+    assert result["urgency"] == "high"
+
+
+def test_analysis_from_toolless_text_urgency_null_preserves_summary_and_news():
+    """urgency=null 이면 summary·source_news를 버리지 않고, urgency는 "normal"로 정규화한다.
+
+    urgency 정규화를 제거하면 ValidationError → continue → 폴백으로 원본 JSON이
+    summary에 노출되어 이 테스트가 red가 된다.
+    """
+    raw = '{"summary":"삼성전자 요약","source_news":["뉴스1"],"urgency":null}'
+    result = services._analysis_from_toolless_text(raw)
+    assert result["summary"] == "삼성전자 요약", "urgency=null이 원본 JSON을 summary에 노출해서는 안 된다"
+    assert result["source_news"] == ["뉴스1"]
+    assert result["urgency"] == "normal"
+
+
+def test_analysis_from_toolless_text_urgency_unsupported_string_preserves_summary_and_news():
+    """urgency가 미지원 문자열("medium")이면 "normal"로 정규화하고 summary·source_news를 보존한다.
+
+    urgency 정규화를 제거하면 ValidationError → continue → 폴백으로 원본 JSON이
+    summary에 노출되어 이 테스트가 red가 된다.
+    """
+    raw = '{"summary":"삼성전자 요약","source_news":["뉴스1"],"urgency":"medium"}'
+    result = services._analysis_from_toolless_text(raw)
+    assert result["summary"] == "삼성전자 요약", "urgency=medium이 원본 JSON을 summary에 노출해서는 안 된다"
+    assert result["source_news"] == ["뉴스1"]
+    assert result["urgency"] == "normal"
+
+
+def test_analysis_from_toolless_text_urgency_key_absent_defaults_to_normal():
+    """urgency 키가 없으면 기본값 "normal"이 적용되고 summary·source_news가 보존된다."""
+    raw = '{"summary":"삼성전자 요약","source_news":["뉴스1"]}'
+    result = services._analysis_from_toolless_text(raw)
+    assert result["summary"] == "삼성전자 요약"
+    assert result["source_news"] == ["뉴스1"]
+    assert result["urgency"] == "normal"

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -1037,6 +1037,10 @@ def test_analysis_from_toolless_text_urgency_valid_high_preserves_summary_and_ne
 
     urgency 정규화를 제거(원래대로 data.get("urgency","normal"))해도 이 케이스는
     통과하므로, 뮤테이션 가드로서 아래 null/medium 케이스와 함께 동작한다.
+
+    부수 가드: 이 테스트가 urgency=="high"를 단언하므로,
+    _URGENCY_LEVELS 파생이 깨지면(Literal 변경 등) 이 테스트가 red가 된다.
+    즉 이 테스트를 지우면 _URGENCY_LEVELS 스키마-파생의 안전망도 함께 사라진다.
     """
     raw = '{"summary":"삼성전자 요약","source_news":["뉴스1"],"urgency":"high"}'
     result = services._analysis_from_toolless_text(raw)
@@ -1091,3 +1095,97 @@ def test_analysis_from_toolless_text_fallback_source_signals_is_empty_list():
     assert result["source_signals"] == [], (
         "폴백 경로의 source_signals는 None이 아니라 []여야 한다"
     )
+
+
+# ── #211 리뷰 반영: 비문자열 urgency TypeError 회귀 방지 ────────────────────────
+
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "urgency_value",
+    [
+        ["high"],  # list — frozenset 멤버십 검사에서 TypeError 유발 (핵심 버그)
+        3,         # int
+        True,      # bool
+        False,     # bool
+        None,      # null (urgency 키 값이 null인 경우, 키 부재와 구분)
+    ],
+)
+def test_analysis_from_toolless_text_urgency_non_string_does_not_raise(urgency_value):
+    """urgency가 list/int/bool/null이어도 TypeError 없이 normal로 정규화되고 summary가 보존된다.
+
+    이 테스트가 잡는 mutation: `isinstance(raw_urgency, str)` 가드 제거.
+    가드 없이 `raw_urgency in _URGENCY_LEVELS`만 쓰면 list가 frozenset
+    멤버십 검사에서 TypeError: unhashable type: 'list'를 일으켜
+    /api/v1/analyze가 500이 된다. origin/main에서는 같은 입력이 폴백으로
+    열화될 뿐 살아남으므로 이 TypeError는 이 PR이 만든 회귀다.
+    """
+    import json
+
+    raw = json.dumps(
+        {"summary": "삼성전자 요약", "source_news": ["뉴스1"], "urgency": urgency_value}
+    )
+    result = services._analysis_from_toolless_text(raw)
+    assert result["urgency"] == "normal", (
+        f"urgency={urgency_value!r}는 비문자열이므로 'normal'로 정규화되어야 한다"
+    )
+    assert result["summary"] == "삼성전자 요약", (
+        "비문자열 urgency가 summary를 원본 JSON으로 오염시켜서는 안 된다"
+    )
+
+
+def test_analysis_from_toolless_text_urgency_dict_does_not_raise():
+    """urgency가 dict여도 TypeError 없이 정상 반환된다.
+
+    dict urgency는 _json_objects_from_text의 reversed 순서 때문에
+    내부 객체가 먼저 후보로 선택되어 summary가 원본 JSON이 되는 선행 문제
+    (Improvement #3)가 있다. 이는 이 PR 이전부터 존재하는 문제이므로
+    이 테스트는 summary 내용이 아닌 '예외 없이 반환된다'만 고정한다.
+    urgency 결과는 내부 객체에 urgency 키가 없어 'normal'이 된다.
+    """
+    import json
+
+    raw = json.dumps(
+        {"summary": "삼성전자 요약", "source_news": ["뉴스1"], "urgency": {"level": "high"}}
+    )
+    result = services._analysis_from_toolless_text(raw)
+    assert isinstance(result, dict), "dict urgency여도 예외 없이 dict를 반환해야 한다"
+    assert result["urgency"] == "normal"
+
+
+# ── #211 리뷰 반영: urgency 하향 시 urgency_reason·telegram_alert 모순 방지 ──
+
+
+def test_analysis_from_toolless_text_normalized_urgency_clears_reason_and_alert():
+    """urgency가 정규화(하향)되면 urgency_reason·telegram_alert도 함께 버린다.
+
+    urgency="medium"(미지원)→"normal" 정규화 시 urgency_reason·telegram_alert를
+    그대로 두면 "Urgency: normal - 즉시 대응 필요"처럼 모순된 문구가 나간다.
+    이 테스트가 잡는 mutation: `normalized` 조건 제거(reason/alert 무조건 통과).
+    """
+    raw = (
+        '{"summary":"삼성전자 요약","source_news":["뉴스1"],'
+        '"urgency":"medium","urgency_reason":"delisting imminent","telegram_alert":true}'
+    )
+    result = services._analysis_from_toolless_text(raw)
+    assert result["urgency"] == "normal"
+    assert result["urgency_reason"] is None, (
+        "urgency 하향 시 urgency_reason도 None이어야 한다"
+    )
+    assert result["telegram_alert"] is False, (
+        "urgency 하향 시 telegram_alert도 False여야 한다"
+    )
+
+
+def test_analysis_from_toolless_text_valid_urgency_preserves_reason_and_alert():
+    """urgency가 유효값이면 urgency_reason·telegram_alert을 그대로 통과시킨다."""
+    raw = (
+        '{"summary":"삼성전자 요약","source_news":["뉴스1"],'
+        '"urgency":"high","urgency_reason":"거래정지 위험","telegram_alert":true}'
+    )
+    result = services._analysis_from_toolless_text(raw)
+    assert result["urgency"] == "high"
+    assert result["urgency_reason"] == "거래정지 위험"
+    assert result["telegram_alert"] is True

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -1078,3 +1078,16 @@ def test_analysis_from_toolless_text_urgency_key_absent_defaults_to_normal():
     assert result["summary"] == "삼성전자 요약"
     assert result["source_news"] == ["뉴스1"]
     assert result["urgency"] == "normal"
+
+
+def test_analysis_from_toolless_text_fallback_source_signals_is_empty_list():
+    """JSON 파싱 실패 시 폴백의 source_signals는 None이 아니라 []여야 한다.
+
+    이 테스트가 잡는 mutation: 폴백에서 `source_signals=[]` 제거.
+    source_signals를 명시하지 않으면 AnalysisReport 기본값 None이 나가고,
+    NAT 경로(source_signals=None → source_news 되채움 보정)와 비대칭이 생긴다.
+    """
+    result = services._analysis_from_toolless_text("JSON이 없는 순수 텍스트 응답")
+    assert result["source_signals"] == [], (
+        "폴백 경로의 source_signals는 None이 아니라 []여야 한다"
+    )

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -1189,3 +1189,26 @@ def test_analysis_from_toolless_text_valid_urgency_preserves_reason_and_alert():
     assert result["urgency"] == "high"
     assert result["urgency_reason"] == "거래정지 위험"
     assert result["telegram_alert"] is True
+
+
+@pytest.mark.parametrize("raw_json", [
+    # urgency 키 자체가 없는 경우
+    '{"summary":"삼성전자 요약","source_news":["뉴스1"],"urgency_reason":"거래정지 위험","telegram_alert":true}',
+    # urgency=null (키는 있지만 값이 null)인 경우
+    '{"summary":"삼성전자 요약","source_news":["뉴스1"],"urgency":null,"urgency_reason":"거래정지 위험","telegram_alert":true}',
+])
+def test_analysis_from_toolless_text_absent_urgency_preserves_reason_and_alert(raw_json):
+    """urgency 키가 없거나 null이면 하향이 아니므로 urgency_reason·telegram_alert을 보존한다.
+
+    이 테스트가 잡는 regression: `normalized = urgency != raw_urgency`에서
+    `raw_urgency is not None` 가드가 빠지면, urgency 키가 없을 때도 normalized=True가
+    되어 urgency_reason·telegram_alert이 부당하게 버려진다.
+    """
+    result = services._analysis_from_toolless_text(raw_json)
+    assert result["urgency"] == "normal"
+    assert result["urgency_reason"] == "거래정지 위험", (
+        "urgency 키 부재·null은 하향이 아니므로 urgency_reason을 보존해야 한다"
+    )
+    assert result["telegram_alert"] is True, (
+        "urgency 키 부재·null은 하향이 아니므로 telegram_alert을 보존해야 한다"
+    )


### PR DESCRIPTION
## 배경

#211 (PR #203 리뷰 후속). `_analysis_from_toolless_text`가 JSON 후보를 `AnalysisReport`로 검증하고 실패하면 `continue`로 버리는데, `urgency`가 `Literal["low","normal","high","critical"]`이라 **필드 하나가 틀리면 `summary`·`source_news`까지 함께 버려졌습니다.** 유효 후보가 없으면 폴백이 원문 전체를 요약으로 쓰므로 화면에 원본 JSON 덩어리가 떴습니다.

`data.get("urgency", "normal")`은 **키 부재만** 처리하고 명시적 `null`·미지원 문자열은 통과시켜 `ValidationError`를 냅니다.

## 변경

알 수 없는 `urgency`를 후보 전체를 버리는 대신 안전한 방향(`normal`)으로 낮춥니다.

`_URGENCY_LEVELS`는 **스키마에서 파생**시켰습니다 — 두 곳이 갈라지는 것을 막습니다:

```python
_URGENCY_LEVELS: frozenset[str] = frozenset(
    get_args(AnalysisReport.model_fields["urgency"].annotation)
)
```

실측 확인: `[critical, high, low, normal]`

## 실측 (직접 실행)

| 입력 | 수정 전 summary | 수정 전 source_news | 수정 후 summary | 수정 후 source_news | urgency |
| --- | --- | --- | --- | --- | --- |
| `urgency: "high"` | 삼성전자 요약 | `["뉴스1"]` | 삼성전자 요약 | `["뉴스1"]` | high |
| `urgency: null` | **원본 JSON 전체** | **`[]`** | 삼성전자 요약 ✅ | `["뉴스1"]` ✅ | normal |
| `urgency: "medium"` | **원본 JSON 전체** | **`[]`** | 삼성전자 요약 ✅ | `["뉴스1"]` ✅ | normal |
| `urgency` 키 없음 | 삼성전자 요약 | `["뉴스1"]` | 삼성전자 요약 | `["뉴스1"]` | normal |
| 관련 없는 JSON `{"foo":1}` | — | — | 원문 폴백 (기존 의도 유지) | `[]` | normal |

## "안전한 방향"이 맞는지 직접 확인했습니다

이슈가 *"`should_send_telegram_alert`이 보는 값도 긴급도를 낮추는 방향이라 안전하다"*고 했는데, 코드로 검증했습니다:

```python
URGENT_TELEGRAM_LEVELS = {"high", "critical"}          # telegram_notifier.py:13
... and analysis_data.get("urgency") in URGENT_TELEGRAM_LEVELS   # :68
```

`normal`은 이 집합에 없으므로 알림이 **덜** 나가는 방향입니다. 알 수 없는 값 때문에 알림이 더 나가는 경로는 없습니다.

## 함께 처리한 Nitpicks

**1. 서드파티 import 위치** — `from pydantic import ValidationError`를 `.config` 블록 아래에서 다른 서드파티 import들과 함께 위로 올렸습니다.

**2. 폴백 `source_signals` 비대칭** — 이슈가 지적한 비대칭이 실재하는지 확인했습니다. `services.py:742-743`에 NAT 경로의 보정이 실제로 있습니다:

```python
if dumped.get("source_signals") is None:
    dumped["source_signals"] = dumped.get("source_news", [])
```

폴백에 `source_signals=[]`를 명시해 두 경로 출력을 맞췄습니다.

## 검증

`pytest backend/` — **289 → 294 passed, 2 skipped** (실패 0건, +5건).

뮤테이션:

| 뮤턴트 | 결과 |
| --- | --- |
| `urgency` 정규화 제거 (원래대로) | **2 failed** ✅ |
| 폴백 `source_signals=[]` 제거 | **1 failed** ✅ |

두 번째 가드는 초기 구현에 빠져 있어(그 줄을 지워도 CI가 초록이었음) 별도 커밋으로 보강했습니다.

Closes #211