### PR TITLE
fix: 중첩 JSON 응답에서 원본 JSON이 요약으로 노출되던 문제 (#218)

### DIFF
--- a/backend/services.py
+++ b/backend/services.py
@@ -283,7 +283,17 @@ def _analysis_from_toolless_text(raw: str) -> dict[str, Any]:
     미사용) — Improvement #2 (#162 리뷰).
     """
     text = (raw or "").strip()
-    for data in _json_objects_from_text(text):
+    # #218: summary 키를 가진 후보를 우선 시도한다.
+    # _json_objects_from_text는 텍스트 내 마지막 JSON을 먼저 반환하도록
+    # reversed 순서를 쓰는데, 중첩 JSON이 있으면 안쪽 객체가 바깥 객체보다
+    # 나중 위치에서 발견되어 reversed 후 선두에 온다. 안쪽 객체엔 summary 키가
+    # 없으므로 data.get("summary") or text[:8000]이 원본 JSON 전체를 요약으로
+    # 채워버린다. 안정 정렬로 summary 키 보유 여부를 먼저 분리하면, 바깥 객체를
+    # 먼저 시도하면서도 summary를 모두 가진 후보들 사이에서는 기존 reversed 순서
+    # (텍스트 내 마지막 우선)가 유지된다.
+    _candidates = _json_objects_from_text(text)
+    _candidates.sort(key=lambda d: "summary" not in d)
+    for data in _candidates:
         # ValidationError를 유발하는 AnalysisReport() 생성만 try 안에 둔다.
         # 정규화는 TypeError를 낼 수 있어 except ValidationError에 잡히지 않으므로
         # try 밖에서 먼저 처리한다 (Nitpick #2).

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -1139,11 +1139,9 @@ def test_analysis_from_toolless_text_urgency_non_string_does_not_raise(urgency_v
 def test_analysis_from_toolless_text_urgency_dict_does_not_raise():
     """urgency가 dict여도 TypeError 없이 정상 반환된다.
 
