### PR TITLE
test: 잔고 리포트 형식 계약을 JS·Python 공유 픽스처로 고정 (#137)

### DIFF
--- a/backend/tests/test_balance_parser.py
+++ b/backend/tests/test_balance_parser.py
@@ -20,9 +20,14 @@ _FIXTURE_PATH = (
 _FIXTURE = json.loads(_FIXTURE_PATH.read_text(encoding="utf-8"))
 
 # REAL_BALANCE_TEXT는 이제 공유 픽스처에서 로드합니다(이슈 #137).
-# 이전에는 손으로 복사한 리터럴이었으나, 이제 balance.js balance.test.js 픽스처 테스트가
-# 깨지면 이 값도 함께 변경되므로, 아래 TestBalanceExtraction 테스트들도 드리프트를
-# 일으키지 않고 자동으로 새 형식을 검증합니다.
+# 이전에는 손으로 복사한 리터럴이었으나, 이제 balance.js의 변경이 balance.test.js 픽스처
+# 테스트를 깨뜨리므로, 아래 TestBalanceExtraction 테스트들도 드리프트를 일으키지 않고
+# 자동으로 새 형식을 검증합니다.
+#
+# 이 심볼은 test_scheduler.py::test_parse_balance_holdings_with_real_fixture 가
+# 크로스모듈 import 해 사용합니다. 수량·평단가 커버리지는
+# TestSharedFixture::test_fixture_normal_round_trips_qty_and_avg_price 에서도
+# 독립적으로 제공되므로, 이 export 를 제거할 때는 해당 테스트를 함께 확인하세요.
 REAL_BALANCE_TEXT = _FIXTURE["normal"]["expected_text"]
 
 
@@ -336,6 +341,28 @@ class TestSharedFixture(unittest.TestCase):
         """픽스처 normal.expected_text 에는 잘림 안내 문구가 없어야 합니다."""
         text = _FIXTURE["normal"]["expected_text"]
         self.assertFalse(is_balance_truncated(text))
+
+    def test_fixture_normal_round_trips_qty_and_avg_price(self):
+        """expected_text 를 파싱한 결과가 픽스처 input 의 원본 KIS 값과 일치해야 합니다.
+        기대값을 input 에서 파생시켜, 형식이 바뀌면 이 테스트가 직접 red 가 되게 합니다.
+
+        이 테스트는 test_scheduler.py::test_parse_balance_holdings_with_real_fixture 의
+        수량·평단가 커버리지를 TestSharedFixture 안에서 독립적으로 제공합니다.
+        크로스모듈 import 가 제거되거나 test_parse_balance_holdings_with_real_fixture 가
+        삭제되더라도, 이 테스트가 avg_price=0.0 회귀를 잡습니다.
+        """
+        from backend.scheduler import _parse_balance_holdings
+
+        case = _FIXTURE["normal"]
+        holdings = _parse_balance_holdings(case["expected_text"])
+        expected = case["input"]["output1"]
+
+        self.assertEqual(len(holdings), len(expected))
+        for parsed, raw in zip(holdings, expected):
+            self.assertEqual(parsed.code, raw["pdno"])
+            self.assertEqual(parsed.name, raw["prdt_name"])
+            self.assertEqual(parsed.quantity, int(raw["hldg_qty"]))
+            self.assertAlmostEqual(parsed.avg_price, float(raw["pchs_avg_pric"]), places=2)
 
     def test_fixture_truncated_extracts_stocks_without_notice_line(self):
         """픽스처 truncated.expected_text 에서 [안내] 잘림 문구는 종목으로 추출되지 않고,

--- a/backend/tests/test_balance_parser.py
+++ b/backend/tests/test_balance_parser.py
@@ -4,36 +4,26 @@
 mcp-trading/data/stocks.json`으로 직접 확인할 수 있다.
 """
 
+import json
+import pathlib
 import unittest
 from backend.scheduler import extract_stocks_from_balance, is_balance_truncated
 
-# 아래 픽스처는 mcp-trading/balance.js의 formatBalanceReport()가 실제로 생성하는
-# 문자열을 그대로 재현한 것입니다. 근거(줄 번호 대신 심볼/테스트명으로 고정 — 이 저장소
-# 안의 mcp-trading/ 디렉터리를 대상으로 git grep 으로 바로 확인 가능합니다):
-#   - 생성부: mcp-trading/balance.js 의 formatBalanceReport() — 종목 줄 템플릿과
-#     종목 사이 구분자 .join("\n\n")
-#   - 검증부: mcp-trading/tests/order.test.js 의
-#     "formatBalanceReport displays unsettled cash fields and account return rate" 테스트
-# REAL_BALANCE_TEXT는 그 테스트의 기대값 리터럴을 그대로 복사한 것이므로, balance.js의
-# 종목 줄 템플릿을 바꾸면 이 픽스처와 그 테스트의 기대값 양쪽을 함께 수정해야 합니다.
-# 종목 한 건은 3줄 블록(헤더 줄 + 공백 2칸 들여쓰기 2줄)이며, 종목 사이에는 빈 줄이 하나 있습니다.
-REAL_BALANCE_TEXT = """[계좌 잔고 현황]
-- 총 평가금액: 1,210,000원
-- 순자산금액: 1,210,000원
-- 총 손익: 9,000원 (수익률: 🔴 ▲ +2.23%)
-- 거래가능금액: 1,000,000원
-- 정산중 금액(가수도): 1,009,000원
-- 익일 정산예정금액: 790,000원
-- 금일 매수/매도: 210,000원 / 0원
+# 이슈 #137: mcp-trading·backend 공유 픽스처.
+# formatBalanceReport() 출력 계약을 한 파일로 고정해, JS 쪽만 갱신하고 Python 픽스처가
+# 낡은 채로 남는 드리프트를 방지합니다. 경로는 __file__ 기준 절대 경로라 worktree·CI
+# 양쪽에서 동일하게 해석됩니다.
+_FIXTURE_PATH = (
+    pathlib.Path(__file__).parent.parent.parent
+    / "mcp-trading" / "tests" / "fixtures" / "balance_report.json"
+)
+_FIXTURE = json.loads(_FIXTURE_PATH.read_text(encoding="utf-8"))
 
-[보유 종목 리스트]
-- 삼성전자 (005930) · 3주
-  평단가 67,000원 → 평가금액 210,000원
-  손익 +9,000원 · 수익률 🔴 ▲ +4.48%
-
-- NAVER (035420) · 1주
-  평단가 201,000원 → 평가금액 200,500원
-  손익 -500원 · 수익률 🔵 ▼ -0.25%"""
+# REAL_BALANCE_TEXT는 이제 공유 픽스처에서 로드합니다(이슈 #137).
+# 이전에는 손으로 복사한 리터럴이었으나, 이제 balance.js balance.test.js 픽스처 테스트가
+# 깨지면 이 값도 함께 변경되므로, 아래 TestBalanceExtraction 테스트들도 드리프트를
+# 일으키지 않고 자동으로 새 형식을 검증합니다.
+REAL_BALANCE_TEXT = _FIXTURE["normal"]["expected_text"]
 
 
 class TestBalanceExtraction(unittest.TestCase):
@@ -323,6 +313,44 @@ class TestBalanceTruncationDetection(unittest.TestCase):
         self.assertTrue(is_balance_truncated(balance_text))
         stocks = extract_stocks_from_balance(balance_text)
         self.assertEqual(stocks, ["삼성전자"])
+
+
+class TestSharedFixture(unittest.TestCase):
+    """이슈 #137: mcp-trading/tests/fixtures/balance_report.json 공유 픽스처를 사용해
+    formatBalanceReport() 출력과 파서 입력이 한 파일로 고정되는지 검증합니다.
+
+    픽스처의 expected_text 는 JS 테스트(balance.test.js)가 formatBalanceReport(input)
+    와 비교하는 것과 동일한 문자열입니다. 형식이 바뀌면 JS 픽스처 테스트가 먼저 깨지고,
+    픽스처를 수정하면 이 테스트들도 새 형식을 자동으로 검증하게 됩니다.
+    """
+
+    def test_fixture_normal_extracts_correct_stocks(self):
+        """픽스처 normal.expected_text 를 파서에 직접 넣어 종목이 올바르게 추출되는지 확인합니다.
+        이 텍스트는 JS formatBalanceReport() 가 실제 생성하는 문자열과 동일합니다.
+        """
+        text = _FIXTURE["normal"]["expected_text"]
+        result = extract_stocks_from_balance(text)
+        self.assertEqual(result, ["삼성전자", "NAVER"])
+
+    def test_fixture_normal_is_not_truncated(self):
+        """픽스처 normal.expected_text 에는 잘림 안내 문구가 없어야 합니다."""
+        text = _FIXTURE["normal"]["expected_text"]
+        self.assertFalse(is_balance_truncated(text))
+
+    def test_fixture_truncated_extracts_stocks_without_notice_line(self):
+        """픽스처 truncated.expected_text 에서 [안내] 잘림 문구는 종목으로 추출되지 않고,
+        실제 보유 종목(삼성전자)만 추출되어야 합니다. JS 테스트가 잘림 문구를 [보유 종목
+        리스트] 바깥에 배치하는 계약을 고정하며, 이 테스트는 Python 파서가 그 계약을
+        올바르게 소비하는지 공유 픽스처로 고정합니다.
+        """
+        text = _FIXTURE["truncated"]["expected_text"]
+        result = extract_stocks_from_balance(text)
+        self.assertEqual(result, ["삼성전자"])
+
+    def test_fixture_truncated_is_detected_as_truncated(self):
+        """픽스처 truncated.expected_text 는 is_balance_truncated() 에서 True 여야 합니다."""
+        text = _FIXTURE["truncated"]["expected_text"]
+        self.assertTrue(is_balance_truncated(text))
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -1415,6 +1415,10 @@ def test_parse_balance_holdings_extracts_name_code_qty_avg():
 def test_parse_balance_holdings_with_real_fixture():
     """REAL_BALANCE_TEXT(balance.js 실제 출력 픽스처)에서 올바르게 파싱됩니다."""
     from ..scheduler import _parse_balance_holdings
+    # 크로스모듈 import 이유: test_balance_parser 가 공유 픽스처를 로드하는 유일한
+    # 진입점임을 명시해, 양쪽 모듈이 같은 expected_text 를 사용함을 보장합니다.
+    # 수량·평단가 커버리지는 test_balance_parser.TestSharedFixture.
+    # test_fixture_normal_round_trips_qty_and_avg_price 에서도 독립적으로 제공됩니다.
     from .test_balance_parser import REAL_BALANCE_TEXT
 
     holdings = _parse_balance_holdings(REAL_BALANCE_TEXT)

--- a/mcp-trading/tests/balance.test.js
+++ b/mcp-trading/tests/balance.test.js
@@ -1,7 +1,15 @@
 import assert from "node:assert/strict";
 import util from "node:util";
 import test from "node:test";
+import { readFileSync } from "node:fs";
 import { buildBalanceParams, fetchAllBalance, formatBalanceReport, formatPercent } from "../balance.js";
+
+// 이슈 #137: mcp-trading·backend 공유 픽스처. 이 파일을 로드해 JS와 Python 테스트가
+// 같은 expected_text를 사용하게 함으로써, formatBalanceReport() 형식 변경 시 한쪽만
+// 갱신하는 드리프트를 방지합니다. 아래 픽스처 테스트가 깨지면 fixtures/ 파일도 함께 수정하세요.
+const _fixture = JSON.parse(
+  readFileSync(new URL("fixtures/balance_report.json", import.meta.url), "utf-8"),
+);
 
 test("buildBalanceParams includes required KIS inquire-balance fields", () => {
   assert.deepEqual(buildBalanceParams("1234567801"), {
@@ -684,4 +692,19 @@ test("formatBalanceReport highlights negative return rates", () => {
   평단가 66,666.67원 → 평가금액 190,000원
   손익 -10,000원 · 수익률 🔵 ▼ -5.00%`,
   );
+});
+
+// 이슈 #137: 공유 픽스처 기반 계약 테스트.
+// 이 두 테스트가 깨지면 mcp-trading/tests/fixtures/balance_report.json 도 함께 수정해야 합니다.
+// Python 테스트(test_balance_parser.py)는 같은 파일의 expected_text 를 파서에 넣어 검증하므로,
+// 픽스처 수정 시 Python 쪽에서 파서 계약이 유지되는지 확인하세요.
+
+test("formatBalanceReport output matches shared fixture — normal case (fixtures/balance_report.json)", () => {
+  const { input, expected_text } = _fixture.normal;
+  assert.equal(formatBalanceReport(input), expected_text);
+});
+
+test("formatBalanceReport output matches shared fixture — truncated/max_pages case (fixtures/balance_report.json)", () => {
+  const { input, format_meta, expected_text } = _fixture.truncated;
+  assert.equal(formatBalanceReport(input, format_meta), expected_text);
 });

--- a/mcp-trading/tests/balance.test.js
+++ b/mcp-trading/tests/balance.test.js
@@ -7,7 +7,7 @@ import { buildBalanceParams, fetchAllBalance, formatBalanceReport, formatPercent
 // 이슈 #137: mcp-trading·backend 공유 픽스처. 이 파일을 로드해 JS와 Python 테스트가
 // 같은 expected_text를 사용하게 함으로써, formatBalanceReport() 형식 변경 시 한쪽만
 // 갱신하는 드리프트를 방지합니다. 아래 픽스처 테스트가 깨지면 fixtures/ 파일도 함께 수정하세요.
-const _fixture = JSON.parse(
+const balanceFixture = JSON.parse(
   readFileSync(new URL("fixtures/balance_report.json", import.meta.url), "utf-8"),
 );
 
@@ -700,11 +700,11 @@ test("formatBalanceReport highlights negative return rates", () => {
 // 픽스처 수정 시 Python 쪽에서 파서 계약이 유지되는지 확인하세요.
 
 test("formatBalanceReport output matches shared fixture — normal case (fixtures/balance_report.json)", () => {
-  const { input, expected_text } = _fixture.normal;
+  const { input, expected_text } = balanceFixture.normal;
   assert.equal(formatBalanceReport(input), expected_text);
 });
 
 test("formatBalanceReport output matches shared fixture — truncated/max_pages case (fixtures/balance_report.json)", () => {
-  const { input, format_meta, expected_text } = _fixture.truncated;
+  const { input, format_meta, expected_text } = balanceFixture.truncated;
   assert.equal(formatBalanceReport(input, format_meta), expected_text);
 });

--- a/mcp-trading/tests/fixtures/balance_report.json
+++ b/mcp-trading/tests/fixtures/balance_report.json
@@ -1,0 +1,68 @@
+{
+  "_comment": "이슈 #137: mcp-trading/balance.js formatBalanceReport()의 출력 계약을 backend/scheduler.py 파서와 공유하는 픽스처입니다. JS 테스트(balance.test.js)는 formatBalanceReport(input) === expected_text 를 검증하고, Python 테스트(test_balance_parser.py)는 expected_text 를 파서에 직접 넣어 검증합니다. 형식이 바뀌면 이 파일도 함께 수정해야 하며, 수정하지 않으면 양쪽 스위트 중 하나가 반드시 실패합니다.",
+  "normal": {
+    "_comment": "formatBalanceReport(input) 의 기대 출력. balance.test.js 'formatBalanceReport displays unsettled cash fields and account return rate' 테스트와 동일한 입력·기대값. Python의 REAL_BALANCE_TEXT 도 이 값에서 로드합니다.",
+    "input": {
+      "output1": [
+        {
+          "prdt_name": "삼성전자",
+          "pdno": "005930",
+          "hldg_qty": "3",
+          "pchs_avg_pric": "67000",
+          "evlu_amt": "210000",
+          "evlu_pfls_amt": "9000",
+          "evlu_pfls_rt": "4.48"
+        },
+        {
+          "prdt_name": "NAVER",
+          "pdno": "035420",
+          "hldg_qty": "1",
+          "pchs_avg_pric": "201000",
+          "evlu_amt": "200500",
+          "evlu_pfls_amt": "-500",
+          "evlu_pfls_rt": "-0.25"
+        }
+      ],
+      "output2": [
+        {
+          "tot_evlu_amt": "1210000",
+          "nass_amt": "1210000",
+          "evlu_pfls_smtl_amt": "9000",
+          "asst_icdc_erng_rt": "0.75",
+          "dnca_tot_amt": "1000000",
+          "nxdy_excc_amt": "790000",
+          "prvs_rcdl_excc_amt": "1009000",
+          "thdt_buy_amt": "210000",
+          "thdt_sll_amt": "0"
+        }
+      ]
+    },
+    "expected_text": "[계좌 잔고 현황]\n- 총 평가금액: 1,210,000원\n- 순자산금액: 1,210,000원\n- 총 손익: 9,000원 (수익률: 🔴 ▲ +2.23%)\n- 거래가능금액: 1,000,000원\n- 정산중 금액(가수도): 1,009,000원\n- 익일 정산예정금액: 790,000원\n- 금일 매수/매도: 210,000원 / 0원\n\n[보유 종목 리스트]\n- 삼성전자 (005930) · 3주\n  평단가 67,000원 → 평가금액 210,000원\n  손익 +9,000원 · 수익률 🔴 ▲ +4.48%\n\n- NAVER (035420) · 1주\n  평단가 201,000원 → 평가금액 200,500원\n  손익 -500원 · 수익률 🔵 ▼ -0.25%"
+  },
+  "truncated": {
+    "_comment": "formatBalanceReport(input, format_meta) 의 기대 출력(잘림 안내 포함). Python 파서가 [안내] 줄을 종목으로 오인식하지 않는지, is_balance_truncated()가 True를 반환하는지 양쪽을 고정합니다.",
+    "input": {
+      "output1": [
+        {
+          "prdt_name": "삼성전자",
+          "pdno": "005930",
+          "hldg_qty": "3",
+          "pchs_avg_pric": "67000",
+          "evlu_amt": "210000",
+          "evlu_pfls_amt": "9000",
+          "evlu_pfls_rt": "4.48"
+        }
+      ],
+      "output2": [
+        {
+          "tot_evlu_amt": "210000"
+        }
+      ]
+    },
+    "format_meta": {
+      "pages": 20,
+      "truncated": "max_pages"
+    },
+    "expected_text": "[계좌 잔고 현황]\n- 총 평가금액: 210,000원\n- 순자산금액: -\n- 총 손익: - (수익률: -)\n- 거래가능금액: -\n- 정산중 금액(가수도): -\n- 익일 정산예정금액: -\n- 금일 매수/매도: - / -\n\n[보유 종목 리스트]\n- 삼성전자 (005930) · 3주\n  평단가 67,000원 → 평가금액 210,000원\n  손익 +9,000원 · 수익률 🔴 ▲ +4.48%\n\n[안내] 페이지 상한(20회)에 도달하여 조회가 중단되어 일부 보유 종목이 위 목록에서 누락되었을 수 있습니다. 실제 잔고는 별도로 확인하세요."
+  }
+}


### PR DESCRIPTION
## 배경

#137. `mcp-trading`이 생성하는 잔고 리포트 문자열과 `backend`가 파싱하는 계약이 **두 곳에 손으로 복제**돼 있었습니다.

`balance.js`의 표시 형식을 바꾸고 JS 테스트만 갱신하면 Python 픽스처는 낡은 채로 남고 **양쪽이 모두 통과**합니다. 그 상태로 배포되면 파서가 빈 리스트를 반환하고, 스케줄러가 실제 보유 종목을 감시에서 통째로 빠뜨립니다.

## 변경

`mcp-trading/tests/fixtures/balance_report.json`에 두 케이스(`normal`, `truncated`)를 두고 `input`(KIS `output1`/`output2`)과 `expected_text`를 함께 보관합니다.

- **JS**: `formatBalanceReport(input) === expected_text`
- **Python**: `expected_text`를 그대로 파서에 투입 (`REAL_BALANCE_TEXT`를 픽스처 값으로 교체)

이제 *실제 생성기 출력 == 파일에 저장된 문자열 == 파서가 소비하는 입력* 이 한 파일로 강제됩니다.

잘림 안내(`[안내] ...`) 케이스도 픽스처에 포함했습니다 — 기존에는 JS 쪽에만 가드가 있고, Python 파서가 `- ` 접두사가 없다는 이유로 무시한다는 점이 Python 테스트로 고정돼 있지 않았습니다.

**기존 테스트는 삭제하지 않았습니다.** JS 인라인 테스트도, Python 기존 메서드도 전부 유지하고 픽스처 기반 테스트를 추가했습니다.

## 검증 (직접 실행) — 이 이슈의 존재 이유

**픽스처가 낡으면 양쪽이 동시에 실패해야 합니다.** 실측했습니다:

| 뮤턴트 | JS | Python |
| --- | --- | --- |
| 기준선 | 137 pass / 0 fail | 23 passed / 0 failed |
| **픽스처 `expected_text`만 낡게** (종목 줄 `- ` 제거) | **1 failed** ✅ | **2 failed** ✅ |
| `balance.js` 형식 변경 (`- ` → `* `) | **6 failed** ✅ | 0 failed |

첫 번째가 이 PR의 핵심입니다 — 픽스처가 실제 형식과 어긋나는 순간 **양쪽이 함께** 깨집니다. 두 번째는 생성기 드리프트를 JS가 즉시 잡는다는 확인입니다.

## 테스트

- JS: `npm test` — **135 → 137 pass / 0 fail**
- Python: `pytest backend/tests/test_balance_parser.py` — **19 → 23 passed**
- Python 전체: `pytest backend/` — **325 passed, 2 skipped** (실패 0건)

최근 머지된 동작(소수점 평단가 `평단가 66,666.67원`, 마커 부재 가드, `_parse_balance_holdings` 위임)과 픽스처가 어긋나지 않는 것도 확인했습니다.

Closes #137