### PR TITLE
fix: 도구가 성공했지만 빈 결과일 때 강제 게이트를 통과하던 문제 (#209)

### DIFF
--- a/finus_nat/src/nat_finus_nat/agents.py
+++ b/finus_nat/src/nat_finus_nat/agents.py
@@ -137,6 +137,14 @@ _TOOL_ENFORCEMENT_REJECTION = (
     "다시 질문해 주세요."
 )
 
+# Returned when every read tool executed but returned an empty result set.
+# Skips the retry — the second attempt cannot produce rows either.
+# Must NOT be model-generated text.
+_EMPTY_RESULT_REJECTION = (
+    "[조회 결과 없음] 요청하신 조건으로 조회했으나 데이터가 없습니다. "
+    "조회 기간이나 종목을 바꿔 다시 질문해 주세요."
+)
+
 # Prepended to the query on the second attempt to force tool usage.
 # Changes the input rather than repeating the same system-prompt instruction
 # (which the model already ignored on the first attempt).
@@ -195,6 +203,17 @@ async def _run_with_gate(
             inner_name,
         )
         return _TOOL_ENFORCEMENT_REJECTION
+
+    # Empty-result guard: all read tools executed but returned empty data.
+    # Retrying is futile — the tools will return the same empty result again.
+    # Return an honest "no data" message instead of the misleading _TOOL_ENFORCEMENT_REJECTION.
+    if ledger.only_empty_reads():
+        logger.info(
+            "Gate tripped but every read tool returned an empty result (%s) — "
+            "skipping retry; the retry cannot produce rows.",
+            inner_name,
+        )
+        return _EMPTY_RESULT_REJECTION
 
     # --- Second attempt with changed input ---
     corrective_query = _CORRECTIVE_TOOL_PREFIX + query

--- a/finus_nat/src/nat_finus_nat/agents.py
+++ b/finus_nat/src/nat_finus_nat/agents.py
@@ -202,7 +202,9 @@ async def _run_with_gate(
             "tool ran — skipping retry to avoid duplicate writes",
             inner_name,
         )
-        return _TOOL_ENFORCEMENT_REJECTION
+        # 재시도는 어느 쪽이든 건너뛴다. 메시지만 실제 상황에 맞춘다:
+        # 쓰기 도구와 함께 빈 조회가 실행됐다면 "도구 없이"는 사실이 아니다.
+        return _EMPTY_RESULT_REJECTION if ledger.only_empty_reads() else _TOOL_ENFORCEMENT_REJECTION
 
     # Empty-result guard: all read tools executed but returned empty data.
     # Retrying is futile — the tools will return the same empty result again.
@@ -227,6 +229,17 @@ async def _run_with_gate(
 
     if not _check_tool_enforcement(answer2, ledger2, chat_request):
         return answer2
+
+    # 1차와 동일: 2차에서 도구는 실행됐고 결과가 비었을 뿐이라면
+    # "도구 없이"라고 말하는 _TOOL_ENFORCEMENT_REJECTION은 사실과 다르다.
+    # 교정 프리픽스가 2차의 도구 호출을 유도하므로 흔한 경로다.
+    if ledger2.only_empty_reads():
+        logger.info(
+            "Gate tripped twice (%s) but the retry's read tools all returned "
+            "empty results — returning the honest no-data message.",
+            inner_name,
+        )
+        return _EMPTY_RESULT_REJECTION
 
     logger.error(
         "Tool enforcement gate tripped twice (%s) — returning deterministic rejection",

--- a/finus_nat/src/nat_finus_nat/finus_api.py
+++ b/finus_nat/src/nat_finus_nat/finus_api.py
@@ -75,6 +75,68 @@ DATA_TOOL_LEDGER: ContextVar["DataToolLedger | None"] = ContextVar(
 
 _ERROR_JSON_PREFIX_RE = re.compile(r'^\s*\{"error"')
 
+# 각 MCP 서버가 조회 결과가 없을 때 출력하는 리터럴 부분문자열.
+# 추측한 휴리스틱이 아니라 MCP 소스 코드에서 직접 추출한 문자열이다.
+#   mcp-trading/index.js  formatDailyOrderCcldReport (~411행):
+#     "- 결과: 해당 조건의 주문·체결이 없습니다."
+#   mcp-news/index.js     fetchMarketNews (~107행):
+#     `'${stockName}'에 대한 뉴스를 찾지 못했습니다.`  (종목명 부분 제외한 고정 접미사)
+#   mcp-dart/index.js     formatEarningsReport (~427행):
+#     "- 조회 결과: OpenDART 재무제표 데이터가 없습니다."
+_EMPTY_RESULT_LITERALS: dict[str, str] = {
+    "finus_mcp_trading_today_orders": "해당 조건의 주문·체결이 없습니다.",
+    "finus_market_news": "에 대한 뉴스를 찾지 못했습니다.",
+    "finus_earnings_report": "OpenDART 재무제표 데이터가 없습니다.",
+}
+
+
+def _has_empty_result(tool_name: str, stripped: str) -> bool:
+    """Return True when the tool response is successful but contains no data rows.
+
+    Detection priority:
+
+    1. Structural (JSON): attempt to parse the result; an empty list or null
+       signals no data.  Covers finus_list_diaries ("[]" or "null").
+
+    2. finus_mcp_trading_balance_rlz_pl: balance-rlz-pl-report.js emits
+       "보유 종목이 없습니다." for an empty rows set.  When KIS also returns a
+       summary object, "[계좌 집계]" is appended with real account numbers, so
+       only the no-summary path is truly empty.
+
+    3. Documented MCP literals (_EMPTY_RESULT_LITERALS): exact substrings from
+       each MCP server's source code — not guessed patterns.
+
+    Tools not covered here return False (conservative: do not block unknown
+    formats) to avoid false positives on variable-shape responses such as
+    finus_account_balance (remote KIS, api_type-dependent) or
+    finus_disclosure_signal (all-empty detection would require multi-section
+    parsing) or finus_mcp_trading_get_balance (always contains account-level
+    summary numbers even when no individual holdings are held).
+    """
+    # --- 1. Structural: JSON empty array or null ---
+    try:
+        parsed = json.loads(stripped)
+        if parsed is None or (isinstance(parsed, list) and len(parsed) == 0):
+            return True
+        # Non-empty JSON (object or non-empty list) → has data; skip literal checks.
+        return False
+    except json.JSONDecodeError:
+        pass
+
+    # --- 2. balance_rlz_pl: empty holdings without account summary ---
+    # balance-rlz-pl-report.js formatBalanceRlzPlReport rows.length===0 branch:
+    #   always emits "보유 종목이 없습니다."
+    #   appends "[계좌 집계]" block only when summary object exists (real numbers).
+    if tool_name == "finus_mcp_trading_balance_rlz_pl":
+        return "보유 종목이 없습니다." in stripped and "[계좌 집계]" not in stripped
+
+    # --- 3. Documented literal markers from MCP source code ---
+    literal = _EMPTY_RESULT_LITERALS.get(tool_name)
+    if literal is not None:
+        return literal in stripped
+
+    return False
+
 
 def _record_to_ledger(tool_name: str, result: str) -> None:
     """Record a completed data-tool call into the current context's ledger.
@@ -96,9 +158,15 @@ def _record_to_ledger(tool_name: str, result: str) -> None:
         return
     stripped = result.strip()
     ok = bool(stripped) and not _ERROR_JSON_PREFIX_RE.match(stripped)
-    # 쓰기 도구의 성공은 "조회해서 데이터를 받았다"가 아니다. any_success()에 포함되면
-    # 일지 저장 한 번으로 그 호출 전체의 게이트가 풀린다.
-    ledger.record(tool_name, ok=ok, produced_rows=ok and tool_name not in _SIDE_EFFECT_TOOLS)
+    # produced_rows 조건:
+    # 1. ok — 오류 응답이 아님
+    # 2. 쓰기 도구가 아님 (_SIDE_EFFECT_TOOLS) — 일지 저장 성공이 게이트를 끄지 않도록
+    # 3. 빈 결과가 아님 (_has_empty_result) — 성공했지만 데이터가 없는 응답(#209)
+    ledger.record(
+        tool_name,
+        ok=ok,
+        produced_rows=ok and tool_name not in _SIDE_EFFECT_TOOLS and not _has_empty_result(tool_name, stripped),
+    )
 
 
 # Remote MCP / doc 한도

--- a/finus_nat/src/nat_finus_nat/finus_api.py
+++ b/finus_nat/src/nat_finus_nat/finus_api.py
@@ -34,6 +34,7 @@ class DataToolRecord(NamedTuple):
     tool_name: str
     ok: bool          # True when the response contains non-error data
     produced_rows: bool  # True when ok and the response body is non-empty
+    empty: bool = False  # True when ok=True but the result set is empty (빈 결과)
 
 
 # Tools that produce irreversible side effects (writes). When any of these appear in
@@ -53,8 +54,8 @@ class DataToolLedger:
 
     records: list[DataToolRecord] = field(default_factory=list)
 
-    def record(self, tool_name: str, *, ok: bool, produced_rows: bool) -> None:
-        self.records.append(DataToolRecord(tool_name=tool_name, ok=ok, produced_rows=produced_rows))
+    def record(self, tool_name: str, *, ok: bool, produced_rows: bool, empty: bool = False) -> None:
+        self.records.append(DataToolRecord(tool_name=tool_name, ok=ok, produced_rows=produced_rows, empty=empty))
 
     def any_success(self) -> bool:
         """Return True if at least one tool call successfully produced data rows."""
@@ -68,6 +69,16 @@ class DataToolLedger:
         """
         return any(r.tool_name in _SIDE_EFFECT_TOOLS for r in self.records)
 
+    def only_empty_reads(self) -> bool:
+        """읽기 도구가 실행됐고, 실행된 것이 전부 '성공했지만 빈 결과'인 경우.
+
+        게이트가 트립됐을 때 이 메서드가 True이면 재시도가 무의미하다 —
+        빈 결과는 두 번째 시도에서도 바뀌지 않는다. 재시도를 건너뛰고
+        _EMPTY_RESULT_REJECTION을 즉시 반환한다.
+        """
+        reads = [r for r in self.records if r.tool_name not in _SIDE_EFFECT_TOOLS]
+        return bool(reads) and all(r.empty for r in reads)
+
 
 DATA_TOOL_LEDGER: ContextVar["DataToolLedger | None"] = ContextVar(
     "finus_data_tool_ledger", default=None
@@ -77,11 +88,11 @@ _ERROR_JSON_PREFIX_RE = re.compile(r'^\s*\{"error"')
 
 # 각 MCP 서버가 조회 결과가 없을 때 출력하는 리터럴 부분문자열.
 # 추측한 휴리스틱이 아니라 MCP 소스 코드에서 직접 추출한 문자열이다.
-#   mcp-trading/index.js  formatDailyOrderCcldReport (~411행):
+#   mcp-trading/index.js  formatDailyOrderCcldReport 함수:
 #     "- 결과: 해당 조건의 주문·체결이 없습니다."
-#   mcp-news/index.js     fetchMarketNews (~107행):
+#   mcp-news/index.js     fetchMarketNews 함수:
 #     `'${stockName}'에 대한 뉴스를 찾지 못했습니다.`  (종목명 부분 제외한 고정 접미사)
-#   mcp-dart/index.js     formatEarningsReport (~427행):
+#   mcp-dart/index.js     formatEarningsReport 함수:
 #     "- 조회 결과: OpenDART 재무제표 데이터가 없습니다."
 _EMPTY_RESULT_LITERALS: dict[str, str] = {
     "finus_mcp_trading_today_orders": "해당 조건의 주문·체결이 없습니다.",
@@ -95,8 +106,10 @@ def _has_empty_result(tool_name: str, stripped: str) -> bool:
 
     Detection priority:
 
-    1. Structural (JSON): attempt to parse the result; an empty list or null
-       signals no data.  Covers finus_list_diaries ("[]" or "null").
+    1. Structural (JSON): 모든 도구에 적용된다. JSON 파싱에 성공하고 빈 컨테이너
+       (null, 빈 list/dict/str)이면 즉시 True를 반환한다. 그 외에는 다음 분기로
+       fall-through한다 — 응답이 JSON으로 감싸인 뒤에도 리터럴 탐지가 유효하게
+       유지하기 위해서다.
 
     2. finus_mcp_trading_balance_rlz_pl: balance-rlz-pl-report.js emits
        "보유 종목이 없습니다." for an empty rows set.  When KIS also returns a
@@ -113,15 +126,16 @@ def _has_empty_result(tool_name: str, stripped: str) -> bool:
     parsing) or finus_mcp_trading_get_balance (always contains account-level
     summary numbers even when no individual holdings are held).
     """
-    # --- 1. Structural: JSON empty array or null ---
+    # --- 1. Structural: JSON empty container or null ---
     try:
         parsed = json.loads(stripped)
-        if parsed is None or (isinstance(parsed, list) and len(parsed) == 0):
-            return True
-        # Non-empty JSON (object or non-empty list) → has data; skip literal checks.
-        return False
     except json.JSONDecodeError:
         pass
+    else:
+        if parsed is None or (isinstance(parsed, (list, dict, str)) and len(parsed) == 0):
+            return True
+        # 비어있지 않은 JSON이어도 리터럴 검사는 계속한다 — 응답이 JSON으로
+        # 감싸이는 순간 리터럴 탐지가 조용히 죽는 것을 막는다.
 
     # --- 2. balance_rlz_pl: empty holdings without account summary ---
     # balance-rlz-pl-report.js formatBalanceRlzPlReport rows.length===0 branch:
@@ -158,6 +172,9 @@ def _record_to_ledger(tool_name: str, result: str) -> None:
         return
     stripped = result.strip()
     ok = bool(stripped) and not _ERROR_JSON_PREFIX_RE.match(stripped)
+    is_read = ok and tool_name not in _SIDE_EFFECT_TOOLS
+    # empty: ok=True였지만 결과 집합이 비어 있음(#209 빈 결과 축)
+    is_empty = is_read and _has_empty_result(tool_name, stripped)
     # produced_rows 조건:
     # 1. ok — 오류 응답이 아님
     # 2. 쓰기 도구가 아님 (_SIDE_EFFECT_TOOLS) — 일지 저장 성공이 게이트를 끄지 않도록
@@ -165,7 +182,8 @@ def _record_to_ledger(tool_name: str, result: str) -> None:
     ledger.record(
         tool_name,
         ok=ok,
-        produced_rows=ok and tool_name not in _SIDE_EFFECT_TOOLS and not _has_empty_result(tool_name, stripped),
+        produced_rows=is_read and not is_empty,
+        empty=is_empty,
     )
 
 

--- a/finus_nat/tests/test_tool_enforcement.py
+++ b/finus_nat/tests/test_tool_enforcement.py
@@ -493,3 +493,183 @@ def test_has_numeric_claims_does_not_match_juga_with_neun_particle():
     """'주가는 N원입니다'에서 주가 명사는 제외하되 원 단위 수치로 탐지된다."""
     # 주가(株價) 자체는 MISS이지만 7만원 때문에 전체 문장은 HIT
     assert _has_numeric_claims("주가는 7만원입니다.") is True
+
+
+# ---------------------------------------------------------------------------
+# 이슈 #209 — 빈-결과 축: 읽기 도구 성공 + 빈 응답은 any_success()=False
+# ---------------------------------------------------------------------------
+
+def test_record_to_ledger_empty_today_orders_does_not_count_as_success():
+    """당일 주문체결 조회 성공 + 결과 없음 → any_success()=False.
+
+    mcp-trading/index.js formatDailyOrderCcldReport 의 rows.length===0 분기가
+    "해당 조건의 주문·체결이 없습니다." 리터럴을 출력한다.
+    이 응답으로 _record_to_ledger를 호출하면 produced_rows=False가 돼야 한다.
+    """
+    ledger = DataToolLedger()
+    token = DATA_TOOL_LEDGER.set(ledger)
+    try:
+        _record_to_ledger(
+            "finus_mcp_trading_today_orders",
+            "[당일 주문·체결 내역] 20260807\n- 조회 TR: TTTC0081R\n- 결과: 해당 조건의 주문·체결이 없습니다.",
+        )
+    finally:
+        DATA_TOOL_LEDGER.reset(token)
+
+    assert ledger.any_success() is False
+    answer = "Final Answer: 오늘 체결된 주문은 삼성전자 100주입니다."
+    assert _check_tool_enforcement(answer, ledger, _simple_req()) is True
+
+
+def test_record_to_ledger_nonempty_today_orders_counts_as_success():
+    """당일 주문체결 조회 성공 + 데이터 있음 → any_success()=True (오탐 없음)."""
+    ledger = DataToolLedger()
+    token = DATA_TOOL_LEDGER.set(ledger)
+    try:
+        _record_to_ledger(
+            "finus_mcp_trading_today_orders",
+            "[당일 주문·체결 내역] 20260807\n1. 삼성전자 (005930)\n   주문 100주 @ 75,300원",
+        )
+    finally:
+        DATA_TOOL_LEDGER.reset(token)
+
+    assert ledger.any_success() is True
+
+
+def test_record_to_ledger_empty_market_news_does_not_count_as_success():
+    """시장 뉴스 조회 성공 + 결과 없음 → any_success()=False.
+
+    mcp-news/index.js fetchMarketNews 가 뉴스 항목이 없을 때
+    "'${stockName}'에 대한 뉴스를 찾지 못했습니다." 를 반환한다.
+    """
+    ledger = DataToolLedger()
+    token = DATA_TOOL_LEDGER.set(ledger)
+    try:
+        _record_to_ledger(
+            "finus_market_news",
+            "'삼성전자'에 대한 뉴스를 찾지 못했습니다.",
+        )
+    finally:
+        DATA_TOOL_LEDGER.reset(token)
+
+    assert ledger.any_success() is False
+
+
+def test_record_to_ledger_nonempty_market_news_counts_as_success():
+    """시장 뉴스 조회 성공 + 데이터 있음 → any_success()=True (오탐 없음)."""
+    ledger = DataToolLedger()
+    token = DATA_TOOL_LEDGER.set(ledger)
+    try:
+        _record_to_ledger(
+            "finus_market_news",
+            "삼성전자 4분기 실적 호조 - 반도체 수요 회복 | 2026-08-07 | https://news.naver.com/...",
+        )
+    finally:
+        DATA_TOOL_LEDGER.reset(token)
+
+    assert ledger.any_success() is True
+
+
+def test_record_to_ledger_empty_earnings_report_does_not_count_as_success():
+    """실적 리포트 조회 성공 + 데이터 없음 → any_success()=False.
+
+    mcp-dart/index.js formatEarningsReport 의 rows.length===0 분기가
+    "OpenDART 재무제표 데이터가 없습니다." 리터럴을 출력한다.
+    """
+    ledger = DataToolLedger()
+    token = DATA_TOOL_LEDGER.set(ledger)
+    try:
+        _record_to_ledger(
+            "finus_earnings_report",
+            "[삼성전자] DART 실적 리포트\n- 조회기간: 2026Q1\n- 조회 결과: OpenDART 재무제표 데이터가 없습니다.",
+        )
+    finally:
+        DATA_TOOL_LEDGER.reset(token)
+
+    assert ledger.any_success() is False
+
+
+def test_record_to_ledger_empty_list_diaries_does_not_count_as_success():
+    """매매일지 목록 조회 성공 + 빈 배열("[]") → any_success()=False.
+
+    finus_api.py finus_list_diaries 는 body.get("data")를 json.dumps()해 반환한다.
+    data가 빈 리스트일 때 결과는 "[]" 이므로 구조적으로 탐지한다.
+    """
+    ledger = DataToolLedger()
+    token = DATA_TOOL_LEDGER.set(ledger)
+    try:
+        _record_to_ledger("finus_list_diaries", "[]")
+    finally:
+        DATA_TOOL_LEDGER.reset(token)
+
+    assert ledger.any_success() is False
+
+
+def test_record_to_ledger_null_list_diaries_does_not_count_as_success():
+    """매매일지 목록 조회 성공 + null 응답("null") → any_success()=False.
+
+    body.get("data")가 None이면 json.dumps(None)="null" 이 반환된다.
+    """
+    ledger = DataToolLedger()
+    token = DATA_TOOL_LEDGER.set(ledger)
+    try:
+        _record_to_ledger("finus_list_diaries", "null")
+    finally:
+        DATA_TOOL_LEDGER.reset(token)
+
+    assert ledger.any_success() is False
+
+
+def test_record_to_ledger_nonempty_list_diaries_counts_as_success():
+    """매매일지 목록 조회 성공 + 데이터 있음 → any_success()=True (오탐 없음)."""
+    ledger = DataToolLedger()
+    token = DATA_TOOL_LEDGER.set(ledger)
+    try:
+        _record_to_ledger(
+            "finus_list_diaries",
+            '[{"id": 1, "title": "매매일지 2026-08-07", "content": "삼성전자 매수"}]',
+        )
+    finally:
+        DATA_TOOL_LEDGER.reset(token)
+
+    assert ledger.any_success() is True
+
+
+def test_record_to_ledger_empty_rlz_pl_no_summary_does_not_count_as_success():
+    """실현손익 조회 성공 + 보유종목 없음 + 계좌집계 없음 → any_success()=False.
+
+    balance-rlz-pl-report.js formatBalanceRlzPlReport 의 rows.length===0 분기:
+    summary가 null이면 "[계좌 집계]" 블록을 출력하지 않는다.
+    실제 수치가 전혀 없는 이 응답은 produced_rows=False가 돼야 한다.
+    """
+    ledger = DataToolLedger()
+    token = DATA_TOOL_LEDGER.set(ledger)
+    try:
+        _record_to_ledger(
+            "finus_mcp_trading_balance_rlz_pl",
+            "[주식잔고조회_실현손익]\n- 조회 TR: TTTC8494R (v1_국내주식-041)\n- 보유 종목이 없습니다.",
+        )
+    finally:
+        DATA_TOOL_LEDGER.reset(token)
+
+    assert ledger.any_success() is False
+
+
+def test_record_to_ledger_empty_rlz_pl_with_summary_counts_as_success():
+    """실현손익 조회 성공 + 보유종목 없음 + 계좌집계 있음 → any_success()=True (오탐 없음).
+
+    balance-rlz-pl-report.js 의 rows.length===0 + summary 존재 분기:
+    "[계좌 집계]" 블록에 예수금·평가금액 등 실제 계좌 수치가 포함된다.
+    produced_rows=False로 만들면 이 정상 데이터 응답을 차단하는 오탐이 된다.
+    """
+    ledger = DataToolLedger()
+    token = DATA_TOOL_LEDGER.set(ledger)
+    try:
+        _record_to_ledger(
+            "finus_mcp_trading_balance_rlz_pl",
+            "[주식잔고조회_실현손익]\n- 보유 종목이 없습니다.\n\n[계좌 집계]\n- 예수금: 1,000,000원\n- 실현손익: 52,000원",
+        )
+    finally:
+        DATA_TOOL_LEDGER.reset(token)
+
+    assert ledger.any_success() is True

--- a/finus_nat/tests/test_tool_enforcement.py
+++ b/finus_nat/tests/test_tool_enforcement.py
@@ -7,6 +7,7 @@
 직접 호출해 검증하므로, 실제 ReAct 에이전트나 LLM 없이도 동작이 고정된다.
 """
 
+import json
 import logging
 import pytest
 from pathlib import Path
@@ -33,6 +34,7 @@ from nat_finus_nat.finus_api import (
     DataToolLedger,
     _EMPTY_RESULT_LITERALS,
     _err_json,
+    _has_empty_result,
     _record_to_ledger,
 )
 
@@ -902,3 +904,67 @@ def test_record_to_ledger_nonempty_earnings_report_counts_as_success():
         DATA_TOOL_LEDGER.reset(token)
 
     assert ledger.any_success() is True
+
+# ---------------------------------------------------------------------------
+# Improvement 1 (PR #216 리뷰) — JSON fall-through 회귀 가드
+#
+# _has_empty_result의 JSON 분기는 빈 컨테이너일 때만 True를 확정하고,
+# 비어있지 않은 JSON이어도 리터럴 검사로 fall-through한다.
+# 조기 `return False`를 복원(뮤턴트)하면 이 테스트들이 red가 된다.
+# ---------------------------------------------------------------------------
+
+def test_has_empty_result_json_string_wrapped_literal_detected():
+    """JSON 문자열로 감싼 리터럴도 빈 결과로 판정한다.
+
+    잡는 뮤턴트: JSON 분기에 `return False` 조기 종료를 복원하면,
+    파싱된 문자열이 비어있지 않아 fall-through 없이 False를 반환하고 이 단언이 깨진다.
+
+    Node.js JSON.stringify는 한국어를 \\uXXXX 없이 그대로 직렬화하므로
+    ensure_ascii=False로 시뮬레이션한다.
+    """
+    lit = _EMPTY_RESULT_LITERALS["finus_market_news"]
+    # Node.js style: JSON.stringify("'삼성전자'에 대한 뉴스를 찾지 못했습니다.")
+    wrapped = json.dumps("'삼성전자'" + lit, ensure_ascii=False)
+    assert _has_empty_result("finus_market_news", wrapped) is True
+
+
+def test_has_empty_result_json_object_wrapped_literal_detected():
+    """JSON 객체로 감싼 리터럴도 빈 결과로 판정한다.
+
+    잡는 뮤턴트: JSON 분기에 `return False` 조기 종료를 복원하면,
+    파싱된 객체가 비어있지 않아 fall-through 없이 False를 반환하고 이 단언이 깨진다.
+
+    MCP 래퍼가 {"text": "..."} 형태로 감쌀 때 리터럴 탐지가 유지됨을 고정한다.
+    """
+    lit = _EMPTY_RESULT_LITERALS["finus_market_news"]
+    wrapped = json.dumps({"text": "'삼성전자'" + lit}, ensure_ascii=False)
+    assert _has_empty_result("finus_market_news", wrapped) is True
+
+
+def test_has_empty_result_empty_dict_json_is_true():
+    """빈 dict JSON ('{}')을 빈 결과로 판정한다.
+
+    잡는 뮤턴트: isinstance 판정에서 dict를 제거(list만 허용)하면 {} → False가 돼
+    이 단언이 깨진다. finus_list_diaries 등에서 backend가 {}를 돌려줄 때의 방어선이다.
+    """
+    assert _has_empty_result("finus_list_diaries", "{}") is True
+
+
+def test_has_empty_result_empty_string_json_is_true():
+    """빈 문자열 JSON ('\"\"')을 빈 결과로 판정한다.
+
+    잡는 뮤턴트: isinstance 판정에서 str를 제거(list/dict만 허용)하면 \"\" → False가 돼
+    이 단언이 깨진다.
+    """
+    assert _has_empty_result("finus_list_diaries", '""') is True
+
+
+def test_has_empty_result_data_bearing_json_is_false():
+    """데이터가 있는 JSON은 빈 결과로 판정하지 않는다(오탐 방지).
+
+    fall-through 변경이 오탐을 만들지 않음을 고정한다.
+    리터럴 검사는 도구 이름으로 게이트되므로 finus_market_news 의
+    실제 뉴스 JSON 객체는 통과해야 한다.
+    """
+    data = json.dumps({"items": ["삼성전자 뉴스1", "뉴스2"]}, ensure_ascii=False)
+    assert _has_empty_result("finus_market_news", data) is False

--- a/finus_nat/tests/test_tool_enforcement.py
+++ b/finus_nat/tests/test_tool_enforcement.py
@@ -968,3 +968,95 @@ def test_has_empty_result_data_bearing_json_is_false():
     """
     data = json.dumps({"items": ["삼성전자 뉴스1", "뉴스2"]}, ensure_ascii=False)
     assert _has_empty_result("finus_market_news", data) is False
+
+
+# ---------------------------------------------------------------------------
+# 🟡 Improvement (PR #216 3차 리뷰) — 2차 시도 경로의 only_empty_reads() 가드
+# ---------------------------------------------------------------------------
+
+async def test_run_with_gate_second_attempt_empty_reads_returns_empty_rejection():
+    """1차 도구 없음 → 2차 도구 호출 + 빈 결과 → _EMPTY_RESULT_REJECTION 반환.
+
+    시나리오:
+      1차: 에이전트가 도구를 전혀 호출하지 않고 수치를 지어냄 → 게이트 트립
+           (ledger 비어 있음 → only_empty_reads()=False → 재시도 진행)
+      2차: 교정 프리픽스 덕분에 도구 호출함(today_orders 빈 결과) + 여전히 수치 주장
+           → 게이트 트립 → ledger2.only_empty_reads()=True
+           → _EMPTY_RESULT_REJECTION 반환 ("도구 없이"가 아니므로 올바른 메시지)
+    LLM 호출이 정확히 2회인지 확인한다(2차는 실제로 실행되므로).
+    """
+    call_count = 0
+
+    async def ainvoke_no_tool_then_empty(_input):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:
+            # 2차: 교정 프리픽스로 인해 도구를 호출하지만 빈 결과
+            _record_to_ledger(
+                "finus_mcp_trading_today_orders",
+                "[당일 주문·체결 내역] 20260807\n- 결과: 해당 조건의 주문·체결이 없습니다.",
+            )
+        # 1차·2차 모두 수치를 지어낸 답변 반환
+        return ChatResponse.from_string("오늘 체결된 주문은 삼성전자 100주입니다.", usage=Usage())
+
+    mock_inner = MagicMock()
+    mock_inner.ainvoke = ainvoke_no_tool_then_empty
+
+    result = await _run_with_gate(
+        inner=mock_inner,
+        query="오늘 주문 내역 알려줘",
+        chat_request=_simple_req("오늘 주문 내역 알려줘"),
+        inner_name="trading_agent_react",
+    )
+
+    assert result == _EMPTY_RESULT_REJECTION, (
+        f"2차 빈 결과 경로에서 _EMPTY_RESULT_REJECTION이 반환돼야 합니다. 실제: {result!r}"
+    )
+    assert call_count == 2, (
+        f"1차(도구 없음)·2차(빈 결과) 모두 실행되므로 LLM 호출은 2회여야 합니다. 실제: {call_count}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 🔵 Nitpick (PR #216 3차 리뷰) — had_side_effect + only_empty_reads 조합
+# ---------------------------------------------------------------------------
+
+async def test_side_effect_guard_with_empty_reads_returns_empty_rejection():
+    """save_diary + 빈 조회(market_news) 조합 → _EMPTY_RESULT_REJECTION + 재시도 건너뜀.
+
+    시나리오:
+      쓰기 도구(finus_save_diary)와 빈 결과 읽기 도구(finus_market_news)가 함께 실행됨.
+      had_side_effect()=True → 재시도 건너뜀(call_count=1 유지).
+      only_empty_reads()=True(읽기 목록이 전부 빈 결과) → _EMPTY_RESULT_REJECTION 반환.
+      "도구 없이"라고 말하는 _TOOL_ENFORCEMENT_REJECTION은 사실과 다르므로 차단된다.
+    """
+    call_count = 0
+
+    async def ainvoke_save_and_empty_news(_input):
+        nonlocal call_count
+        call_count += 1
+        # 쓰기 도구: 저장 성공
+        _record_to_ledger("finus_save_diary", '{"id": 12, "title": "매매일지"}')
+        # 읽기 도구: 빈 결과
+        _record_to_ledger(
+            "finus_market_news",
+            "'삼성전자'에 대한 뉴스를 찾지 못했습니다.",
+        )
+        return ChatResponse.from_string("잔고는 500만원입니다.", usage=Usage())
+
+    mock_inner = MagicMock()
+    mock_inner.ainvoke = ainvoke_save_and_empty_news
+
+    result = await _run_with_gate(
+        inner=mock_inner,
+        query="삼성전자 뉴스 알려줘",
+        chat_request=_simple_req("삼성전자 뉴스 알려줘"),
+        inner_name="news_agent",
+    )
+
+    assert result == _EMPTY_RESULT_REJECTION, (
+        f"쓰기+빈 조회 조합에서 _EMPTY_RESULT_REJECTION이 반환돼야 합니다. 실제: {result!r}"
+    )
+    assert call_count == 1, (
+        f"부작용 가드로 재시도 없이 1회만 호출해야 합니다. 실제: {call_count}"
+    )

--- a/finus_nat/tests/test_tool_enforcement.py
+++ b/finus_nat/tests/test_tool_enforcement.py
@@ -8,6 +8,8 @@
 """
 
 import logging
+import pytest
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 from nat.data_models.api_server import (
@@ -19,13 +21,28 @@ from nat.data_models.api_server import (
 )
 
 from nat_finus_nat.agents import (
+    _EMPTY_RESULT_REJECTION,
     _TOOL_ENFORCEMENT_REJECTION,
     _check_tool_enforcement,
     _extract_financial_numbers,
     _has_numeric_claims,
     _run_with_gate,
 )
-from nat_finus_nat.finus_api import DATA_TOOL_LEDGER, DataToolLedger, _err_json, _record_to_ledger
+from nat_finus_nat.finus_api import (
+    DATA_TOOL_LEDGER,
+    DataToolLedger,
+    _EMPTY_RESULT_LITERALS,
+    _err_json,
+    _record_to_ledger,
+)
+
+# 계약 테스트용: MCP 소스 파일 경로 (리포지토리 루트 기준)
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_MCP_SOURCES: dict[str, str] = {
+    "finus_mcp_trading_today_orders": "mcp-trading/index.js",
+    "finus_market_news": "mcp-news/index.js",
+    "finus_earnings_report": "mcp-dart/index.js",
+}
 
 
 # ---------------------------------------------------------------------------
@@ -668,6 +685,218 @@ def test_record_to_ledger_empty_rlz_pl_with_summary_counts_as_success():
         _record_to_ledger(
             "finus_mcp_trading_balance_rlz_pl",
             "[주식잔고조회_실현손익]\n- 보유 종목이 없습니다.\n\n[계좌 집계]\n- 예수금: 1,000,000원\n- 실현손익: 52,000원",
+        )
+    finally:
+        DATA_TOOL_LEDGER.reset(token)
+
+    assert ledger.any_success() is True
+
+
+# ---------------------------------------------------------------------------
+# Critical (PR #216 리뷰) — only_empty_reads() 단위 테스트
+# ---------------------------------------------------------------------------
+
+def test_only_empty_reads_true_when_all_reads_empty():
+    """읽기 도구가 실행됐고 전부 빈 결과면 only_empty_reads()=True."""
+    ledger = DataToolLedger()
+    token = DATA_TOOL_LEDGER.set(ledger)
+    try:
+        _record_to_ledger(
+            "finus_mcp_trading_today_orders",
+            "[당일 주문·체결 내역] 20260807\n- 결과: 해당 조건의 주문·체결이 없습니다.",
+        )
+    finally:
+        DATA_TOOL_LEDGER.reset(token)
+
+    assert ledger.only_empty_reads() is True
+
+
+def test_only_empty_reads_false_when_no_records():
+    """도구를 전혀 호출하지 않으면 only_empty_reads()=False."""
+    ledger = DataToolLedger()
+    assert ledger.only_empty_reads() is False
+
+
+def test_only_empty_reads_false_when_only_side_effects():
+    """쓰기 도구만 있으면 읽기 목록이 비어 only_empty_reads()=False."""
+    ledger = DataToolLedger()
+    token = DATA_TOOL_LEDGER.set(ledger)
+    try:
+        _record_to_ledger("finus_save_diary", '{"id": 12, "title": "매매일지"}')
+    finally:
+        DATA_TOOL_LEDGER.reset(token)
+
+    assert ledger.only_empty_reads() is False
+
+
+def test_only_empty_reads_false_when_one_read_has_data():
+    """빈 읽기와 데이터 있는 읽기가 섞이면 only_empty_reads()=False."""
+    ledger = DataToolLedger()
+    token = DATA_TOOL_LEDGER.set(ledger)
+    try:
+        _record_to_ledger(
+            "finus_mcp_trading_today_orders",
+            "[당일 주문·체결 내역] 20260807\n- 결과: 해당 조건의 주문·체결이 없습니다.",
+        )
+        _record_to_ledger(
+            "finus_market_news",
+            "삼성전자 4분기 실적 호조 - 반도체 수요 회복 | 2026-08-07",
+        )
+    finally:
+        DATA_TOOL_LEDGER.reset(token)
+
+    assert ledger.only_empty_reads() is False
+
+
+# ---------------------------------------------------------------------------
+# Critical (PR #216 리뷰) — _run_with_gate: 빈 결과 경로의 재시도 건너뜀 확인
+# ---------------------------------------------------------------------------
+
+async def test_run_with_gate_empty_reads_skips_retry_returns_empty_rejection():
+    """빈 결과 + 0값 답변: 재시도 없이 _EMPTY_RESULT_REJECTION을 반환해야 한다.
+
+    시나리오: today_orders가 빈 결과를 돌려주고 에이전트가 '0주'라고 정직하게 답한다.
+    수정 전: 게이트 트립 → 재시도 → 재시도도 트립 → _TOOL_ENFORCEMENT_REJECTION (거짓 메시지)
+    수정 후: 게이트 트립 → only_empty_reads()=True → 재시도 건너뜀 → _EMPTY_RESULT_REJECTION
+    LLM 호출이 1회로 끝나는지(재시도 없음)를 확인한다.
+    """
+    call_count = 0
+
+    async def ainvoke_empty_then_zero(_input):
+        nonlocal call_count
+        call_count += 1
+        _record_to_ledger(
+            "finus_mcp_trading_today_orders",
+            "[당일 주문·체결 내역] 20260807\n- 결과: 해당 조건의 주문·체결이 없습니다.",
+        )
+        return ChatResponse.from_string("오늘 체결된 주문은 0주입니다.", usage=Usage())
+
+    mock_inner = MagicMock()
+    mock_inner.ainvoke = ainvoke_empty_then_zero
+
+    result = await _run_with_gate(
+        inner=mock_inner,
+        query="오늘 주문 내역 알려줘",
+        chat_request=_simple_req("오늘 주문 내역 알려줘"),
+        inner_name="trading_agent_react",
+    )
+
+    assert result == _EMPTY_RESULT_REJECTION, (
+        f"_EMPTY_RESULT_REJECTION이 반환돼야 합니다. 실제: {result!r}"
+    )
+    assert call_count == 1, (
+        f"빈 결과 가드로 재시도 없이 1회만 호출해야 합니다. 실제: {call_count}"
+    )
+
+
+async def test_run_with_gate_empty_reads_fabricated_nonzero_still_blocked():
+    """빈 결과 + 비0 수치 지어내기: 여전히 차단되고 _EMPTY_RESULT_REJECTION을 반환한다.
+
+    수정의 의도는 게이트를 통째로 푸는 것이 아니다 — 빈 결과로 수치를 지어내는 것은
+    여전히 차단된다. 다만 거짓 _TOOL_ENFORCEMENT_REJECTION 대신 정직한
+    _EMPTY_RESULT_REJECTION을 반환하고, LLM 호출은 1회로 줄인다.
+    """
+    call_count = 0
+
+    async def ainvoke_empty_then_fabricated(_input):
+        nonlocal call_count
+        call_count += 1
+        _record_to_ledger(
+            "finus_mcp_trading_today_orders",
+            "[당일 주문·체결 내역] 20260807\n- 결과: 해당 조건의 주문·체결이 없습니다.",
+        )
+        return ChatResponse.from_string("잔고는 500만원입니다.", usage=Usage())
+
+    mock_inner = MagicMock()
+    mock_inner.ainvoke = ainvoke_empty_then_fabricated
+
+    result = await _run_with_gate(
+        inner=mock_inner,
+        query="잔고 알려줘",
+        chat_request=_simple_req("잔고 알려줘"),
+        inner_name="trading_agent_react",
+    )
+
+    assert result == _EMPTY_RESULT_REJECTION, (
+        f"_EMPTY_RESULT_REJECTION이 반환돼야 합니다. 실제: {result!r}"
+    )
+    assert call_count == 1, (
+        f"빈 결과 가드로 재시도 없이 1회만 호출해야 합니다. 실제: {call_count}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Improvement 2 (PR #216 리뷰) — MCP 소스와의 계약 테스트
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("tool_name,rel_path", sorted(_MCP_SOURCES.items()))
+def test_empty_result_literal_still_exists_in_mcp_source(tool_name: str, rel_path: str):
+    """_EMPTY_RESULT_LITERALS는 MCP 소스 문자열에 대한 하드 의존이다.
+
+    JS 쪽 문구가 바뀌면 게이트가 조용히 #209로 회귀하므로, 여기서 깨뜨려 알린다.
+    """
+    source = (_REPO_ROOT / rel_path).read_text(encoding="utf-8")
+    literal = _EMPTY_RESULT_LITERALS[tool_name]
+    assert literal in source, (
+        f"{rel_path}에서 '{literal}'가 사라졌습니다. "
+        f"_EMPTY_RESULT_LITERALS[{tool_name!r}]를 새 문구로 갱신하세요."
+    )
+
+
+def test_rlz_pl_dual_condition_markers_still_exist():
+    """balance-rlz-pl-report.js의 이중 조건 마커가 유지되는지 확인한다.
+
+    '보유 종목이 없습니다.'와 '[계좌 집계]'가 두 분기를 구분하는 근거다.
+    둘 중 하나라도 바뀌면 빈-결과 판정 로직이 조용히 무력화된다.
+    """
+    source = (_REPO_ROOT / "mcp-trading/balance-rlz-pl-report.js").read_text(encoding="utf-8")
+    assert "보유 종목이 없습니다." in source
+    assert "[계좌 집계]" in source
+
+
+# ---------------------------------------------------------------------------
+# Improvement 3 (PR #216 리뷰) — get_balance 의도적 통과를 고정하는 테스트
+# ---------------------------------------------------------------------------
+
+def test_record_to_ledger_get_balance_no_holdings_still_counts_as_success():
+    """무보유 잔고 응답은 '데이터 없음'이 아니라 '보유 0건이라는 실제 데이터'다.
+
+    mcp-trading/balance.js 는 보유 목록이 비어도 [계좌 잔고 현황] 블록에
+    거래가능금액·정산예정금액 등 실제 KIS 수치를 그대로 포함한다.
+    이를 빈 결과로 판정하면 예수금을 인용하는 정상 답변이 차단된다(오탐).
+    balance-rlz-pl-report.js 와 문구가 같으므로 도구 이름 게이트가 필수다.
+    """
+    ledger = DataToolLedger()
+    token = DATA_TOOL_LEDGER.set(ledger)
+    try:
+        _record_to_ledger(
+            "finus_mcp_trading_get_balance",
+            "[계좌 잔고 현황]\n- 총 평가금액: 0원\n- 거래가능금액: 1,250,000원\n"
+            "- 익일 정산예정금액: 1,250,000원\n\n[보유 종목 리스트]\n보유 종목이 없습니다.",
+        )
+    finally:
+        DATA_TOOL_LEDGER.reset(token)
+
+    assert ledger.any_success() is True
+
+
+# ---------------------------------------------------------------------------
+# Nitpick 1 (PR #216 리뷰) — finus_earnings_report 대칭 페어 추가
+# ---------------------------------------------------------------------------
+
+def test_record_to_ledger_nonempty_earnings_report_counts_as_success():
+    """실적 리포트 조회 성공 + 데이터 있음 → any_success()=True (오탐 없음).
+
+    mcp-dart/index.js formatEarningsReport 의 데이터 있는 분기는
+    '[주요 실적]' 블록을 포함한다. 이 응답이 빈 결과로 오판되지 않아야 한다.
+    """
+    ledger = DataToolLedger()
+    token = DATA_TOOL_LEDGER.set(ledger)
+    try:
+        _record_to_ledger(
+            "finus_earnings_report",
+            "[삼성전자] DART 실적 리포트\n- 조회기간: 2025FY\n[주요 실적]\n"
+            "- 매출: 300조원\n- 영업이익: 32조원",
         )
     finally:
         DATA_TOOL_LEDGER.reset(token)


### PR DESCRIPTION
## 배경

#209. 읽기 도구가 **성공했지만 데이터가 비어 있는** 경우 `any_success()`가 True가 되어 게이트가 통과합니다. 그 뒤 에이전트가 수치를 지어내면 잡히지 않습니다.

## 변경

`produced_rows`가 세 조건을 **모두** 만족할 때만 `True`가 됩니다:

1. `ok` — 오류 응답이 아님
2. 쓰기 도구가 아님 (PR #205)
3. **빈 결과가 아님** (이 PR)

## 탐지 방식 — 추측 휴리스틱 없음

이슈가 "추측으로 문자열 패턴을 넣으면 오탐이 #152가 경계한 무조건 차단과 같은 실패 양상"이라고 경고해서, **MCP 소스 코드에서 직접 추출한 리터럴만** 씁니다. 우선순위는 구조적 판정 → 문서화된 리터럴입니다.

| 도구 | 빈-결과 신호 | 근거 | 판정 |
| --- | --- | --- | --- |
| `finus_list_diaries` | `[]` / `null` | JSON 파싱 (구조적) | 분류 |
| `finus_mcp_trading_today_orders` | `해당 조건의 주문·체결이 없습니다.` | `mcp-trading/index.js` | 분류 |
| `finus_market_news` | `에 대한 뉴스를 찾지 못했습니다.` | `mcp-news/index.js` | 분류 |
| `finus_earnings_report` | `OpenDART 재무제표 데이터가 없습니다.` | `mcp-dart/index.js` | 분류 |
| `finus_mcp_trading_balance_rlz_pl` | `보유 종목이 없습니다.` **+** `[계좌 집계]` 부재 | `balance-rlz-pl-report.js` | 분류(이중 조건) |
| `finus_mcp_trading_get_balance` | — | 아래 참조 | **미분류(보수적 통과)** |
| `finus_disclosure_signal` | 3섹션 개별 마커 | 판별 복잡, 오탐 위험 | **미분류** |
| `finus_account_balance` | `api_type`별 가변 | 형식 불안정 | **미분류** |

리터럴 5종이 실제 MCP 소스에 존재하는지 직접 확인했습니다(각각 1~3건 매치). 도구 이름 키가 실제 `_record_to_ledger` 호출부와 일치하는지도 전수 대조해 **죽은 키가 없음**을 확인했습니다.

## ⚠️ 이슈 본문의 예시가 일부만 해결됩니다 — 반드시 읽어주세요

이슈 #209 본문은 예시로 *"잔고 조회가 정상 응답으로 '보유 종목이 없습니다'를 돌려준 뒤 에이전트가 잔고 수치를 지어내면"* 을 들었습니다. 그런데 **`finus_mcp_trading_get_balance`는 미분류로 남았습니다.**

이유를 소스로 확인했습니다. `mcp-trading/balance.js`의 무보유 분기는 보유 목록만 비고 **계좌 요약은 실제 KIS 수치를 그대로 포함**합니다:

```
- 거래가능금액: ...
- 정산중 금액(가수도): ...
- 익일 정산예정금액: ...
- 금일 매수/매도: ... / ...

[보유 종목 리스트]
보유 종목이 없습니다.
```

즉 이 응답은 "데이터 없음"이 아니라 **"보유 종목이 0건이라는 실제 데이터"** 입니다. 이것을 빈 결과로 판정하면, 예수금·거래가능금액을 인용하는 정상 답변이 트립합니다 — 오탐입니다.

**남는 갭**: 에이전트가 이 응답을 받은 뒤 *보유 종목* 수치를 지어내면 게이트가 통과합니다. 계좌 요약 인용은 정당하고 보유 종목 주장은 부당한데, 원장은 그 둘을 구분하지 못합니다. 해결하려면 "어떤 수치를 주장하는가"와 "도구가 어떤 데이터를 줬는가"를 대응시켜야 하는데, 이 PR의 범위(원장 판정)를 넘습니다.

`finus_mcp_trading_balance_rlz_pl`는 계좌 집계가 없는 경우가 실재해 이중 조건으로 분류했습니다 — 같은 "잔고" 계열이라도 응답 형태가 달라 판정이 갈립니다.

## 검증 (직접 실행)

`pytest tests/` (프로젝트 venv) — **120 → 130 passed, 1 skipped** (실패 0건, +10건).

12종 실측:

| 케이스 | `ok` | `produced_rows` | `any_success()` |
| --- | --- | --- | --- |
| `list_diaries` 빈 리스트 | True | **False** | False ✅ |
| `list_diaries` 데이터 있음 | True | True | True ✅ |
| `today_orders` 빈 결과 | True | **False** | False ✅ |
| `today_orders` 데이터 있음 | True | True | True ✅ |
| `market_news` 빈 결과 | True | **False** | False ✅ |
| `market_news` 데이터 있음 | True | True | True ✅ |
| `earnings_report` 빈 결과 | True | **False** | False ✅ |
| `balance_rlz_pl` 집계 없음 | True | **False** | False ✅ |
| `balance_rlz_pl` 집계 있음 | True | True | True ✅ |
| `get_balance` 무보유 | True | True | True (의도된 보수적 통과) |
| `save_diary` 저장 성공 | True | False | False (PR #205 유지) ✅ |
| `market_news` 오류 JSON | False | False | False ✅ |

뮤테이션:

| 뮤턴트 | 결과 |
| --- | --- |
| 빈-결과 축 제거 (#209 회귀) | **6 failed** ✅ |
| 쓰기 도구 제외 제거 (PR #205 회귀) | **2 failed** ✅ |
| JSON 구조 판정 제거 | **2 failed** ✅ |
| `balance_rlz_pl` 이중 조건에서 `[계좌 집계]` 검사 제거 | **1 failed** ✅ |

PR #205가 만든 동작(쓰기 도구 성공이 게이트를 끄지 않음, `had_side_effect()`, 오류 JSON 판정)은 회귀하지 않습니다.

Closes #209
