### PR TITLE
fix: 비-trading 에이전트의 KIS 주문 실행 도구 접근 차단 (#66)

### DIFF
--- a/finus_nat/configs/agents/news_agent.yml
+++ b/finus_nat/configs/agents/news_agent.yml
@@ -8,10 +8,11 @@ llms:
     model_name: ${NEWS_OPENAI_CHAT_MODEL:-gpt-5.4-mini}
 
 functions:
-  # #66: news/recommend/strategy/diary 에이전트에서 주문 실행 api_type을 차단한다.
-  # trading_agent.yml의 finus_account_balance(전체 권한)를 조회 전용 래퍼로 대체.
-  # 이 오버라이드는 base 상속 체인(recommend_agent → strategy_agent → diary_agent)에 자동 전파된다.
-  kis-trading-mcp-tool:
+  # #66: news/recommend/strategy 에이전트용 조회 전용 래퍼를 별도 이름으로 등록한다.
+  # 병합된 라우터 설정에서 functions 딕셔너리는 이름이 전역인 평평한 네임스페이스이므로,
+  # 한 이름에 인스턴스는 하나뿐이다. 따라서 trading/monitoring의 kis-trading-mcp-tool
+  # (전체 권한 finus_account_balance)을 건드리지 않고 별도 이름으로 분리해야 한다.
+  kis-trading-mcp-tool-readonly:
     _type: finus_account_balance_readonly
     mcp_transport: sse
     mcp_url: ${FINUS_KIS_TRADING_MCP_URL:-http://host.docker.internal:3300/sse}
@@ -21,7 +22,7 @@ functions:
     _type: react_agent
     llm_name: news_openai_llm
     tool_names:
-      - kis-trading-mcp-tool
+      - kis-trading-mcp-tool-readonly
       # news agent가 실수로 주식거래를 해버리는 위험을 막기 위해 향후에 다른 것으로 변경
       - mcp-news-get-market-news
       - mcp-dart-get-disclosure-signal
@@ -48,7 +49,7 @@ functions:
       Action: 여기에는 위 도구 이름 중 하나만 그대로 적습니다(대괄호나 "중 하나" 문구를 넣지 마세요).
 
       Action Input:
-      - Kis Trading MCP(``kis-trading-mcp-tool``): {{"tool_name":"domestic_stock","api_type":"...","params":{{...}}}}
+      - Kis Trading MCP(``kis-trading-mcp-tool-readonly``): {{"tool_name":"domestic_stock","api_type":"...","params":{{...}}}}
       - ``mcp-news-get-market-news`` / ``mcp-dart-get-disclosure-signal`` / ``mcp-dart-get-earnings-report``: {{"stock_name":"삼성전자"}} (``mcp-dart-get-earnings-report``만 ``period`` 선택 추가 가능, 예: {{"stock_name":"삼성전자","period":"2025Q1"}})
 
       그 다음 줄부터는 Observation이 옵니다(모델이 직접 쓰지 않음).
@@ -74,9 +75,9 @@ functions:
       - DART 실적 리포트: `mcp-dart-get-earnings-report` (stock_name, period 선택). 실적·분기보고서·사업보고서·earnings 질문에는 이 도구와 최신 뉴스를 함께 사용합니다.
       - 실적 분석 모드에서는 매출/영업이익/순이익 YoY, 실적 서프라이즈/미스 여부, 주요 뉴스 기반 정성 코멘트, 다음 분기 전망을 구조화해 답하십시오.
         컨센서스 또는 시장 기대치 데이터가 도구 Observation에 없으면 추정하지 말고 "컨센서스 데이터 없음"으로 명시하십시오.
-      - `kis-trading-mcp-tool`: 보유종목/포트폴리오 확인이 필요할 때 사용합니다.
+      - `kis-trading-mcp-tool-readonly`: 보유종목/포트폴리오 확인이 필요할 때 사용합니다.
         기본 잔고 조회는 `api_type:"inquire_balance"`, `params:{{"env_dv":"real","inqr_dvsn":"01"}}`로 시작하십시오.
-      - 최근 대화에 종목명이 이미 있으면 그 종목명을 그대로 사용해도 됩니다. 그렇지 않다면 kis-trading-mcp-tool을 사용하여 직접 조회하고 종목명을 가져옵니다.
+      - 최근 대화에 종목명이 이미 있으면 그 종목명을 그대로 사용해도 됩니다. 그렇지 않다면 kis-trading-mcp-tool-readonly를 사용하여 직접 조회하고 종목명을 가져옵니다.
         예: 사용자가 "내 포트폴리오는 삼성전자와 네이버야"라고 말한 뒤 포트폴리오 관련 뉴스를 물으면 삼성전자와 NAVER 각각에 대해 `mcp-news-get-market-news`를 호출합니다.
 
       도구 Observation을 받기 전에는 Final Answer를 쓰지 마십시오.

--- a/finus_nat/configs/agents/news_agent.yml
+++ b/finus_nat/configs/agents/news_agent.yml
@@ -8,9 +8,9 @@ llms:
     model_name: ${NEWS_OPENAI_CHAT_MODEL:-gpt-5.4-mini}
 
 functions:
-  # #66: news/recommend/strategy 에이전트에서 주문 실행 api_type을 차단한다.
+  # #66: news/recommend/strategy/diary 에이전트에서 주문 실행 api_type을 차단한다.
   # trading_agent.yml의 finus_account_balance(전체 권한)를 조회 전용 래퍼로 대체.
-  # 이 오버라이드는 base 상속 체인(recommend_agent → strategy_agent)에 자동 전파된다.
+  # 이 오버라이드는 base 상속 체인(recommend_agent → strategy_agent → diary_agent)에 자동 전파된다.
   kis-trading-mcp-tool:
     _type: finus_account_balance_readonly
     mcp_transport: sse

--- a/finus_nat/configs/agents/news_agent.yml
+++ b/finus_nat/configs/agents/news_agent.yml
@@ -8,6 +8,15 @@ llms:
     model_name: ${NEWS_OPENAI_CHAT_MODEL:-gpt-5.4-mini}
 
 functions:
+  # #66: news/recommend/strategy 에이전트에서 주문 실행 api_type을 차단한다.
+  # trading_agent.yml의 finus_account_balance(전체 권한)를 조회 전용 래퍼로 대체.
+  # 이 오버라이드는 base 상속 체인(recommend_agent → strategy_agent)에 자동 전파된다.
+  kis-trading-mcp-tool:
+    _type: finus_account_balance_readonly
+    mcp_transport: sse
+    mcp_url: ${FINUS_KIS_TRADING_MCP_URL:-http://host.docker.internal:3300/sse}
+    trading_tool_name: ${FINUS_KIS_TRADING_TOOL_NAME:-domestic_stock}
+
   news_agent:
     _type: react_agent
     llm_name: news_openai_llm

--- a/finus_nat/configs/agents/recommend_agent.yml
+++ b/finus_nat/configs/agents/recommend_agent.yml
@@ -14,7 +14,7 @@ functions:
 
     llm_name: recommend_openai_llm
     tool_names:
-      - kis-trading-mcp-tool
+      - kis-trading-mcp-tool-readonly
       - mcp-news-get-market-news
       - add_user_memory
       - get_user_memory
@@ -38,7 +38,7 @@ functions:
       Action: 여기에는 위 도구 이름 중 하나만 그대로 적습니다(대괄호나 "중 하나" 문구를 넣지 마세요).
 
       Action Input:
-      - Kis Trading MCP(``kis-trading-mcp-tool``): {{"tool_name":"domestic_stock","api_type":"inquire_balance","params":{{...}}}} (오류 시 ``find_api_detail``로 스키마 확인 후 재시도)
+      - Kis Trading MCP(``kis-trading-mcp-tool-readonly``): {{"tool_name":"domestic_stock","api_type":"inquire_balance","params":{{...}}}} (오류 시 ``find_api_detail``로 스키마 확인 후 재시도)
       - ``mcp-news-get-market-news``: {{"stock_name":"삼성전자"}}
 
       그 다음 줄부터는 Observation이 옵니다(모델이 직접 쓰지 않음).
@@ -59,7 +59,7 @@ functions:
       같은 주제로 도구를 쓰거나 답합니다. 이미 정해진 업종/테마를 다시 묻지 마세요.
 
       사용자의 질문에 따라 조건에 맞는 종목을 추천합니다.
-      정형적인 데이터에 기반한 조건을 질문할 경우 kis-trading-mcp-tool을 호출합니다.
+      정형적인 데이터에 기반한 조건을 질문할 경우 kis-trading-mcp-tool-readonly를 호출합니다.
       KIS 조회에서 API/validation 오류가 나면 오류 응답으로 끝내지 말고 `find_api_detail`로 해당 api_type의 필드와 기본값을 확인한 뒤 params를 고쳐 원래 조회를 다시 실행합니다. 이 재시도까지가 성공 조건입니다.
       잔고/포트폴리오 맥락이 필요한 경우 `inquire_balance` 기본값은 params `{{"env_dv":"real","inqr_dvsn":"01"}}` 입니다.
       비정형적인 데이터에 기반한 조건을 질문할 경우 mcp-news 툴을 호출합니다.

--- a/finus_nat/configs/agents/strategy_agent.yml
+++ b/finus_nat/configs/agents/strategy_agent.yml
@@ -15,7 +15,7 @@ functions:
     tool_names:
       - mcp-news-get-market-news
       - mcp-dart-get-disclosure-signal
-      - kis-trading-mcp-tool
+      - kis-trading-mcp-tool-readonly
       - add_user_memory
       - get_user_memory
     verbose: false
@@ -37,7 +37,7 @@ functions:
       Thought: (짧게, 한국어 가능)
       Action: 여기에는 위 도구 이름 중 하나만 그대로 적습니다(대괄호나 "중 하나" 문구를 넣지 마세요).
 
-      Action Input (Kis Trading MCP 전용 — ``kis-trading-mcp-tool``):
+      Action Input (Kis Trading MCP 전용 — ``kis-trading-mcp-tool-readonly``):
       {{"tool_name":"domestic_stock","api_type":"inquire_balance","params":{{...}}}}
       오류 시 ``find_api_detail``로 스키마 확인 후 재시도.
 
@@ -61,7 +61,7 @@ functions:
       사용자의 투자 기간, 위험 선호, 선호 섹터, 답변 스타일처럼 오래 유지되는 개인화 정보는 필요할 때 get_user_memory로 확인합니다.
 
       === 동작 지시 ===
-      - `kis-trading-mcp-tool`: ``api_type``·``params``(필요 시 ``tool_name``) JSON — trading 과 동일. ``find_api_detail`` 로 TR 확인. ``inquire_account_balance`` 에는 ``env_dv``·``inqr_dvsn_1:"00"`` 넣지 마세요.
+      - `kis-trading-mcp-tool-readonly`: ``api_type``·``params``(필요 시 ``tool_name``) JSON. ``find_api_detail`` 로 TR 확인. ``inquire_account_balance`` 에는 ``env_dv``·``inqr_dvsn_1:"00"`` 넣지 마세요. 주문 실행은 이 에이전트의 권한 밖입니다.
       - 잔고/포트폴리오 조회 기본값: ``api_type:"inquire_balance"``, ``params:{{"env_dv":"real","inqr_dvsn":"01"}}``.
       - KIS API/validation 오류가 나면 오류를 최종 답변으로 쓰지 말고 ``find_api_detail`` → params 수정 → 원래 조회 재실행을 수행하세요. 성공 Observation을 얻거나 재시도 실패를 설명할 때만 최종 답변하세요.
       - mcp-news: ``mcp-news-get-market-news`` (종목명). 수급·정형 데이터는 Kis MCP로 조회합니다. mcp-dart: ``mcp-dart-get-disclosure-signal`` 로 지분공시 리스크를 참고하되 자동 매매 근거로만 쓰지 마세요.

--- a/finus_nat/src/nat_finus_nat/finus_api.py
+++ b/finus_nat/src/nat_finus_nat/finus_api.py
@@ -667,6 +667,10 @@ _KIS_TRADING_TOOL_GUIDE = """
 
 # ---- 조회 전용 KIS Trading MCP 래퍼 (#66) ----
 
+# #205/#209 원장 판정 키 — finus_account_balance(전체 권한)와 readonly 래퍼 양쪽이 공유한다.
+# 변경 시 #205/#209 원장 판정 로직과 함께 반드시 동기화할 것.
+_KIS_BALANCE_LEDGER_NAME: str = "finus_account_balance"
+
 # 허용 목록(allowlist) 방식 — fail-closed: 목록에 없는 api_type은 기본 차단.
 #
 # 설계 근거:
@@ -686,6 +690,11 @@ _KIS_TRADING_TOOL_GUIDE = """
 # _READONLY_API_ALLOWLIST_EXACT에 추가하거나 접두사를 확장하세요.
 _READONLY_API_ALLOWLIST_PREFIXES: tuple[str, ...] = ("inquire_", "search_")
 _READONLY_API_ALLOWLIST_EXACT: frozenset[str] = frozenset({"find_api_detail"})
+
+# 조회 전용 래퍼가 허용하는 MCP tool_name 허용 목록. fail-closed: 목록 밖의 tool_name은 차단.
+# 비-trading 에이전트 프롬프트가 실제로 지정하는 값은 domestic_stock 하나이나,
+# 해외 주식 조회를 위해 overseas_stock도 포함한다.
+_READONLY_TOOL_ALLOWLIST: frozenset[str] = frozenset({"domestic_stock", "overseas_stock"})
 
 
 def _is_readonly_api_type(api_type: str) -> bool:
@@ -718,30 +727,44 @@ class FinusAccountBalanceReadonlyConfig(FinusAccountBalanceConfig, name="finus_a
 async def finus_account_balance_readonly(config: FinusAccountBalanceReadonlyConfig, _builder: Builder):
 
     async def get_account_balance_readonly(inp: KisTradingMcpCallInput) -> str:
-        """Kis Trading MCP 조회 전용 래퍼 — 허용 목록에 없는 api_type은 차단된다 (#66).
+        """Kis Trading MCP 조회 전용 래퍼 — tool_name·api_type 허용 목록으로 이중 차단 (#66).
 
-        허용(pass-through): inquire_*(잔고·시세·체결 등), search_*, find_api_detail.
-        차단(fail-closed): order_*, modify_order, cancel_order, 및 목록에 없는 모든 api_type.
+        허용 tool_name: domestic_stock, overseas_stock.
+        허용 api_type(pass-through): inquire_*(잔고·시세·체결 등), search_*, find_api_detail.
+        차단(fail-closed): 목록 밖의 tool_name 또는 api_type(order_* 계열 포함).
         """
         prepared = _prepare_kis_trading_mcp_call(inp, config)
         if isinstance(prepared, str):
-            _record_to_ledger("finus_account_balance", prepared)
+            _record_to_ledger(_KIS_BALANCE_LEDGER_NAME, prepared)
             return prepared
         tool_name, arguments = prepared
+        if tool_name.lower() not in _READONLY_TOOL_ALLOWLIST:
+            logger.warning("readonly gate blocked tool_name=%r", tool_name)
+            result = _err_json(
+                "kis_tool_name_not_allowed_readonly",
+                tool_name=tool_name,
+                hint=(
+                    "이 도구는 조회 전용입니다. domestic_stock 또는 overseas_stock만 사용하세요. "
+                    "주문 실행은 이 에이전트의 권한이 아니므로 재시도하지 말고 사용자에게 안내하세요."
+                ),
+            )
+            _record_to_ledger(_KIS_BALANCE_LEDGER_NAME, result)
+            return result
         api_type = str(arguments.get("api_type", ""))
         if not _is_readonly_api_type(api_type):
+            logger.warning(
+                "readonly gate blocked api_type=%r (allowlist prefixes: %s, exact: %s)",
+                api_type, _READONLY_API_ALLOWLIST_PREFIXES, sorted(_READONLY_API_ALLOWLIST_EXACT),
+            )
             result = _err_json(
                 "kis_api_type_not_allowed_readonly",
                 api_type=api_type,
                 hint=(
-                    "조회 전용 에이전트에서 허용되지 않은 api_type입니다. "
-                    f"차단된 값: {api_type!r}. "
-                    "허용 목록: inquire_* 접두사, search_* 접두사, find_api_detail. "
-                    "운영자: finus_api.py의 _READONLY_API_ALLOWLIST_EXACT 또는 "
-                    "_READONLY_API_ALLOWLIST_PREFIXES에 추가하세요."
+                    "이 도구는 조회 전용입니다. inquire_*/search_*/find_api_detail 만 사용하세요. "
+                    "주문 실행은 이 에이전트의 권한이 아니므로 재시도하지 말고 사용자에게 안내하세요."
                 ),
             )
-            _record_to_ledger("finus_account_balance", result)
+            _record_to_ledger(_KIS_BALANCE_LEDGER_NAME, result)
             return result
         result = await _mcp_call_tool_remote(
             transport=config.mcp_transport,
@@ -750,7 +773,7 @@ async def finus_account_balance_readonly(config: FinusAccountBalanceReadonlyConf
             arguments=arguments,
             timeout_sec=config.timeout_sec,
         )
-        _record_to_ledger("finus_account_balance", result)
+        _record_to_ledger(_KIS_BALANCE_LEDGER_NAME, result)
         return result
 
     base_desc = (get_account_balance_readonly.__doc__ or "").strip()
@@ -1132,7 +1155,7 @@ async def finus_account_balance(config: FinusAccountBalanceConfig, _builder: Bui
         """
         prepared = _prepare_kis_trading_mcp_call(inp, config)
         if isinstance(prepared, str):
-            _record_to_ledger("finus_account_balance", prepared)
+            _record_to_ledger(_KIS_BALANCE_LEDGER_NAME, prepared)
             return prepared
         tool_name, arguments = prepared
         result = await _mcp_call_tool_remote(
@@ -1142,7 +1165,7 @@ async def finus_account_balance(config: FinusAccountBalanceConfig, _builder: Bui
             arguments=arguments,
             timeout_sec=config.timeout_sec,
         )
-        _record_to_ledger("finus_account_balance", result)
+        _record_to_ledger(_KIS_BALANCE_LEDGER_NAME, result)
         return result
 
     base_desc = (get_account_balance.__doc__ or "").strip()

--- a/finus_nat/src/nat_finus_nat/finus_api.py
+++ b/finus_nat/src/nat_finus_nat/finus_api.py
@@ -692,9 +692,13 @@ _READONLY_API_ALLOWLIST_PREFIXES: tuple[str, ...] = ("inquire_", "search_")
 _READONLY_API_ALLOWLIST_EXACT: frozenset[str] = frozenset({"find_api_detail"})
 
 # 조회 전용 래퍼가 허용하는 MCP tool_name 허용 목록. fail-closed: 목록 밖의 tool_name은 차단.
-# 비-trading 에이전트 프롬프트가 실제로 지정하는 값은 domestic_stock 하나이나,
-# 해외 주식 조회를 위해 overseas_stock도 포함한다.
-_READONLY_TOOL_ALLOWLIST: frozenset[str] = frozenset({"domestic_stock", "overseas_stock"})
+# api_type 게이트가 주문을 막으므로, tool_name은 조회 대상 자산군을 넓게 허용한다.
+# auth는 조회 목적이 없고 인증 상태를 바꿀 수 있어 제외한다.
+# trading_agent.yml·KisTradingMcpCallInput에 나열된 자산군 8종 중 auth만 제외한 7종.
+_READONLY_TOOL_ALLOWLIST: frozenset[str] = frozenset({
+    "domestic_stock", "overseas_stock", "domestic_bond",
+    "domestic_futureoption", "overseas_futureoption", "elw", "etfetn",
+})
 
 
 def _is_readonly_api_type(api_type: str) -> bool:
@@ -715,6 +719,18 @@ def _is_readonly_api_type(api_type: str) -> bool:
     )
 
 
+def _is_readonly_tool_name(tool_name: str) -> bool:
+    """Return True when *tool_name* is in the readonly asset-class allowlist (fail-closed).
+
+    Allowed: domestic_stock, overseas_stock, domestic_bond, domestic_futureoption,
+    overseas_futureoption, elw, etfetn.
+
+    Excluded: auth (인증 상태를 바꿀 수 있어 조회 전용 래퍼에서 허용하지 않는다).
+    Any unknown tool_name returns False.
+    """
+    return (tool_name or "").strip().lower() in _READONLY_TOOL_ALLOWLIST
+
+
 class FinusAccountBalanceReadonlyConfig(FinusAccountBalanceConfig, name="finus_account_balance_readonly"):
     """finus_account_balance 조회 전용 래퍼 — allowlist 방식 api_type 차단 (#66).
 
@@ -729,7 +745,8 @@ async def finus_account_balance_readonly(config: FinusAccountBalanceReadonlyConf
     async def get_account_balance_readonly(inp: KisTradingMcpCallInput) -> str:
         """Kis Trading MCP 조회 전용 래퍼 — tool_name·api_type 허용 목록으로 이중 차단 (#66).
 
-        허용 tool_name: domestic_stock, overseas_stock.
+        허용 tool_name: domestic_stock, overseas_stock, domestic_bond, domestic_futureoption,
+        overseas_futureoption, elw, etfetn (auth 제외 — 인증 상태 변경 가능).
         허용 api_type(pass-through): inquire_*(잔고·시세·체결 등), search_*, find_api_detail.
         차단(fail-closed): 목록 밖의 tool_name 또는 api_type(order_* 계열 포함).
         """
@@ -738,13 +755,15 @@ async def finus_account_balance_readonly(config: FinusAccountBalanceReadonlyConf
             _record_to_ledger(_KIS_BALANCE_LEDGER_NAME, prepared)
             return prepared
         tool_name, arguments = prepared
-        if tool_name.lower() not in _READONLY_TOOL_ALLOWLIST:
+        if not _is_readonly_tool_name(tool_name):
             logger.warning("readonly gate blocked tool_name=%r", tool_name)
             result = _err_json(
                 "kis_tool_name_not_allowed_readonly",
                 tool_name=tool_name,
                 hint=(
-                    "이 도구는 조회 전용입니다. domestic_stock 또는 overseas_stock만 사용하세요. "
+                    "이 도구는 조회 전용입니다. "
+                    "domestic_stock, overseas_stock, domestic_bond, domestic_futureoption, "
+                    "overseas_futureoption, elw, etfetn 중 하나를 사용하세요. "
                     "주문 실행은 이 에이전트의 권한이 아니므로 재시도하지 말고 사용자에게 안내하세요."
                 ),
             )

--- a/finus_nat/src/nat_finus_nat/finus_api.py
+++ b/finus_nat/src/nat_finus_nat/finus_api.py
@@ -667,31 +667,50 @@ _KIS_TRADING_TOOL_GUIDE = """
 
 # ---- 조회 전용 KIS Trading MCP 래퍼 (#66) ----
 
-# KIS TR api_type 중 주문 실행(write) 동작에 해당하는 명시적 값 집합.
-# "order" 접두사가 매수·매도·해외주문 계열을 모두 커버하고,
-# modify_/cancel_ 계열은 명시적으로 추가한다.
-_ORDER_EXECUTION_API_EXACT: frozenset[str] = frozenset({
-    "modify_order",
-    "cancel_order",
-})
+# 허용 목록(allowlist) 방식 — fail-closed: 목록에 없는 api_type은 기본 차단.
+#
+# 설계 근거:
+#   KIS TR 이름 규칙: 조회 계열은 예외 없이 ``inquire_`` 또는 ``search_`` 로 시작한다.
+#   스키마 조회(find_api_detail)도 읽기 전용이다 — 에이전트가 이 도구로 TR 스키마를
+#   발견하더라도, 실제 호출 시 api_type이 이 허용 목록을 통과해야 하므로 이중 차단이 된다.
+#   결과적으로 원격 MCP 서버가 새 TR을 추가해도 허용 목록에 명시하기 전까지는 차단된다.
+#
+# 허용 접두사:
+#   inquire_  — 잔고·시세·체결·투자자·일봉·분봉 등 모든 조회 TR
+#   search_   — 종목 코드 검색 등 검색 TR
+#
+# 허용 정확 값:
+#   find_api_detail — TR 스키마 조회 (에이전트 자기교정 루프용; 읽기 전용)
+#
+# 운영자 추가 방법: 새 조회 TR이 위 접두사 패턴을 벗어나면
+# _READONLY_API_ALLOWLIST_EXACT에 추가하거나 접두사를 확장하세요.
+_READONLY_API_ALLOWLIST_PREFIXES: tuple[str, ...] = ("inquire_", "search_")
+_READONLY_API_ALLOWLIST_EXACT: frozenset[str] = frozenset({"find_api_detail"})
 
 
-def _is_order_execution_api_type(api_type: str) -> bool:
-    """Return True when *api_type* is a KIS order-execution (write) operation.
+def _is_readonly_api_type(api_type: str) -> bool:
+    """Return True when *api_type* is a permitted read-only KIS Trading API (allowlist, fail-closed).
 
-    Blocks ``order_*`` prefixed types (order_cash, order_sell, overseas variants, …)
-    and explicit ``modify_order`` / ``cancel_order``.
-    Read-only types (``inquire_*``, ``find_api_detail``, ``auth``, …) return False.
+    Allowed:
+    - ``inquire_*`` prefix — balance, price, chart, investor, and all other inquiry TRs
+    - ``search_*`` prefix — stock code and other search TRs
+    - ``find_api_detail`` — TR schema lookup (safe: discovering schemas does not execute orders)
+
+    Any api_type not in the above list returns False, including all order-execution types
+    (``order_cash``, ``order_sell``, ``modify_order``, ``cancel_order``, novel future types, …).
     """
     lower = (api_type or "").strip().lower()
-    return lower.startswith("order") or lower in _ORDER_EXECUTION_API_EXACT
+    return (
+        any(lower.startswith(p) for p in _READONLY_API_ALLOWLIST_PREFIXES)
+        or lower in _READONLY_API_ALLOWLIST_EXACT
+    )
 
 
 class FinusAccountBalanceReadonlyConfig(FinusAccountBalanceConfig, name="finus_account_balance_readonly"):
-    """finus_account_balance 조회 전용 래퍼 — 주문 실행 api_type 차단 (#66).
+    """finus_account_balance 조회 전용 래퍼 — allowlist 방식 api_type 차단 (#66).
 
-    비-trading 에이전트(news/recommend/strategy)가 잔고·시세 조회 능력은 유지하되
-    주문 실행 api_type(order_*, modify_order, cancel_order)을 호출하지 못하도록 한다.
+    비-trading 에이전트(news/recommend/strategy/diary)가 잔고·시세 조회 능력은 유지하되
+    허용 목록(inquire_*, search_*, find_api_detail)에 없는 api_type은 fail-closed로 차단한다.
     """
 
 
@@ -699,11 +718,10 @@ class FinusAccountBalanceReadonlyConfig(FinusAccountBalanceConfig, name="finus_a
 async def finus_account_balance_readonly(config: FinusAccountBalanceReadonlyConfig, _builder: Builder):
 
     async def get_account_balance_readonly(inp: KisTradingMcpCallInput) -> str:
-        """Kis Trading MCP 조회 전용 래퍼 — 주문 실행 api_type은 차단된다 (#66).
+        """Kis Trading MCP 조회 전용 래퍼 — 허용 목록에 없는 api_type은 차단된다 (#66).
 
-        잔고·시세·종목 조회(inquire_balance, inquire_price, find_api_detail 등)는
-        finus_account_balance와 동일하게 동작한다.
-        주문 실행(order_cash, modify_order, cancel_order 등)은 즉시 오류를 반환한다.
+        허용(pass-through): inquire_*(잔고·시세·체결 등), search_*, find_api_detail.
+        차단(fail-closed): order_*, modify_order, cancel_order, 및 목록에 없는 모든 api_type.
         """
         prepared = _prepare_kis_trading_mcp_call(inp, config)
         if isinstance(prepared, str):
@@ -711,11 +729,17 @@ async def finus_account_balance_readonly(config: FinusAccountBalanceReadonlyConf
             return prepared
         tool_name, arguments = prepared
         api_type = str(arguments.get("api_type", ""))
-        if _is_order_execution_api_type(api_type):
+        if not _is_readonly_api_type(api_type):
             result = _err_json(
-                "kis_order_execution_blocked",
+                "kis_api_type_not_allowed_readonly",
                 api_type=api_type,
-                hint="이 에이전트는 조회 전용입니다. 주문 실행은 trading_agent를 사용하세요.",
+                hint=(
+                    "조회 전용 에이전트에서 허용되지 않은 api_type입니다. "
+                    f"차단된 값: {api_type!r}. "
+                    "허용 목록: inquire_* 접두사, search_* 접두사, find_api_detail. "
+                    "운영자: finus_api.py의 _READONLY_API_ALLOWLIST_EXACT 또는 "
+                    "_READONLY_API_ALLOWLIST_PREFIXES에 추가하세요."
+                ),
             )
             _record_to_ledger("finus_account_balance", result)
             return result

--- a/finus_nat/src/nat_finus_nat/finus_api.py
+++ b/finus_nat/src/nat_finus_nat/finus_api.py
@@ -665,6 +665,84 @@ _KIS_TRADING_TOOL_GUIDE = """
 """.strip()
 
 
+# ---- 조회 전용 KIS Trading MCP 래퍼 (#66) ----
+
+# KIS TR api_type 중 주문 실행(write) 동작에 해당하는 명시적 값 집합.
+# "order" 접두사가 매수·매도·해외주문 계열을 모두 커버하고,
+# modify_/cancel_ 계열은 명시적으로 추가한다.
+_ORDER_EXECUTION_API_EXACT: frozenset[str] = frozenset({
+    "modify_order",
+    "cancel_order",
+})
+
+
+def _is_order_execution_api_type(api_type: str) -> bool:
+    """Return True when *api_type* is a KIS order-execution (write) operation.
+
+    Blocks ``order_*`` prefixed types (order_cash, order_sell, overseas variants, …)
+    and explicit ``modify_order`` / ``cancel_order``.
+    Read-only types (``inquire_*``, ``find_api_detail``, ``auth``, …) return False.
+    """
+    lower = (api_type or "").strip().lower()
+    return lower.startswith("order") or lower in _ORDER_EXECUTION_API_EXACT
+
+
+class FinusAccountBalanceReadonlyConfig(FinusAccountBalanceConfig, name="finus_account_balance_readonly"):
+    """finus_account_balance 조회 전용 래퍼 — 주문 실행 api_type 차단 (#66).
+
+    비-trading 에이전트(news/recommend/strategy)가 잔고·시세 조회 능력은 유지하되
+    주문 실행 api_type(order_*, modify_order, cancel_order)을 호출하지 못하도록 한다.
+    """
+
+
+@register_function(config_type=FinusAccountBalanceReadonlyConfig)
+async def finus_account_balance_readonly(config: FinusAccountBalanceReadonlyConfig, _builder: Builder):
+
+    async def get_account_balance_readonly(inp: KisTradingMcpCallInput) -> str:
+        """Kis Trading MCP 조회 전용 래퍼 — 주문 실행 api_type은 차단된다 (#66).
+
+        잔고·시세·종목 조회(inquire_balance, inquire_price, find_api_detail 등)는
+        finus_account_balance와 동일하게 동작한다.
+        주문 실행(order_cash, modify_order, cancel_order 등)은 즉시 오류를 반환한다.
+        """
+        prepared = _prepare_kis_trading_mcp_call(inp, config)
+        if isinstance(prepared, str):
+            _record_to_ledger("finus_account_balance", prepared)
+            return prepared
+        tool_name, arguments = prepared
+        api_type = str(arguments.get("api_type", ""))
+        if _is_order_execution_api_type(api_type):
+            result = _err_json(
+                "kis_order_execution_blocked",
+                api_type=api_type,
+                hint="이 에이전트는 조회 전용입니다. 주문 실행은 trading_agent를 사용하세요.",
+            )
+            _record_to_ledger("finus_account_balance", result)
+            return result
+        result = await _mcp_call_tool_remote(
+            transport=config.mcp_transport,
+            url=config.mcp_url,
+            tool_name=tool_name,
+            arguments=arguments,
+            timeout_sec=config.timeout_sec,
+        )
+        _record_to_ledger("finus_account_balance", result)
+        return result
+
+    base_desc = (get_account_balance_readonly.__doc__ or "").strip()
+    remote = await _fetch_mcp_tool_documentation(config)
+    merged = (
+        f"{base_desc}\n\n{_KIS_TRADING_TOOL_GUIDE}\n\n{remote}"
+        if remote
+        else f"{base_desc}\n\n{_KIS_TRADING_TOOL_GUIDE}"
+    )
+    yield FunctionInfo.from_fn(
+        get_account_balance_readonly,
+        description=_langchain_escape_braces(merged),
+        input_schema=KisTradingMcpCallInput,
+    )
+
+
 def _mcp_news_stock_function_info(
     *,
     vendor_root: str | None,

--- a/finus_nat/tests/test_agent_configs.py
+++ b/finus_nat/tests/test_agent_configs.py
@@ -177,6 +177,67 @@ _IDENTICAL_SYSTEM_PROMPT_AGENTS = [
 ]
 
 
+# ---------------------------------------------------------------------------
+# #66 회귀 가드 — 비-trading 에이전트의 kis-trading-mcp-tool이 조회 전용인지 확인
+# ---------------------------------------------------------------------------
+
+# (config_path, agent 함수 이름) — kis-trading-mcp-tool을 보유하지만 주문 실행 차단 대상 에이전트
+_NON_TRADING_KIS_CONFIGS = [
+    (AGENTS_DIR / "news_agent.yml", "news_agent"),
+    (AGENTS_DIR / "recommend_agent.yml", "recommend_agent"),
+    (AGENTS_DIR / "strategy_agent.yml", "strategy_agent"),
+]
+
+# kis-trading-mcp-tool이 전체 권한(finus_account_balance)을 유지해야 하는 에이전트
+_TRADING_KIS_CONFIGS = [
+    (AGENTS_DIR / "trading_agent.yml", "trading_agent_react"),
+    (AGENTS_DIR / "monitoring_agent.yml", "monitoring_agent"),
+]
+
+_NON_TRADING_KIS_IDS = [f"{p.name}::{a}" for p, a in _NON_TRADING_KIS_CONFIGS]
+_TRADING_KIS_IDS = [f"{p.name}::{a}" for p, a in _TRADING_KIS_CONFIGS]
+
+
+@pytest.mark.parametrize("config_path,agent_fn", _NON_TRADING_KIS_CONFIGS, ids=_NON_TRADING_KIS_IDS)
+def test_non_trading_agents_kis_tool_is_readonly(config_path: Path, agent_fn: str):
+    """#66: news/recommend/strategy의 kis-trading-mcp-tool은 finus_account_balance_readonly여야 한다.
+
+    trading_agent.yml이 정의한 finus_account_balance(전체 권한)가 상속 체인을 통해
+    비-trading 에이전트에 그대로 전파되는 회귀를 방지한다.
+    """
+    import nat_finus_nat.register  # noqa: F401
+    from nat.runtime.loader import load_config
+    from nat_finus_nat.finus_api import FinusAccountBalanceReadonlyConfig
+
+    config = load_config(config_path)
+    tool_config = config.functions["kis-trading-mcp-tool"]
+    assert isinstance(tool_config, FinusAccountBalanceReadonlyConfig), (
+        f"{config_path.name}: kis-trading-mcp-tool은 finus_account_balance_readonly여야 합니다. "
+        f"실제 타입: {type(tool_config).__name__}"
+    )
+
+
+@pytest.mark.parametrize("config_path,agent_fn", _TRADING_KIS_CONFIGS, ids=_TRADING_KIS_IDS)
+def test_trading_agents_kis_tool_is_full(config_path: Path, agent_fn: str):
+    """trading/monitoring의 kis-trading-mcp-tool은 전체 권한(finus_account_balance)이어야 한다.
+
+    조회 전용 래퍼가 실수로 trading/monitoring 에이전트에도 적용되는 회귀를 방지한다.
+    """
+    import nat_finus_nat.register  # noqa: F401
+    from nat.runtime.loader import load_config
+    from nat_finus_nat.finus_api import FinusAccountBalanceConfig, FinusAccountBalanceReadonlyConfig
+
+    config = load_config(config_path)
+    tool_config = config.functions["kis-trading-mcp-tool"]
+    assert not isinstance(tool_config, FinusAccountBalanceReadonlyConfig), (
+        f"{config_path.name}: kis-trading-mcp-tool은 readonly가 아닌 finus_account_balance여야 합니다."
+    )
+    assert isinstance(tool_config, FinusAccountBalanceConfig), (
+        f"{config_path.name}: kis-trading-mcp-tool은 finus_account_balance여야 합니다. "
+        f"실제 타입: {type(tool_config).__name__}"
+    )
+
+
 def test_kis_agents_share_identical_system_prompt():
     """monitoring/strategy/trading 프롬프트는 의도적으로 동일하다 - 한 곳만 수정되는 드리프트를 막는다."""
     import nat_finus_nat.register  # noqa: F401 - 등록 트리거만 필요

--- a/finus_nat/tests/test_agent_configs.py
+++ b/finus_nat/tests/test_agent_configs.py
@@ -163,76 +163,75 @@ def test_system_prompt_only_names_real_tools(config_path: Path, function_name: s
     assert quoted <= tools, f"프롬프트가 보유하지 않은 도구를 안내함: {sorted(quoted - tools)}"
 
 
-# monitoring/strategy/trading은 tool_names가 완전히 같아(kis-trading-mcp-tool,
+# monitoring/trading은 tool_names가 완전히 같아(kis-trading-mcp-tool,
 # mcp-news-get-market-news, mcp-dart-get-disclosure-signal, add_user_memory, get_user_memory)
-# system_prompt를 의도적으로 바이트 단위로 동일하게 유지한다. recommend_agent는 DART 도구가
-# 없는 다른 tool_names를 가지고 있어(#152 리뷰 Improvement 2로 Action Input에 mcp-news 안내를
-# 추가하면서) 더 이상 나머지 셋과 동일하지 않다 - 그래서 이 셋만 비교한다. 파일이 나뉘어 있어
-# YAML 앵커로 공유할 수 없으니 복제 자체는 불가피하지만, 한 파일만 고치고 나머지를 빠뜨리는
-# 드리프트는 이 테스트가 잡는다.
+# system_prompt를 의도적으로 바이트 단위로 동일하게 유지한다.
+# #66 수정으로 strategy_agent는 kis-trading-mcp-tool-readonly를 tool_names에 쓰게 되어
+# system_prompt가 이 둘과 분기했으므로 비교 대상에서 제외한다.
+# 파일이 나뉘어 있어 YAML 앵커로 공유할 수 없으니 복제 자체는 불가피하지만, 한 파일만
+# 고치고 나머지를 빠뜨리는 드리프트는 이 테스트가 잡는다.
 _IDENTICAL_SYSTEM_PROMPT_AGENTS = [
     ("monitoring_agent.yml", "monitoring_agent"),
-    ("strategy_agent.yml", "strategy_agent"),
     ("trading_agent.yml", "trading_agent_react"),
 ]
 
 
 # ---------------------------------------------------------------------------
-# #66 회귀 가드 — 비-trading 에이전트의 kis-trading-mcp-tool이 조회 전용인지 확인
+# #66 회귀 가드 — 두 KIS 함수의 타입과 에이전트별 tool_names 참조를 고정
 # ---------------------------------------------------------------------------
 
-# (config_path, agent 함수 이름) — kis-trading-mcp-tool이 scope에 있고 주문 실행 차단 대상.
-# news_agent.yml의 override가 상속 체인(recommend → strategy → diary)에 전파됨.
-# diary_agent는 tool_names에 kis-trading-mcp-tool을 포함하지 않지만, 함수가 scope에
-# 정의되어 있으므로 readonly 상태를 고정한다.
+_ROUTER_PATHS = (CONFIGS_ROOT / "router.yml", CONFIGS_ROOT / "router_nomemory.yml")
+
+# kis-trading-mcp-tool-readonly(조회 전용)가 scope에 있어야 하는 설정.
+# diary_agent는 tool_names에 포함하지 않지만 scope에 정의되어 있으므로 타입을 고정한다.
+# 단독 로드 + 프로덕션 라우터 양쪽에서 검사한다 — 이름을 분리했으므로 라우터 deep-merge가
+# trading/monitoring의 kis-trading-mcp-tool(전체 권한)을 덮어쓰지 않음을 함께 보증한다.
 _NON_TRADING_KIS_CONFIGS = [
-    (AGENTS_DIR / "news_agent.yml", "news_agent"),
-    (AGENTS_DIR / "recommend_agent.yml", "recommend_agent"),
-    (AGENTS_DIR / "strategy_agent.yml", "strategy_agent"),
-    (AGENTS_DIR / "diary_agent.yml", "diary_agent"),
+    AGENTS_DIR / "news_agent.yml",
+    AGENTS_DIR / "recommend_agent.yml",
+    AGENTS_DIR / "strategy_agent.yml",
+    AGENTS_DIR / "diary_agent.yml",
+    *_ROUTER_PATHS,
 ]
 
-# kis-trading-mcp-tool이 전체 권한(finus_account_balance)을 유지해야 하는 에이전트.
-# 단독 로드뿐 아니라 프로덕션 라우터 설정도 포함한다 — base 체인 deep-merge 결과에서
-# news_agent.yml의 오버라이드가 trading/monitoring 권한을 빼앗는 회귀를 잡기 위해서다.
+# kis-trading-mcp-tool(전체 권한 finus_account_balance)이어야 하는 설정.
+# 단독 로드뿐 아니라 프로덕션 라우터도 포함 — 이름 분리로 news_agent.yml의 readonly 함수가
+# 이 함수를 덮어쓰지 않음을 라우터 병합 결과에서 직접 확인한다.
 _TRADING_KIS_CONFIGS = [
-    (AGENTS_DIR / "trading_agent.yml", "trading_agent_react"),
-    (AGENTS_DIR / "monitoring_agent.yml", "monitoring_agent"),
-    (CONFIGS_ROOT / "router.yml", "trading_agent_react"),
-    (CONFIGS_ROOT / "router_nomemory.yml", "trading_agent_react"),
-    (CONFIGS_ROOT / "router.yml", "monitoring_agent"),
-    (CONFIGS_ROOT / "router_nomemory.yml", "monitoring_agent"),
+    AGENTS_DIR / "trading_agent.yml",
+    AGENTS_DIR / "monitoring_agent.yml",
+    *_ROUTER_PATHS,
 ]
 
-_NON_TRADING_KIS_IDS = [f"{p.name}::{a}" for p, a in _NON_TRADING_KIS_CONFIGS]
-_TRADING_KIS_IDS = [f"{p.name}::{a}" for p, a in _TRADING_KIS_CONFIGS]
+_NON_TRADING_KIS_IDS = [p.name for p in _NON_TRADING_KIS_CONFIGS]
+_TRADING_KIS_IDS = [p.name for p in _TRADING_KIS_CONFIGS]
 
 
-@pytest.mark.parametrize("config_path,agent_fn", _NON_TRADING_KIS_CONFIGS, ids=_NON_TRADING_KIS_IDS)
-def test_non_trading_agents_kis_tool_is_readonly(config_path: Path, agent_fn: str):
-    """#66: news/recommend/strategy/diary의 kis-trading-mcp-tool은 finus_account_balance_readonly여야 한다.
+@pytest.mark.parametrize("config_path", _NON_TRADING_KIS_CONFIGS, ids=_NON_TRADING_KIS_IDS)
+def test_non_trading_agents_kis_tool_is_readonly(config_path: Path):
+    """#66: kis-trading-mcp-tool-readonly는 어떤 설정에서 로드해도 finus_account_balance_readonly여야 한다.
 
-    trading_agent.yml이 정의한 finus_account_balance(전체 권한)가 상속 체인을 통해
-    비-trading 에이전트(news→recommend→strategy→diary)에 그대로 전파되는 회귀를 방지한다.
-    diary_agent는 tool_names에 포함하지 않지만 scope에 정의된 함수 타입을 고정한다.
+    news_agent.yml이 별도 이름(kis-trading-mcp-tool-readonly)으로 조회 전용 래퍼를 등록하므로,
+    라우터 deep-merge 결과에서도 전체 권한 kis-trading-mcp-tool을 건드리지 않는다.
     """
     import nat_finus_nat.register  # noqa: F401
     from nat.runtime.loader import load_config
     from nat_finus_nat.finus_api import FinusAccountBalanceReadonlyConfig
 
     config = load_config(config_path)
-    tool_config = config.functions["kis-trading-mcp-tool"]
+    tool_config = config.functions["kis-trading-mcp-tool-readonly"]
     assert isinstance(tool_config, FinusAccountBalanceReadonlyConfig), (
-        f"{config_path.name}: kis-trading-mcp-tool은 finus_account_balance_readonly여야 합니다. "
+        f"{config_path.name}: kis-trading-mcp-tool-readonly는 finus_account_balance_readonly여야 합니다. "
         f"실제 타입: {type(tool_config).__name__}"
     )
 
 
-@pytest.mark.parametrize("config_path,agent_fn", _TRADING_KIS_CONFIGS, ids=_TRADING_KIS_IDS)
-def test_trading_agents_kis_tool_is_full(config_path: Path, agent_fn: str):
-    """trading/monitoring의 kis-trading-mcp-tool은 전체 권한(finus_account_balance)이어야 한다.
+@pytest.mark.parametrize("config_path", _TRADING_KIS_CONFIGS, ids=_TRADING_KIS_IDS)
+def test_trading_agents_kis_tool_is_full(config_path: Path):
+    """#66: kis-trading-mcp-tool은 어떤 설정에서 로드해도 전체 권한(finus_account_balance)이어야 한다.
 
-    조회 전용 래퍼가 실수로 trading/monitoring 에이전트에도 적용되는 회귀를 방지한다.
+    이름 분리 후에는 news_agent.yml의 readonly 함수가 별도 키(kis-trading-mcp-tool-readonly)에
+    등록되므로 kis-trading-mcp-tool(전체 권한)이 라우터 병합으로 덮이지 않는다.
     """
     import nat_finus_nat.register  # noqa: F401
     from nat.runtime.loader import load_config
@@ -246,6 +245,48 @@ def test_trading_agents_kis_tool_is_full(config_path: Path, agent_fn: str):
     assert isinstance(tool_config, FinusAccountBalanceConfig), (
         f"{config_path.name}: kis-trading-mcp-tool은 finus_account_balance여야 합니다. "
         f"실제 타입: {type(tool_config).__name__}"
+    )
+
+
+# 각 에이전트의 tool_names가 권한에 맞는 KIS 도구를 참조하는지 고정한다.
+# 타입만 검사하면 tool_names 드리프트(예: news_agent가 kis-trading-mcp-tool-readonly 대신
+# kis-trading-mcp-tool을 참조)를 놓칠 수 있다 — 참조 고정으로 이중 보증한다.
+_AGENT_KIS_TOOL_REFS = [
+    # (config_path, agent_fn, expected_tool_name_in_tool_names)
+    (AGENTS_DIR / "trading_agent.yml", "trading_agent_react", "kis-trading-mcp-tool"),
+    (AGENTS_DIR / "monitoring_agent.yml", "monitoring_agent", "kis-trading-mcp-tool"),
+    (AGENTS_DIR / "news_agent.yml", "news_agent", "kis-trading-mcp-tool-readonly"),
+    (AGENTS_DIR / "recommend_agent.yml", "recommend_agent", "kis-trading-mcp-tool-readonly"),
+    (AGENTS_DIR / "strategy_agent.yml", "strategy_agent", "kis-trading-mcp-tool-readonly"),
+    (CONFIGS_ROOT / "router.yml", "trading_agent_react", "kis-trading-mcp-tool"),
+    (CONFIGS_ROOT / "router.yml", "monitoring_agent", "kis-trading-mcp-tool"),
+    (CONFIGS_ROOT / "router.yml", "news_agent", "kis-trading-mcp-tool-readonly"),
+    (CONFIGS_ROOT / "router.yml", "recommend_agent", "kis-trading-mcp-tool-readonly"),
+    (CONFIGS_ROOT / "router.yml", "strategy_agent", "kis-trading-mcp-tool-readonly"),
+    (CONFIGS_ROOT / "router_nomemory.yml", "trading_agent_react", "kis-trading-mcp-tool"),
+    (CONFIGS_ROOT / "router_nomemory.yml", "monitoring_agent", "kis-trading-mcp-tool"),
+    (CONFIGS_ROOT / "router_nomemory.yml", "news_agent", "kis-trading-mcp-tool-readonly"),
+    (CONFIGS_ROOT / "router_nomemory.yml", "recommend_agent", "kis-trading-mcp-tool-readonly"),
+    (CONFIGS_ROOT / "router_nomemory.yml", "strategy_agent", "kis-trading-mcp-tool-readonly"),
+]
+_AGENT_KIS_TOOL_REF_IDS = [f"{p.name}::{a}::{t}" for p, a, t in _AGENT_KIS_TOOL_REFS]
+
+
+@pytest.mark.parametrize("config_path,agent_fn,expected_tool", _AGENT_KIS_TOOL_REFS, ids=_AGENT_KIS_TOOL_REF_IDS)
+def test_agent_references_expected_kis_tool(config_path: Path, agent_fn: str, expected_tool: str):
+    """#66: 에이전트 tool_names가 권한에 맞는 KIS 도구를 참조하는지 고정한다.
+
+    kis-trading-mcp-tool(전체 권한)은 trading/monitoring만, kis-trading-mcp-tool-readonly는
+    news/recommend/strategy만 참조해야 한다. 라우터 설정에서도 동일하게 검사한다.
+    """
+    import nat_finus_nat.register  # noqa: F401
+    from nat.runtime.loader import load_config
+
+    config = load_config(config_path)
+    tool_names = [str(t) for t in config.functions[agent_fn].tool_names]
+    assert expected_tool in tool_names, (
+        f"{config_path.name}::{agent_fn}: tool_names에 {expected_tool!r}가 없습니다. "
+        f"실제 tool_names: {tool_names}"
     )
 
 

--- a/finus_nat/tests/test_agent_configs.py
+++ b/finus_nat/tests/test_agent_configs.py
@@ -204,10 +204,11 @@ _TRADING_KIS_IDS = [f"{p.name}::{a}" for p, a in _TRADING_KIS_CONFIGS]
 
 @pytest.mark.parametrize("config_path,agent_fn", _NON_TRADING_KIS_CONFIGS, ids=_NON_TRADING_KIS_IDS)
 def test_non_trading_agents_kis_tool_is_readonly(config_path: Path, agent_fn: str):
-    """#66: news/recommend/strategy의 kis-trading-mcp-tool은 finus_account_balance_readonly여야 한다.
+    """#66: news/recommend/strategy/diary의 kis-trading-mcp-tool은 finus_account_balance_readonly여야 한다.
 
     trading_agent.yml이 정의한 finus_account_balance(전체 권한)가 상속 체인을 통해
-    비-trading 에이전트에 그대로 전파되는 회귀를 방지한다.
+    비-trading 에이전트(news→recommend→strategy→diary)에 그대로 전파되는 회귀를 방지한다.
+    diary_agent는 tool_names에 포함하지 않지만 scope에 정의된 함수 타입을 고정한다.
     """
     import nat_finus_nat.register  # noqa: F401
     from nat.runtime.loader import load_config

--- a/finus_nat/tests/test_agent_configs.py
+++ b/finus_nat/tests/test_agent_configs.py
@@ -192,10 +192,16 @@ _NON_TRADING_KIS_CONFIGS = [
     (AGENTS_DIR / "diary_agent.yml", "diary_agent"),
 ]
 
-# kis-trading-mcp-tool이 전체 권한(finus_account_balance)을 유지해야 하는 에이전트
+# kis-trading-mcp-tool이 전체 권한(finus_account_balance)을 유지해야 하는 에이전트.
+# 단독 로드뿐 아니라 프로덕션 라우터 설정도 포함한다 — base 체인 deep-merge 결과에서
+# news_agent.yml의 오버라이드가 trading/monitoring 권한을 빼앗는 회귀를 잡기 위해서다.
 _TRADING_KIS_CONFIGS = [
     (AGENTS_DIR / "trading_agent.yml", "trading_agent_react"),
     (AGENTS_DIR / "monitoring_agent.yml", "monitoring_agent"),
+    (CONFIGS_ROOT / "router.yml", "trading_agent_react"),
+    (CONFIGS_ROOT / "router_nomemory.yml", "trading_agent_react"),
+    (CONFIGS_ROOT / "router.yml", "monitoring_agent"),
+    (CONFIGS_ROOT / "router_nomemory.yml", "monitoring_agent"),
 ]
 
 _NON_TRADING_KIS_IDS = [f"{p.name}::{a}" for p, a in _NON_TRADING_KIS_CONFIGS]

--- a/finus_nat/tests/test_agent_configs.py
+++ b/finus_nat/tests/test_agent_configs.py
@@ -284,9 +284,9 @@ def test_agent_references_expected_kis_tool(config_path: Path, agent_fn: str, ex
 
     config = load_config(config_path)
     tool_names = [str(t) for t in config.functions[agent_fn].tool_names]
-    assert expected_tool in tool_names, (
-        f"{config_path.name}::{agent_fn}: tool_names에 {expected_tool!r}가 없습니다. "
-        f"실제 tool_names: {tool_names}"
+    kis_tools = [t for t in tool_names if t.startswith("kis-trading-mcp-tool")]
+    assert kis_tools == [expected_tool], (
+        f"{config_path.name}::{agent_fn}: KIS 도구 참조는 [{expected_tool!r}] 하나여야 합니다. 실제: {kis_tools}"
     )
 
 
@@ -330,6 +330,60 @@ def test_readonly_api_type_blocks_non_allowlisted(api_type: str):
     from nat_finus_nat.finus_api import _is_readonly_api_type
     assert _is_readonly_api_type(api_type) is False, (
         f"{api_type!r}는 조회 전용 허용 목록에서 차단되어야 합니다."
+    )
+
+
+# ---------------------------------------------------------------------------
+# #66 allowlist 단위 테스트 — _is_readonly_tool_name 판정 고정
+# fail-closed 검증: allowlist 판정을 무조건 True로 뒤집으면 이 테스트가 red.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("tool_name", [
+    "domestic_stock",
+    "overseas_stock",
+    "domestic_bond",
+    "domestic_futureoption",
+    "overseas_futureoption",
+    "elw",
+    "etfetn",
+], ids=lambda x: x)
+def test_readonly_tool_name_allows_asset_classes(tool_name: str):
+    """#66: 허용 자산군 7종은 _is_readonly_tool_name이 True를 반환해야 한다."""
+    from nat_finus_nat.finus_api import _is_readonly_tool_name
+    assert _is_readonly_tool_name(tool_name) is True, (
+        f"{tool_name!r}는 조회 전용 tool_name 허용 목록에 포함되어야 합니다."
+    )
+
+
+@pytest.mark.parametrize("tool_name", [
+    "auth",     # 인증 상태 변경 가능 — 핵심 차단 케이스
+    "foo_bar",  # 알 수 없는 tool_name — fail-closed 핵심 케이스
+    "",         # 빈 문자열
+], ids=lambda x: x or "<empty>")
+def test_readonly_tool_name_blocks_non_allowlisted(tool_name: str):
+    """#66: 허용 목록 밖의 tool_name은 _is_readonly_tool_name이 False를 반환해야 한다.
+
+    ``auth`` 케이스가 핵심: 인증 상태를 바꿀 수 있어 조회 전용 래퍼에서 제외한다.
+    allowlist 판정을 무조건 True로 교체하면 이 테스트들이 red가 된다.
+    """
+    from nat_finus_nat.finus_api import _is_readonly_tool_name
+    assert _is_readonly_tool_name(tool_name) is False, (
+        f"{tool_name!r}는 조회 전용 허용 목록에서 차단되어야 합니다."
+    )
+
+
+@pytest.mark.parametrize("tool_name,expected", [
+    ("DOMESTIC_STOCK", True),    # 대문자 → 허용 (대소문자 무시)
+    ("Overseas_Stock", True),    # 혼합 대소문자 → 허용
+    ("  etfetn  ", True),        # 앞뒤 공백 → 허용 (strip 처리)
+    ("AUTH", False),             # 대문자 auth → 차단
+    ("DOMESTIC_BOND ", True),    # 뒤 공백 있어도 strip 후 허용
+], ids=lambda x: repr(x) if isinstance(x, str) else str(x))
+def test_readonly_tool_name_case_and_whitespace(tool_name: str, expected: bool):
+    """#66: _is_readonly_tool_name은 대소문자·앞뒤 공백을 정규화해 판정해야 한다."""
+    from nat_finus_nat.finus_api import _is_readonly_tool_name
+    assert _is_readonly_tool_name(tool_name) is expected, (
+        f"{tool_name!r}: expected={expected}"
     )
 
 

--- a/finus_nat/tests/test_agent_configs.py
+++ b/finus_nat/tests/test_agent_configs.py
@@ -181,11 +181,15 @@ _IDENTICAL_SYSTEM_PROMPT_AGENTS = [
 # #66 회귀 가드 — 비-trading 에이전트의 kis-trading-mcp-tool이 조회 전용인지 확인
 # ---------------------------------------------------------------------------
 
-# (config_path, agent 함수 이름) — kis-trading-mcp-tool을 보유하지만 주문 실행 차단 대상 에이전트
+# (config_path, agent 함수 이름) — kis-trading-mcp-tool이 scope에 있고 주문 실행 차단 대상.
+# news_agent.yml의 override가 상속 체인(recommend → strategy → diary)에 전파됨.
+# diary_agent는 tool_names에 kis-trading-mcp-tool을 포함하지 않지만, 함수가 scope에
+# 정의되어 있으므로 readonly 상태를 고정한다.
 _NON_TRADING_KIS_CONFIGS = [
     (AGENTS_DIR / "news_agent.yml", "news_agent"),
     (AGENTS_DIR / "recommend_agent.yml", "recommend_agent"),
     (AGENTS_DIR / "strategy_agent.yml", "strategy_agent"),
+    (AGENTS_DIR / "diary_agent.yml", "diary_agent"),
 ]
 
 # kis-trading-mcp-tool이 전체 권한(finus_account_balance)을 유지해야 하는 에이전트
@@ -235,6 +239,49 @@ def test_trading_agents_kis_tool_is_full(config_path: Path, agent_fn: str):
     assert isinstance(tool_config, FinusAccountBalanceConfig), (
         f"{config_path.name}: kis-trading-mcp-tool은 finus_account_balance여야 합니다. "
         f"실제 타입: {type(tool_config).__name__}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# #66 allowlist 단위 테스트 — _is_readonly_api_type 판정 고정
+# fail-closed 검증: allowlist 판정을 무조건 True로 뒤집으면 이 테스트가 red.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("api_type", [
+    "inquire_balance",
+    "inquire_price",
+    "inquire_account_balance",
+    "inquire_daily_itemchartprice",
+    "inquire_investor",
+    "search_stock_info",
+    "find_api_detail",
+], ids=lambda x: x)
+def test_readonly_api_type_allows_read_only(api_type: str):
+    """#66: 조회 계열 api_type은 _is_readonly_api_type이 True를 반환해야 한다."""
+    from nat_finus_nat.finus_api import _is_readonly_api_type
+    assert _is_readonly_api_type(api_type) is True, (
+        f"{api_type!r}는 조회 전용 허용 목록에 포함되어야 합니다."
+    )
+
+
+@pytest.mark.parametrize("api_type", [
+    "order_cash",
+    "order_sell",
+    "modify_order",
+    "cancel_order",
+    "overseas_stock_order",   # order_ 접두사 없는 가상의 주문 TR — fail-closed 핵심 케이스
+    "unknown_operation",      # 목록에 없는 임의 api_type — fail-closed 핵심 케이스
+    "",                       # 빈 문자열
+], ids=lambda x: x or "<empty>")
+def test_readonly_api_type_blocks_non_allowlisted(api_type: str):
+    """#66: 허용 목록에 없는 api_type은 _is_readonly_api_type이 False를 반환해야 한다.
+
+    ``unknown_operation``, ``overseas_stock_order`` 케이스가 fail-closed 핵심이다.
+    allowlist 판정을 무조건 True로 교체하면 이 테스트들이 red가 된다.
+    """
+    from nat_finus_nat.finus_api import _is_readonly_api_type
+    assert _is_readonly_api_type(api_type) is False, (
+        f"{api_type!r}는 조회 전용 허용 목록에서 차단되어야 합니다."
     )
 
 


### PR DESCRIPTION
## 배경

#66. `news_agent`·`recommend_agent`·`strategy_agent`에 `kis-trading-mcp-tool`이 **주문 실행 금지 명시 없이** 등록돼 있었습니다. 현재는 `KIS_REAL_ORDER_ENABLED=false` + 모의 계좌라 즉각적 위험은 낮지만, 이슈가 "실계좌 전환 또는 프로덕션 배포 전에 반드시 처리"라고 적은 항목입니다.

## 변경

조회 전용 래퍼 `finus_account_balance_readonly`를 만들고, `news_agent.yml`에서 `kis-trading-mcp-tool`을 그 타입으로 오버라이드했습니다.

**도구 목록 자체는 한 줄도 바꾸지 않았습니다** — `tool_names` diff가 0줄입니다. 각 에이전트가 보는 도구 이름은 그대로고 **구현만 교체**되므로, 프롬프트·ReAct 흐름이 영향을 받지 않습니다.

### 상속 체인

```
trading_agent → monitoring_agent → news_agent → recommend_agent → strategy_agent → diary_agent
                                   └── 여기 오버라이드 하나로 이하 전부 전파
```

| 에이전트 | `kis-trading-mcp-tool` 구현 | 조회 | 주문 실행 |
| --- | --- | --- | --- |
| `trading_agent` | `finus_account_balance` (전체) | ✅ | ✅ 유지 |
| `monitoring_agent` | `finus_account_balance` (전체) | ✅ | ✅ 유지 |
| `news_agent` | **`_readonly`** | ✅ | ❌ 차단 |
| `recommend_agent` | **`_readonly`** (상속) | ✅ | ❌ 차단 |
| `strategy_agent` | **`_readonly`** (상속) | ✅ | ❌ 차단 |
| `diary_agent` | **`_readonly`** (상속) | ✅ | ❌ 차단 |

`diary_agent`는 이슈 본문 범위 밖이지만 `strategy_agent`를 상속하므로 함께 영향을 받습니다. 매매일지 작성 에이전트가 주문 실행 권한을 가질 이유가 없어 그대로 두고, **테스트로 상태를 고정**했습니다.

## 허용 목록(allowlist) — fail-closed

초안은 거부 목록(`startswith("order")`)이었으나 **fail-open이라 뒤집었습니다.** 실제 api_type 이름은 이 레포가 아니라 **원격 KIS MCP 서버**가 정합니다 — 저장소 전체를 grep해도 등장하는 api_type은 `inquire_balance`·`inquire_price`·`find_api_detail`뿐이고, 주문 계열은 `order_cash` 하나가 문서에만 있습니다. 에이전트는 `find_api_detail`로 런타임에 발견합니다. 즉 모르는 이름은 거부 목록을 그대로 통과합니다.

허용: `inquire_*`, `search_*`, `find_api_detail`. 그 외 전부 차단.

**실측 14종 — 불일치 0건:**

| api_type | 거부 목록(초안) | 허용 목록(현재) |
| --- | --- | --- |
| `overseas_stock_order` | **통과** ❌ | 차단 ✅ |
| `domestic_order` | **통과** ❌ | 차단 ✅ |
| `foo_bar_unknown` | **통과** ❌ | 차단 ✅ |
| `order_cash` / `order_sell` / `modify_order` / `cancel_order` | 차단 | 차단 ✅ |
| `  ORDER_CASH  ` (대소문자·공백) | 차단 | 차단 ✅ |
| `inquire_balance` / `inquire_price` / `inquire_daily_itemchartprice` | 통과 | 통과 ✅ |
| `search_stock_info` / `find_api_detail` | 통과 | 통과 ✅ |

**기능 손실이 없는지 확인했습니다** — 비-trading 4개 에이전트의 프롬프트에 등장하는 api_type을 전수 조사한 결과 `inquire_balance` 하나뿐이라 전부 허용됩니다.

**트레이드오프**: `find_api_detail`로 새 조회 TR을 발견해도 그 api_type이 `inquire_`/`search_` 패턴을 벗어나면 차단됩니다. 안전 장치이므로 fail-closed를 택했고, 차단 시 오류 메시지에 **차단된 값과 허용 목록, 운영자가 추가할 위치**를 함께 남겨 대응할 수 있게 했습니다.

## PR #205 게이트와의 정합성

래퍼는 `_record_to_ledger("finus_account_balance", ...)`로 전체 권한 도구와 **같은 이름**을 씁니다. 도구 이름이 바뀌면 #205/#209의 원장 판정(`_SIDE_EFFECT_TOOLS`, `_EMPTY_RESULT_LITERALS`)이 깨지므로 의도된 선택입니다.

차단 응답이 게이트를 끄지 않는지 실측했습니다:

```
차단 응답: {"error": "kis_api_type_not_allowed_readonly", "api_type": ...
원장 기록: ok=False  produced_rows=False  any_success=False
```

`_ERROR_JSON_PREFIX_RE`가 잡아 `ok=False`가 됩니다 — 주문 시도가 차단됐다고 해서 "데이터를 받았다"로 기록되지 않습니다.

## `nat start mcp` 우회 경로 (#152 지적)

**이 PR은 그 경로를 막지 못합니다.** `nat start mcp`가 `tool_names`가 비면 등록된 **모든** 함수를 노출하는데, 함수 이름 분리 이후 전체 권한 `finus_account_balance`와 조회 전용 래퍼가 **둘 다** 등록되므로 래퍼를 추가해도 무관합니다. (리뷰 정정: 이름 분리 이전에는 병합된 `router*.yml`에 `finus_account_balance` 인스턴스가 아예 없었습니다.)

다만 `finus_nat/configs/`에 `front_end`·`endpoints` 블록이 **0건**이라 그 실행 경로는 현재 존재하지 않습니다(직접 확인). #152가 적은 대로 잠재적 위험으로 남습니다.

## 검증 (직접 실행)

`pytest tests/` (프로젝트 venv) — **120 → 140 passed, 1 skipped** (실패 0건, +20건).

양방향 가드 테스트를 넣었습니다: 비-trading 4개는 `_readonly`여야 하고, trading/monitoring 2개는 전체 권한이어야 합니다(래퍼가 실수로 trading에 적용되는 회귀도 방지).

뮤테이션:

| 뮤턴트 | 결과 |
| --- | --- |
| allowlist 판정을 무조건 통과로 (fail-open 회귀) | **7 failed** ✅ |
| `news_agent` 오버라이드 제거 (주문 도구 재노출) | **4 failed** ✅ |

두 번째 뮤턴트가 **오버라이드 하나 제거에 4건 red**가 되는 것으로 상속 전파가 실증됩니다.

## 확인하지 못한 것

원격 KIS MCP 서버의 실제 api_type 전체 목록은 이 환경에서 열거할 수 없습니다. 허용 목록은 KIS TR 명명 규칙(`inquire_`/`search_`)과 레포 내 사용처를 근거로 정했고, 벗어나는 조회 TR이 있으면 차단됩니다 — fail-closed라 안전한 방향이지만 운영 중 발견되면 목록 확장이 필요합니다.

Closes #66