-    dict urgency는 _json_objects_from_text의 reversed 순서 때문에
-    내부 객체가 먼저 후보로 선택되어 summary가 원본 JSON이 되는 선행 문제
-    (Improvement #3)가 있다. 이는 이 PR 이전부터 존재하는 문제이므로
-    이 테스트는 summary 내용이 아닌 '예외 없이 반환된다'만 고정한다.
-    urgency 결과는 내부 객체에 urgency 키가 없어 'normal'이 된다.
+    #218 수정 후: summary 키를 가진 바깥 객체가 우선 선택된다.
+    urgency는 {"level":"high"} dict를 받고, isinstance(..., str) 검사를
+    통과하지 못해 "normal"로 정규화된다. summary·source_news는 보존된다.
     """
     import json
 
@@ -1212,3 +1210,41 @@ def test_analysis_from_toolless_text_absent_urgency_preserves_reason_and_alert(r
     assert result["telegram_alert"] is True, (
         "urgency 키 부재·null은 하향이 아니므로 telegram_alert을 보존해야 한다"
     )
+
+
+# ── #218: 중첩 JSON 객체 — summary 키 우선 선택 ───────────────────────────────
+
+
+def test_analysis_from_toolless_text_nested_json_uses_outer_summary():
+    """중첩 JSON 객체가 있어도 summary 키를 가진 바깥 객체에서 올바른 요약을 뽑는다. (#218)
+
+    _json_objects_from_text는 reversed 순서로 후보를 반환하므로, 안쪽 {"pe":12}가
+    바깥 객체보다 먼저 온다. 안쪽 객체엔 summary 키가 없어
+    data.get("summary") or text[:8000]이 원본 JSON 전체를 summary로 채우고,
+    source_news는 []가 된다. summary 키 우선 정렬로 바깥 객체를 먼저 시도해 이를 막는다.
+
+    이 테스트가 잡는 mutation: 후보 정렬 로직(_candidates.sort(...)) 제거.
+    정렬을 지우면 안쪽 {"pe":12}가 먼저 시도돼 summary가 원본 JSON 전체로,
+    source_news가 []로 나와 두 단정 모두 실패한다.
+    """
+    raw = '{"summary":"삼성전자 요약","source_news":["뉴스1"],"detail":{"pe":12}}'
+    result = services._analysis_from_toolless_text(raw)
+    assert result["summary"] == "삼성전자 요약", (
+        "중첩 JSON이 있을 때 원본 JSON 전체가 summary로 노출되어서는 안 된다"
+    )
+    assert result["source_news"] == ["뉴스1"]
+
+
+def test_analysis_from_toolless_text_no_summary_json_still_falls_back():
+    """관련 없는 JSON(summary 키 없음)만 있으면 여전히 원문 폴백을 사용한다.
+
+    summary 키 우선 정렬이 except ValidationError: continue 의도를 깨지 않는지 확인한다.
+    {"count":3} 같은 객체는 summary 후보에 없고 ValidationError로 건너뛰어
+    결국 폴백 경로로 간다.
+    """
+    raw = '{"count":3,"items":["a","b","c"]}'
+    result = services._analysis_from_toolless_text(raw)
+    # 폴백: 원문 전체가 summary
+    assert result["summary"] == raw
+    assert result["source_news"] == []
+    assert result["details"] is None

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -1151,6 +1151,9 @@ def test_analysis_from_toolless_text_urgency_dict_does_not_raise():
     result = services._analysis_from_toolless_text(raw)
     assert isinstance(result, dict), "dict urgency여도 예외 없이 dict를 반환해야 한다"
     assert result["urgency"] == "normal"
+    # #218: 중첩된 urgency dict가 후보로 선택되어 summary를 오염시키면 안 된다
+    assert result["summary"] == "삼성전자 요약"
+    assert result["source_news"] == ["뉴스1"]
 
 
 # ── #211 리뷰 반영: urgency 하향 시 urgency_reason·telegram_alert 모순 방지 ──
@@ -1236,15 +1239,33 @@ def test_analysis_from_toolless_text_nested_json_uses_outer_summary():
 
 
 def test_analysis_from_toolless_text_no_summary_json_still_falls_back():
-    """관련 없는 JSON(summary 키 없음)만 있으면 여전히 원문 폴백을 사용한다.
+    """관련 없는 JSON(summary 키 없음)만 있으면 원문 전체가 summary로 사용된다.
 
-    summary 키 우선 정렬이 except ValidationError: continue 의도를 깨지 않는지 확인한다.
-    {"count":3} 같은 객체는 summary 후보에 없고 ValidationError로 건너뛰어
-    결국 폴백 경로로 간다.
+    {"count":3} 같은 객체는 summary 키가 없으므로 루프 안에서
+    `data.get("summary") or text[:8000]` 폴백이 동작해 원본 텍스트를 summary로 채운다.
+    ValidationError는 발생하지 않는다 — AnalysisReport 생성 인수가 모두 강제 변환되기 때문이다.
     """
     raw = '{"count":3,"items":["a","b","c"]}'
     result = services._analysis_from_toolless_text(raw)
-    # 폴백: 원문 전체가 summary
+    # 루프 내 폴백: data.get("summary") or text[:8000] → 원문 전체가 summary
     assert result["summary"] == raw
     assert result["source_news"] == []
     assert result["details"] is None
+
+
+def test_analysis_from_toolless_text_invalid_candidate_is_skipped():
+    """스키마 검증에 실패하는 후보는 건너뛰고 유효한 후보를 쓴다.
+
+    summary 우선 정렬이 `except ValidationError: continue` 의도를 깨지 않는지 확인한다.
+    trading_trend는 `str | None`이라 정수를 넣으면 ValidationError가 난다.
+
+    이 테스트가 잡는 mutation: `except ValidationError: continue` 제거.
+    건너뛰기가 없으면 정수 trading_trend로 ValidationError가 전파되어 실패한다.
+    """
+    raw = (
+        '{"summary":"유효 요약","source_news":["뉴스1"],"trading_trend":"상승"} '
+        '{"summary":"깨진 후보","trading_trend":12}'
+    )
+    result = services._analysis_from_toolless_text(raw)
+    assert result["summary"] == "유효 요약"
+    assert result["trading_trend"] == "상승"


### PR DESCRIPTION
## 배경

#218 (PR #215 리뷰의 Improvement 3 후속). 리뷰어가 "이 PR이 만든 문제는 아님"이라고 했고, `origin/main`에서도 동일하게 재현되는 기존 문제라 분리했던 건입니다.

## 원인

`_json_objects_from_text`는 **텍스트 내 마지막 JSON을 먼저 반환하도록 `reversed` 순서**를 씁니다. 그런데 중첩 JSON이 있으면 안쪽 객체가 바깥 객체보다 **나중 위치**에서 발견되므로, 역순 뒤에는 안쪽이 선두에 옵니다. 안쪽 객체엔 `summary` 키가 없어 `data.get("summary") or text[:8000]`이 **원본 JSON 전체를 요약으로 채웁니다.**

## 변경

후보 목록을 `summary` 키 보유 여부로 **안정 정렬**합니다.

```python
_candidates = _json_objects_from_text(text)
_candidates.sort(key=lambda d: "summary" not in d)
```

안정 정렬이라 `summary`를 가진 후보들 사이에서는 **기존 `reversed` 순서(텍스트 내 마지막 우선)가 그대로 유지**됩니다. 바깥 객체를 먼저 시도하게 만들되 기존 동작을 바꾸지 않는 최소 변경입니다.

## 실측 (직접 실행)

| 입력 | 수정 전 summary | 수정 후 summary | source_news |
| --- | --- | --- | --- |
| 중첩 객체 있음 | **원본 JSON 전체** | `삼성전자 요약` ✅ | `["뉴스1"]` ✅ |
| 중첩 없음 | `삼성전자 요약` | `삼성전자 요약` | `["뉴스1"]` |
| 순수 텍스트 | 원문 폴백 | 원문 폴백 ✅ | `[]` |
| 관련 없는 JSON만 (`{"foo":1}`) | 원문 폴백 | 원문 폴백 ✅ | `[]` |
| `summary` 없는 바깥+안쪽 | 원문 폴백 | 원문 폴백 ✅ | `[]` |
| 중첩 + `urgency:null` | — | `요약` / `urgency=normal` ✅ | `["n"]` |

관련 없는 JSON 객체를 건너뛰는 기존 의도(`except ValidationError: continue`)와 순수 텍스트 폴백이 모두 유지됩니다.

`_json_objects_from_text`가 `list`를 반환하는 것을 확인하고 `.sort()`를 썼습니다.

## 검증

`pytest backend/` — **321 → 323 passed, 2 skipped** (실패 0건).

뮤테이션 — 신규 1건과 **PR #215 회귀 2건**을 함께 확인했습니다:

| 뮤턴트 | 결과 |
| --- | --- |
| 후보 정렬 제거 (#218 회귀) | **1 failed** ✅ |
| `urgency` 정규화 제거 (PR #215 회귀) | **2 failed** ✅ |
| 폴백 `source_signals=[]` 제거 (PR #215 회귀) | **1 failed** ✅ |

Closes #218