### PR TITLE
feat: pending_orders를 Redis TTL 저장소로 이전 — 멀티워커·재시작 시 주문 유실 방지 (#63)

### DIFF
--- a/backend/redis_state.py
+++ b/backend/redis_state.py
@@ -238,6 +238,12 @@ class RedisPendingOrderStore:
         self.ttl_sec = ttl_sec
         self._keys = keys or RedisKeys()
 
+    def _serialize(self, order: Any) -> str:
+        """PendingOrder → JSON 문자열. set/set_if_absent가 공유한다."""
+        data = asdict(order)
+        data["created_at"] = data["created_at"].isoformat()
+        return json.dumps(data, ensure_ascii=False)
+
     def _deserialize(self, raw: str | bytes) -> Any:
         """raw JSON → PendingOrder. ValueError/TypeError/KeyError는 호출자가 처리한다."""
         from .trading_orders import PendingOrder
@@ -280,11 +286,9 @@ class RedisPendingOrderStore:
 
     async def set(self, chat_id: str, order: Any) -> None:
         """PendingOrder를 JSON 직렬화하여 TTL과 함께 저장한다."""
-        data = asdict(order)
-        data["created_at"] = data["created_at"].isoformat()
         await self.redis.set(
             self._keys.pending_order(chat_id),
-            json.dumps(data, ensure_ascii=False),
+            self._serialize(order),
             ex=self.ttl_sec,
         )
 
@@ -292,11 +296,9 @@ class RedisPendingOrderStore:
         """이미 대기 주문이 있으면 False. 경합하는 /buy 요청 중 승자를 하나로 고정한다.
         RedisSchedulerState.acquire_*_lock과 같은 NX 관용구를 따른다.
         """
-        data = asdict(order)
-        data["created_at"] = data["created_at"].isoformat()
         result = await self.redis.set(
             self._keys.pending_order(chat_id),
-            json.dumps(data, ensure_ascii=False),
+            self._serialize(order),
             ex=self.ttl_sec,
             nx=True,
         )

--- a/backend/redis_state.py
+++ b/backend/redis_state.py
@@ -1,8 +1,10 @@
 import hashlib
+import json
 import logging
 import re
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
+from datetime import datetime
 from typing import Any, AsyncIterator
 from uuid import uuid4
 
@@ -14,6 +16,12 @@ SCHEDULER_LOCK_TTL_SEC = 60 * 30
 COOLDOWN_TTL_SEC = 60 * 10
 TELEGRAM_ALERT_MODES = {"urgent", "all", "off"}
 DEFAULT_TELEGRAM_ALERT_MODE = "urgent"
+
+# pending_order TTL: 10분(600초).
+# 앱 레벨 ORDER_EXPIRES_AFTER(60초)는 별도 존재하며 직접 만료 체크를 수행한다.
+# Redis TTL은 프로세스 크래시·재시작 후 stale 키를 자동 정리하는 안전망 역할이다.
+# 이슈 #63이 "5~10분" 범위를 제안했고, ORDER_EXPIRES_AFTER의 10× 여유를 택한다.
+PENDING_ORDER_TTL_SEC = 60 * 10
 
 
 def normalize_signal_text(signal_text: str) -> str:
@@ -51,6 +59,9 @@ class RedisKeys:
 
     def telegram_alert_mode(self) -> str:
         return f"{self.prefix}:telegram:alert_mode"
+
+    def pending_order(self, chat_id: str) -> str:
+        return f"{self.prefix}:pending_order:{chat_id}"
 
 
 class RedisSchedulerState:
@@ -141,6 +152,99 @@ class RedisSchedulerState:
             return False
         await self.redis.set(self.keys.telegram_alert_mode(), mode)
         return True
+
+class InMemoryPendingOrderStore:
+    """테스트 전용 인메모리 pending_order 저장소.
+
+    async 메서드(get/set/delete/has)와 동기 dict 인터페이스(__getitem__,
+    __contains__, __eq__)를 동시에 제공해, 기존 테스트 코드의
+    ``handler.pending_orders['123']``, ``handler.pending_orders == {}`` 등을
+    수정 없이 유지할 수 있게 한다.
+
+    멀티워커 프로덕션 환경에서는 사용하지 말 것.
+    프로세스 간 격리로 이슈 #63의 주문 유실 버그가 재현된다.
+    """
+
+    def __init__(self) -> None:
+        self._store: dict[str, Any] = {}
+
+    async def get(self, chat_id: str) -> Any:
+        return self._store.get(chat_id)
+
+    async def set(self, chat_id: str, order: Any) -> None:
+        self._store[chat_id] = order
+
+    async def delete(self, chat_id: str) -> None:
+        self._store.pop(chat_id, None)
+
+    async def has(self, chat_id: str) -> bool:
+        return chat_id in self._store
+
+    # 동기 dict 인터페이스: 기존 테스트의 handler.pending_orders[...] 접근용
+    def __getitem__(self, chat_id: str) -> Any:
+        return self._store[chat_id]
+
+    def __contains__(self, chat_id: object) -> bool:
+        return chat_id in self._store
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, dict):
+            return self._store == other
+        if isinstance(other, InMemoryPendingOrderStore):
+            return self._store == other._store
+        return NotImplemented
+
+    def __repr__(self) -> str:
+        return f"InMemoryPendingOrderStore({self._store!r})"
+
+
+class RedisPendingOrderStore:
+    """Redis TTL 저장소로 pending_order를 저장한다. 멀티워커·재시작 대응.
+
+    Redis 장애 시 fail-closed — 인메모리 폴백 없음.
+    - 폴백을 두면 멀티워커에서 원래 버그(프로세스 간 격리)가 재현된다.
+    - Redis 장애 → 호출자에게 예외가 전파되고 사용자는 명시적 오류 메시지를 받는다.
+      조용한 주문 유실보다 명시적 실패가 금전 경로에서 더 안전하다.
+
+    scheduler.py의 Redis fallback(fail-open)은 멱등 모니터링 작업이라 가능하다.
+    주문 확인/취소는 금전이 오가는 경로이므로 같은 기준을 적용할 수 없다.
+
+    키 패턴: ``finus:pending_order:{chat_id}``
+    TTL: PENDING_ORDER_TTL_SEC (600초 = 10분)
+    """
+
+    def __init__(self, redis: Any, ttl_sec: int = PENDING_ORDER_TTL_SEC) -> None:
+        self.redis = redis
+        self.ttl_sec = ttl_sec
+        self._keys = RedisKeys()
+
+    async def get(self, chat_id: str) -> Any:
+        """PendingOrder를 반환하거나, 없으면(TTL 만료 포함) None을 반환한다."""
+        from .trading_orders import PendingOrder
+
+        raw = await self.redis.get(self._keys.pending_order(chat_id))
+        if raw is None:
+            return None
+        data: dict[str, Any] = json.loads(raw if isinstance(raw, str) else raw.decode())
+        data["created_at"] = datetime.fromisoformat(data["created_at"])
+        return PendingOrder(**data)
+
+    async def set(self, chat_id: str, order: Any) -> None:
+        """PendingOrder를 JSON 직렬화하여 TTL과 함께 저장한다."""
+        data = asdict(order)
+        data["created_at"] = data["created_at"].isoformat()
+        await self.redis.set(
+            self._keys.pending_order(chat_id),
+            json.dumps(data, ensure_ascii=False),
+            ex=self.ttl_sec,
+        )
+
+    async def delete(self, chat_id: str) -> None:
+        await self.redis.delete(self._keys.pending_order(chat_id))
+
+    async def has(self, chat_id: str) -> bool:
+        return bool(await self.redis.exists(self._keys.pending_order(chat_id)))
+
 
 def create_redis_client() -> Any:
     from redis.asyncio import Redis

--- a/backend/redis_state.py
+++ b/backend/redis_state.py
@@ -153,6 +153,7 @@ class RedisSchedulerState:
         await self.redis.set(self.keys.telegram_alert_mode(), mode)
         return True
 
+
 class InMemoryPendingOrderStore:
     """테스트 전용 인메모리 pending_order 저장소.
 
@@ -180,6 +181,17 @@ class InMemoryPendingOrderStore:
     async def has(self, chat_id: str) -> bool:
         return chat_id in self._store
 
+    async def claim(self, chat_id: str) -> Any:
+        """주문을 원자적으로 꺼내며 삭제한다. 재전송 update의 중복 체결을 방지한다."""
+        return self._store.pop(chat_id, None)
+
+    async def set_if_absent(self, chat_id: str, order: Any) -> bool:
+        """이미 대기 주문이 있으면 False. 경합하는 /buy 요청 중 승자를 하나로 고정한다."""
+        if chat_id in self._store:
+            return False
+        self._store[chat_id] = order
+        return True
+
     # 동기 dict 인터페이스: 기존 테스트의 handler.pending_orders[...] 접근용
     def __getitem__(self, chat_id: str) -> Any:
         return self._store[chat_id]
@@ -193,6 +205,8 @@ class InMemoryPendingOrderStore:
         if isinstance(other, InMemoryPendingOrderStore):
             return self._store == other._store
         return NotImplemented
+
+    __hash__ = object.__hash__  # __eq__ 정의로 사라진 기본 해시를 복원
 
     def __repr__(self) -> str:
         return f"InMemoryPendingOrderStore({self._store!r})"
@@ -213,21 +227,56 @@ class RedisPendingOrderStore:
     TTL: PENDING_ORDER_TTL_SEC (600초 = 10분)
     """
 
-    def __init__(self, redis: Any, ttl_sec: int = PENDING_ORDER_TTL_SEC) -> None:
+    def __init__(
+        self,
+        redis: Any,
+        *,
+        keys: RedisKeys | None = None,
+        ttl_sec: int = PENDING_ORDER_TTL_SEC,
+    ) -> None:
         self.redis = redis
         self.ttl_sec = ttl_sec
-        self._keys = RedisKeys()
+        self._keys = keys or RedisKeys()
 
-    async def get(self, chat_id: str) -> Any:
-        """PendingOrder를 반환하거나, 없으면(TTL 만료 포함) None을 반환한다."""
+    def _deserialize(self, raw: str | bytes) -> Any:
+        """raw JSON → PendingOrder. ValueError/TypeError/KeyError는 호출자가 처리한다."""
         from .trading_orders import PendingOrder
 
-        raw = await self.redis.get(self._keys.pending_order(chat_id))
-        if raw is None:
-            return None
         data: dict[str, Any] = json.loads(raw if isinstance(raw, str) else raw.decode())
         data["created_at"] = datetime.fromisoformat(data["created_at"])
         return PendingOrder(**data)
+
+    async def get(self, chat_id: str) -> Any:
+        """PendingOrder를 반환하거나, 없으면(TTL 만료 포함) None을 반환한다.
+
+        역직렬화 오류(스키마 변경·손상 키)는 해당 키를 삭제하고 None을 반환한다.
+        남겨두면 /cancel까지 같은 예외로 막혀 사용자가 스스로 복구할 수 없다.
+        Redis 연결 오류 등 저장소 자체 장애는 여전히 위로 전파된다(fail-closed 유지).
+        """
+        raw = await self.redis.get(self._keys.pending_order(chat_id))
+        if raw is None:
+            return None
+        try:
+            return self._deserialize(raw)
+        except (ValueError, TypeError, KeyError) as exc:
+            logger.error("pending_order 역직렬화 실패, 키 삭제: %s", exc)
+            await self.delete(chat_id)
+            return None
+
+    async def claim(self, chat_id: str) -> Any:
+        """주문을 원자적으로 읽으며 삭제한다(GETDEL). 재전송된 Telegram update가
+        같은 주문을 두 번 체결하는 것을 방지한다. 경합하는 두 호출 중 정확히 하나만
+        order를 받고, 나머지는 None을 받는다.
+        """
+        raw = await self.redis.getdel(self._keys.pending_order(chat_id))
+        if raw is None:
+            return None
+        try:
+            return self._deserialize(raw)
+        except (ValueError, TypeError, KeyError) as exc:
+            # getdel로 이미 삭제됨 — 복원 없이 None 반환
+            logger.error("pending_order 역직렬화 실패 (claim): %s", exc)
+            return None
 
     async def set(self, chat_id: str, order: Any) -> None:
         """PendingOrder를 JSON 직렬화하여 TTL과 함께 저장한다."""
@@ -238,6 +287,20 @@ class RedisPendingOrderStore:
             json.dumps(data, ensure_ascii=False),
             ex=self.ttl_sec,
         )
+
+    async def set_if_absent(self, chat_id: str, order: Any) -> bool:
+        """이미 대기 주문이 있으면 False. 경합하는 /buy 요청 중 승자를 하나로 고정한다.
+        RedisSchedulerState.acquire_*_lock과 같은 NX 관용구를 따른다.
+        """
+        data = asdict(order)
+        data["created_at"] = data["created_at"].isoformat()
+        result = await self.redis.set(
+            self._keys.pending_order(chat_id),
+            json.dumps(data, ensure_ascii=False),
+            ex=self.ttl_sec,
+            nx=True,
+        )
+        return bool(result)
 
     async def delete(self, chat_id: str) -> None:
         await self.redis.delete(self._keys.pending_order(chat_id))

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -229,7 +229,13 @@ class TelegramCommandHandler:
         # pending_orders: 기존 테스트 코드(handler.pending_orders['123'] 등)와
         # 호환되도록 InMemoryPendingOrderStore가 동기 dict 인터페이스를 제공한다.
         # 프로덕션에서는 TelegramCommandPoller가 RedisPendingOrderStore를 주입한다.
-        self.pending_orders: Any = pending_order_store if pending_order_store is not None else InMemoryPendingOrderStore()
+        if pending_order_store is None:
+            logger.warning(
+                "pending_order_store 미주입 — InMemoryPendingOrderStore 사용. "
+                "멀티워커 환경에서는 주문이 프로세스 간 격리된다(#63)."
+            )
+            pending_order_store = InMemoryPendingOrderStore()
+        self.pending_orders: Any = pending_order_store
         self.market_callbacks: dict[str, tuple[str, str]] = {}
 
     async def handle_update(self, update: dict[str, Any]) -> None:
@@ -763,9 +769,15 @@ class TelegramCommandHandler:
             callback_token=secrets.token_urlsafe(8),
         )
         try:
-            await self.pending_orders.set(chat_id, order)
+            stored = await self.pending_orders.set_if_absent(chat_id, order)
         except Exception as exc:
             await self._send_text_or_raise(f"주문 저장 실패: {_short_error(exc)}")
+            return
+        if not stored:
+            # MCP 호출 사이에 같은 chat에서 /buy가 먼저 체결된 경우
+            await self._send_text_or_raise(
+                "이미 대기 중인 주문이 있습니다. /confirm 또는 /cancel로 먼저 처리하세요."
+            )
             return
         await self._send_text_or_raise(
             self._format_order_prompt(order, str(quote_result), str(balance_result)),
@@ -790,17 +802,20 @@ class TelegramCommandHandler:
         await self._send_text_or_raise("대기 주문을 취소했습니다.")
 
     async def _handle_confirm(self, chat_id: str) -> None:
+        # order_gateway 부재 체크를 claim 전에 수행해 주문이 소비되지 않게 한다.
+        if self.order_gateway is None:
+            await self._send_text_or_raise("주문 실행 설정이 준비되지 않았습니다.")
+            return
         try:
             await self._drop_expired_pending_order(chat_id, self.now_factory())
-            order = await self.pending_orders.get(chat_id)
+            # claim(GETDEL): 원자적 읽기+삭제. 재시작 후 재전송된 Telegram update나
+            # 멀티워커 경합에서 정확히 하나의 호출만 order를 받고 나머지는 None을 받는다.
+            order = await self.pending_orders.claim(chat_id)
         except Exception as exc:
             await self._send_text_or_raise(f"주문 저장소 오류: {_short_error(exc)}")
             return
         if order is None:
             await self._send_text_or_raise("확정할 대기 주문이 없습니다.")
-            return
-        if self.order_gateway is None:
-            await self._send_text_or_raise("주문 실행 설정이 준비되지 않았습니다.")
             return
 
         await self.notifier.send_chat_action("typing")
@@ -808,15 +823,16 @@ class TelegramCommandHandler:
             result = await self.order_gateway.place_order(order)
         except Exception as exc:
             if isinstance(exc, HTTPException) and exc.status_code == 403:
-                # 403 = 실계좌 가드 미충족: 주문 미실행이 확실하므로 대기 주문 유지
+                # 403 = 실계좌 가드 미충족: 주문 미실행이 확실하므로 대기 주문 복원.
+                # created_at을 유지하므로 앱 레벨 60초 만료는 그대로 적용된다.
+                try:
+                    await self.pending_orders.set(chat_id, order)
+                except Exception as put_exc:
+                    logger.error("pending_order 복원 실패 (403 후): %s", put_exc)
                 await self._send_text_or_raise(f"주문 실패: {_short_error(exc)}")
                 return
 
-            # 주문 실행 결과 불명확: 중복 주문 방지를 위해 삭제
-            try:
-                await self.pending_orders.delete(chat_id)
-            except Exception as del_exc:
-                logger.error("pending_order 삭제 실패 (gateway 오류 후): %s", del_exc)
+            # 주문 실행 결과 불명확: claim으로 이미 삭제됨 — 추가 delete 불필요
             await self._send_text_or_raise(
                 "주문 실패 또는 상태 확인 필요: "
                 f"{_short_error(exc)}\n"
@@ -824,11 +840,7 @@ class TelegramCommandHandler:
             )
             return
 
-        # 주문 성공: 대기 주문 삭제. 삭제 실패해도 주문 완료 알림은 보낸다
-        try:
-            await self.pending_orders.delete(chat_id)
-        except Exception as del_exc:
-            logger.error("pending_order 삭제 실패 (주문 완료 후): %s", del_exc)
+        # 주문 성공: claim으로 이미 삭제됨 — 추가 delete 불필요
         record_warning = ""
         if self.trade_recorder is not None:
             try:

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -21,7 +21,13 @@ from .config import (
 )
 from .catalyst_repo import SqliteCatalystEventRepo
 from .database import engine
-from .redis_state import RedisSchedulerState, redis_state
+from .redis_state import (
+    InMemoryPendingOrderStore,
+    RedisSchedulerState,
+    RedisPendingOrderStore,
+    create_redis_client,
+    redis_state,
+)
 from .services import llm_chat, run_mcp_tool
 from .watchlist_repo import SqliteWatchlistRepo
 from .telegram_notifier import TELEGRAM_ALERT_MODES, TelegramNotifier, telegram_notifier
@@ -177,6 +183,15 @@ def _create_trade_recorder() -> TradeRecorder:
     return TradeRecorder(lambda: Session(engine))
 
 
+def _create_pending_order_store() -> RedisPendingOrderStore:
+    """프로덕션 Redis pending_order 저장소를 생성한다.
+
+    단일 Redis 클라이언트 인스턴스를 생성해 커넥션 풀을 재사용한다.
+    핸들러 인스턴스당 한 번만 호출되므로 클라이언트 누적 없음.
+    """
+    return RedisPendingOrderStore(create_redis_client())
+
+
 def _default_watchlist_repo() -> SqliteWatchlistRepo:
     return SqliteWatchlistRepo(lambda: Session(engine))
 
@@ -199,6 +214,7 @@ class TelegramCommandHandler:
         trade_recorder: Any | None = None,
         now_factory: Callable[[], datetime] | None = None,
         visualization_url: str = VISUALIZATION_URL,
+        pending_order_store: Any | None = None,
     ):
         self.notifier = notifier
         self.state_factory = state_factory
@@ -210,7 +226,10 @@ class TelegramCommandHandler:
         self.trade_recorder = trade_recorder
         self.now_factory = now_factory or (lambda: datetime.now(KST))
         self.visualization_url = visualization_url.strip()
-        self.pending_orders: dict[str, PendingOrder] = {}
+        # pending_orders: 기존 테스트 코드(handler.pending_orders['123'] 등)와
+        # 호환되도록 InMemoryPendingOrderStore가 동기 dict 인터페이스를 제공한다.
+        # 프로덕션에서는 TelegramCommandPoller가 RedisPendingOrderStore를 주입한다.
+        self.pending_orders: Any = pending_order_store if pending_order_store is not None else InMemoryPendingOrderStore()
         self.market_callbacks: dict[str, tuple[str, str]] = {}
 
     async def handle_update(self, update: dict[str, Any]) -> None:
@@ -381,7 +400,15 @@ class TelegramCommandHandler:
         action: str,
         data: str,
     ) -> None:
-        order = self.pending_orders.get(chat_id)
+        try:
+            order = await self.pending_orders.get(chat_id)
+        except Exception as exc:
+            logger.error("pending_order 조회 실패 (callback): %s", exc)
+            await self._answer_callback_query(
+                callback_query_id,
+                text="주문 저장소 오류로 처리할 수 없습니다. 잠시 후 다시 시도하세요.",
+            )
+            return
         token = self._extract_order_callback_token(data)
         if order is None or not token or token != order.callback_token:
             await self._answer_callback_query(
@@ -673,8 +700,13 @@ class TelegramCommandHandler:
             )
             return
 
-        self._drop_expired_pending_order(chat_id, now)
-        if chat_id in self.pending_orders:
+        try:
+            await self._drop_expired_pending_order(chat_id, now)
+            has_pending = await self.pending_orders.has(chat_id)
+        except Exception as exc:
+            await self._send_text_or_raise(f"주문 저장소 오류: {_short_error(exc)}")
+            return
+        if has_pending:
             await self._send_text_or_raise(
                 "이미 대기 중인 주문이 있습니다. /confirm 또는 /cancel로 먼저 처리하세요."
             )
@@ -730,24 +762,40 @@ class TelegramCommandHandler:
             order_type=order_type,
             callback_token=secrets.token_urlsafe(8),
         )
-        self.pending_orders[chat_id] = order
+        try:
+            await self.pending_orders.set(chat_id, order)
+        except Exception as exc:
+            await self._send_text_or_raise(f"주문 저장 실패: {_short_error(exc)}")
+            return
         await self._send_text_or_raise(
             self._format_order_prompt(order, str(quote_result), str(balance_result)),
             reply_markup=self._order_reply_markup(order),
         )
 
     async def _handle_cancel(self, chat_id: str) -> None:
-        self._drop_expired_pending_order(chat_id, self.now_factory())
-        if chat_id not in self.pending_orders:
+        try:
+            await self._drop_expired_pending_order(chat_id, self.now_factory())
+            has_pending = await self.pending_orders.has(chat_id)
+        except Exception as exc:
+            await self._send_text_or_raise(f"주문 저장소 오류: {_short_error(exc)}")
+            return
+        if not has_pending:
             await self._send_text_or_raise("취소할 대기 주문이 없습니다.")
             return
-
-        self.pending_orders.pop(chat_id, None)
+        try:
+            await self.pending_orders.delete(chat_id)
+        except Exception as exc:
+            await self._send_text_or_raise(f"주문 저장소 오류: {_short_error(exc)}")
+            return
         await self._send_text_or_raise("대기 주문을 취소했습니다.")
 
     async def _handle_confirm(self, chat_id: str) -> None:
-        self._drop_expired_pending_order(chat_id, self.now_factory())
-        order = self.pending_orders.get(chat_id)
+        try:
+            await self._drop_expired_pending_order(chat_id, self.now_factory())
+            order = await self.pending_orders.get(chat_id)
+        except Exception as exc:
+            await self._send_text_or_raise(f"주문 저장소 오류: {_short_error(exc)}")
+            return
         if order is None:
             await self._send_text_or_raise("확정할 대기 주문이 없습니다.")
             return
@@ -760,10 +808,15 @@ class TelegramCommandHandler:
             result = await self.order_gateway.place_order(order)
         except Exception as exc:
             if isinstance(exc, HTTPException) and exc.status_code == 403:
+                # 403 = 실계좌 가드 미충족: 주문 미실행이 확실하므로 대기 주문 유지
                 await self._send_text_or_raise(f"주문 실패: {_short_error(exc)}")
                 return
 
-            self.pending_orders.pop(chat_id, None)
+            # 주문 실행 결과 불명확: 중복 주문 방지를 위해 삭제
+            try:
+                await self.pending_orders.delete(chat_id)
+            except Exception as del_exc:
+                logger.error("pending_order 삭제 실패 (gateway 오류 후): %s", del_exc)
             await self._send_text_or_raise(
                 "주문 실패 또는 상태 확인 필요: "
                 f"{_short_error(exc)}\n"
@@ -771,7 +824,11 @@ class TelegramCommandHandler:
             )
             return
 
-        self.pending_orders.pop(chat_id, None)
+        # 주문 성공: 대기 주문 삭제. 삭제 실패해도 주문 완료 알림은 보낸다
+        try:
+            await self.pending_orders.delete(chat_id)
+        except Exception as del_exc:
+            logger.error("pending_order 삭제 실패 (주문 완료 후): %s", del_exc)
         record_warning = ""
         if self.trade_recorder is not None:
             try:
@@ -858,8 +915,8 @@ class TelegramCommandHandler:
             return None
         return value if value > 0 else None
 
-    def _drop_expired_pending_order(self, chat_id: str, now: datetime) -> None:
-        order = self.pending_orders.get(chat_id)
+    async def _drop_expired_pending_order(self, chat_id: str, now: datetime) -> None:
+        order = await self.pending_orders.get(chat_id)
         if order is None:
             return
         created_at = order.created_at
@@ -868,7 +925,7 @@ class TelegramCommandHandler:
         if now.tzinfo is None:
             now = now.replace(tzinfo=KST)
         if now.astimezone(KST) - created_at.astimezone(KST) > ORDER_EXPIRES_AFTER:
-            self.pending_orders.pop(chat_id, None)
+            await self.pending_orders.delete(chat_id)
 
     def _extract_stock_code(self, text: str) -> str | None:
         match = _STOCK_CODE_EXTRACT_RE.search(text)
@@ -1258,6 +1315,7 @@ class TelegramCommandPoller:
                 notifier=notifier,
                 order_gateway=_create_order_gateway(),
                 trade_recorder=_create_trade_recorder(),
+                pending_order_store=_create_pending_order_store(),
             )
         self.handler = handler
         self.offset: int | None = None

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -825,10 +825,16 @@ class TelegramCommandHandler:
             if isinstance(exc, HTTPException) and exc.status_code == 403:
                 # 403 = 실계좌 가드 미충족: 주문 미실행이 확실하므로 대기 주문 복원.
                 # created_at을 유지하므로 앱 레벨 60초 만료는 그대로 적용된다.
+                # set_if_absent: 복원 도중 새 /buy가 들어온 경우 새 주문을 보호한다.
                 try:
-                    await self.pending_orders.set(chat_id, order)
+                    restored = await self.pending_orders.set_if_absent(chat_id, order)
                 except Exception as put_exc:
                     logger.error("pending_order 복원 실패 (403 후): %s", put_exc)
+                else:
+                    if not restored:
+                        logger.warning(
+                            "403 복원 생략 — 그 사이 새 대기 주문이 생성됨: %s", chat_id
+                        )
                 await self._send_text_or_raise(f"주문 실패: {_short_error(exc)}")
                 return
 

--- a/backend/tests/test_pending_order_store.py
+++ b/backend/tests/test_pending_order_store.py
@@ -1,0 +1,522 @@
+"""pending_order 저장소 테스트 (이슈 #63).
+
+검증 항목:
+- RedisPendingOrderStore: 저장→조회 왕복, TTL 만료 후 조회, Redis 장애 시 동작,
+  chat_id 간 격리, PendingOrder 필드 직렬화 무손실
+- InMemoryPendingOrderStore: 기본 동작, 동기 dict 인터페이스
+- 통합: TTL 만료 후 /confirm 시 명시적 오류, /cancel 시 명시적 오류,
+  Redis 장애 시 handler 오류 메시지 전달
+"""
+
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from backend.redis_state import (
+    PENDING_ORDER_TTL_SEC,
+    InMemoryPendingOrderStore,
+    RedisPendingOrderStore,
+)
+from backend.trading_orders import PendingOrder
+from backend.telegram_commands import TelegramCommandHandler
+
+KST = ZoneInfo("Asia/Seoul")
+
+_SAMPLE_ORDER = PendingOrder(
+    chat_id="123",
+    stock_name="삼성전자",
+    stock_code="005930",
+    side="BUY",
+    quantity=10,
+    price=75000,
+    created_at=datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    order_type="LIMIT",
+    callback_token="abc123",
+)
+
+
+# ---------------------------------------------------------------------------
+# FakeRedis — delete 지원 포함 (test_redis_state.py의 FakeRedis와 별도 정의)
+# ---------------------------------------------------------------------------
+
+class FakeRedis:
+    def __init__(self):
+        self.store: dict = {}
+        self._error: Exception | None = None
+
+    def set_error(self, exc: Exception) -> None:
+        """다음 호출부터 지정 예외를 발생시킨다."""
+        self._error = exc
+
+    def _check_error(self) -> None:
+        if self._error is not None:
+            raise self._error
+
+    async def get(self, key):
+        self._check_error()
+        return self.store.get(key)
+
+    async def set(self, key, value, *, ex=None, nx=False):
+        self._check_error()
+        if nx and key in self.store:
+            return False
+        self.store[key] = value
+        return True
+
+    async def delete(self, key):
+        self._check_error()
+        self.store.pop(key, None)
+
+    async def exists(self, key):
+        self._check_error()
+        return 1 if key in self.store else 0
+
+
+# ---------------------------------------------------------------------------
+# RedisPendingOrderStore 단위 테스트
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_redis_store_set_get_roundtrip():
+    """저장→조회 왕복: 모든 PendingOrder 필드가 손실 없이 복원된다."""
+    redis = FakeRedis()
+    store = RedisPendingOrderStore(redis)
+
+    await store.set("123", _SAMPLE_ORDER)
+    recovered = await store.get("123")
+
+    assert recovered is not None
+    assert recovered.chat_id == "123"
+    assert recovered.stock_name == "삼성전자"
+    assert recovered.stock_code == "005930"
+    assert recovered.side == "BUY"
+    assert recovered.quantity == 10
+    assert recovered.price == 75000
+    assert recovered.order_type == "LIMIT"
+    assert recovered.callback_token == "abc123"
+    # datetime 왕복: isoformat → fromisoformat 과정에서 timezone 보존
+    assert recovered.created_at == _SAMPLE_ORDER.created_at
+
+
+@pytest.mark.asyncio
+async def test_redis_store_get_returns_none_when_missing():
+    """키가 없으면 None을 반환한다 (TTL 만료 또는 미저장)."""
+    redis = FakeRedis()
+    store = RedisPendingOrderStore(redis)
+
+    result = await store.get("nonexistent")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_redis_store_get_returns_none_after_ttl_expiry():
+    """TTL 만료 시뮬레이션: store에서 키를 직접 제거하면 get()이 None을 반환한다."""
+    redis = FakeRedis()
+    store = RedisPendingOrderStore(redis)
+
+    await store.set("123", _SAMPLE_ORDER)
+    # TTL 만료 시뮬레이션: Redis가 키를 자동 삭제한 것처럼 처리
+    redis.store.clear()
+
+    result = await store.get("123")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_redis_store_set_writes_with_correct_ttl():
+    """set() 호출 시 지정된 TTL로 Redis에 저장된다."""
+    redis = FakeRedis()
+    store = RedisPendingOrderStore(redis, ttl_sec=300)
+    # FakeRedis는 TTL을 실제 만료에 쓰지 않지만, set 파라미터를 확인할 수 있도록
+    # set을 래핑해 기록한다.
+    calls: list = []
+    original_set = redis.set
+
+    async def recording_set(key, value, *, ex=None, nx=False):
+        calls.append((key, ex))
+        return await original_set(key, value, ex=ex, nx=nx)
+
+    redis.set = recording_set
+
+    await store.set("123", _SAMPLE_ORDER)
+
+    assert len(calls) == 1
+    key, ttl = calls[0]
+    assert "pending_order:123" in key
+    assert ttl == 300
+
+
+@pytest.mark.asyncio
+async def test_redis_store_default_ttl_matches_constant():
+    """기본 TTL이 PENDING_ORDER_TTL_SEC(600초)와 일치한다."""
+    redis = FakeRedis()
+    store = RedisPendingOrderStore(redis)
+    calls: list = []
+    original_set = redis.set
+
+    async def recording_set(key, value, *, ex=None, nx=False):
+        calls.append(ex)
+        return await original_set(key, value, ex=ex, nx=nx)
+
+    redis.set = recording_set
+    await store.set("123", _SAMPLE_ORDER)
+
+    assert calls[0] == PENDING_ORDER_TTL_SEC
+
+
+@pytest.mark.asyncio
+async def test_redis_store_delete_removes_order():
+    """delete() 후 get()이 None을 반환한다."""
+    redis = FakeRedis()
+    store = RedisPendingOrderStore(redis)
+
+    await store.set("123", _SAMPLE_ORDER)
+    await store.delete("123")
+    result = await store.get("123")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_redis_store_has_true_after_set():
+    redis = FakeRedis()
+    store = RedisPendingOrderStore(redis)
+
+    await store.set("123", _SAMPLE_ORDER)
+
+    assert await store.has("123") is True
+
+
+@pytest.mark.asyncio
+async def test_redis_store_has_false_after_delete():
+    redis = FakeRedis()
+    store = RedisPendingOrderStore(redis)
+
+    await store.set("123", _SAMPLE_ORDER)
+    await store.delete("123")
+
+    assert await store.has("123") is False
+
+
+@pytest.mark.asyncio
+async def test_redis_store_chat_id_isolation():
+    """다른 chat_id 간 데이터가 격리된다."""
+    redis = FakeRedis()
+    store = RedisPendingOrderStore(redis)
+
+    order_a = PendingOrder(
+        chat_id="100", stock_name="삼성전자", stock_code="005930",
+        side="BUY", quantity=1, price=70000,
+        created_at=datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+    order_b = PendingOrder(
+        chat_id="200", stock_name="NAVER", stock_code="035420",
+        side="SELL", quantity=2, price=200000,
+        created_at=datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await store.set("100", order_a)
+    await store.set("200", order_b)
+
+    recovered_a = await store.get("100")
+    recovered_b = await store.get("200")
+
+    assert recovered_a is not None and recovered_a.stock_name == "삼성전자"
+    assert recovered_b is not None and recovered_b.stock_name == "NAVER"
+
+    await store.delete("100")
+
+    assert await store.get("100") is None
+    assert await store.get("200") is not None
+
+
+@pytest.mark.asyncio
+async def test_redis_store_get_raises_on_redis_failure():
+    """Redis 장애 시 get()이 예외를 전파한다 (fail-closed)."""
+    redis = FakeRedis()
+    store = RedisPendingOrderStore(redis)
+    redis.set_error(ConnectionError("Redis 연결 실패"))
+
+    with pytest.raises(ConnectionError, match="Redis 연결 실패"):
+        await store.get("123")
+
+
+@pytest.mark.asyncio
+async def test_redis_store_set_raises_on_redis_failure():
+    """Redis 장애 시 set()이 예외를 전파한다 (fail-closed)."""
+    redis = FakeRedis()
+    store = RedisPendingOrderStore(redis)
+    redis.set_error(ConnectionError("Redis 연결 실패"))
+
+    with pytest.raises(ConnectionError):
+        await store.set("123", _SAMPLE_ORDER)
+
+
+@pytest.mark.asyncio
+async def test_redis_store_key_pattern():
+    """저장 키가 'finus:pending_order:{chat_id}' 패턴을 따른다."""
+    redis = FakeRedis()
+    store = RedisPendingOrderStore(redis)
+
+    await store.set("999", _SAMPLE_ORDER)
+
+    assert "finus:pending_order:999" in redis.store
+
+
+# ---------------------------------------------------------------------------
+# InMemoryPendingOrderStore 단위 테스트
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_memory_store_set_get_roundtrip():
+    store = InMemoryPendingOrderStore()
+
+    await store.set("123", _SAMPLE_ORDER)
+    result = await store.get("123")
+
+    assert result is _SAMPLE_ORDER
+
+
+@pytest.mark.asyncio
+async def test_memory_store_get_none_when_missing():
+    store = InMemoryPendingOrderStore()
+
+    assert await store.get("missing") is None
+
+
+@pytest.mark.asyncio
+async def test_memory_store_delete():
+    store = InMemoryPendingOrderStore()
+
+    await store.set("123", _SAMPLE_ORDER)
+    await store.delete("123")
+
+    assert await store.get("123") is None
+    assert await store.has("123") is False
+
+
+@pytest.mark.asyncio
+async def test_memory_store_has():
+    store = InMemoryPendingOrderStore()
+
+    assert await store.has("123") is False
+    await store.set("123", _SAMPLE_ORDER)
+    assert await store.has("123") is True
+
+
+def test_memory_store_sync_getitem():
+    """동기 __getitem__: 기존 테스트의 handler.pending_orders['123'] 호환."""
+    store = InMemoryPendingOrderStore()
+    store._store["123"] = _SAMPLE_ORDER
+
+    assert store["123"] is _SAMPLE_ORDER
+
+
+def test_memory_store_sync_contains():
+    """동기 __contains__: 기존 테스트의 '123' in handler.pending_orders 호환."""
+    store = InMemoryPendingOrderStore()
+
+    assert "123" not in store
+    store._store["123"] = _SAMPLE_ORDER
+    assert "123" in store
+
+
+def test_memory_store_sync_eq_with_empty_dict():
+    """동기 __eq__: handler.pending_orders == {} 호환."""
+    store = InMemoryPendingOrderStore()
+
+    assert store == {}
+    store._store["123"] = _SAMPLE_ORDER
+    assert store != {}
+
+
+# ---------------------------------------------------------------------------
+# 통합: TTL 만료 후 /confirm, /cancel 시 명시적 오류 메시지
+# ---------------------------------------------------------------------------
+
+class FakeNotifier:
+    def __init__(self, chat_id="123"):
+        self.chat_id = chat_id
+        self.bot_username = ""
+        self.messages: list[str] = []
+        self.reply_markups: list = []
+        self.actions: list = []
+        self.callback_answers: list = []
+
+    async def send_text(self, text, *, reply_markup=None):
+        self.messages.append(text)
+        self.reply_markups.append(reply_markup)
+        return True
+
+    async def send_chat_action(self, action="typing"):
+        self.actions.append(action)
+        return True
+
+    async def answer_callback_query(self, callback_query_id, text=None):
+        self.callback_answers.append((callback_query_id, text))
+        return True
+
+
+@pytest.mark.asyncio
+async def test_confirm_after_ttl_expiry_gives_explicit_error():
+    """/confirm 시 Redis TTL 만료(키 없음)이면 '확정할 대기 주문이 없습니다.' 응답.
+
+    조용히 아무 일도 안 일어나지 않음을 고정한다(이슈 #63 요구사항).
+    """
+    redis = FakeRedis()
+    store = RedisPendingOrderStore(redis)
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        pending_order_store=store,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 2, tzinfo=KST),
+    )
+
+    # Redis에 키가 없는 상태(TTL 만료 시뮬레이션)
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/confirm"}})
+
+    assert notifier.messages[-1] == "확정할 대기 주문이 없습니다."
+
+
+@pytest.mark.asyncio
+async def test_cancel_after_ttl_expiry_gives_explicit_error():
+    """/cancel 시 Redis TTL 만료(키 없음)이면 '취소할 대기 주문이 없습니다.' 응답."""
+    redis = FakeRedis()
+    store = RedisPendingOrderStore(redis)
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        pending_order_store=store,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 2, tzinfo=KST),
+    )
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/cancel"}})
+
+    assert notifier.messages[-1] == "취소할 대기 주문이 없습니다."
+
+
+@pytest.mark.asyncio
+async def test_confirm_button_after_ttl_expiry_gives_stale_callback_text():
+    """인라인 버튼 클릭 시 TTL 만료(키 없음)이면 ORDER_STALE_CALLBACK_TEXT 응답."""
+    from backend.telegram_commands import ORDER_STALE_CALLBACK_TEXT
+
+    redis = FakeRedis()
+    store = RedisPendingOrderStore(redis)
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        pending_order_store=store,
+    )
+
+    await handler.handle_update({
+        "callback_query": {
+            "id": "cb-1",
+            "data": "order:confirm:sometoken",
+            "message": {"chat": {"id": 123}},
+        }
+    })
+
+    assert len(notifier.callback_answers) == 1
+    _, text = notifier.callback_answers[0]
+    assert text == ORDER_STALE_CALLBACK_TEXT
+
+
+@pytest.mark.asyncio
+async def test_confirm_redis_failure_sends_error_message():
+    """Redis 장애 시 /confirm이 사용자에게 오류 메시지를 보낸다 (fail-closed)."""
+    redis = FakeRedis()
+    redis.set_error(ConnectionError("Redis 연결 실패"))
+    store = RedisPendingOrderStore(redis)
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        pending_order_store=store,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/confirm"}})
+
+    assert len(notifier.messages) == 1
+    assert "저장소 오류" in notifier.messages[-1]
+
+
+@pytest.mark.asyncio
+async def test_cancel_redis_failure_sends_error_message():
+    """Redis 장애 시 /cancel이 사용자에게 오류 메시지를 보낸다 (fail-closed)."""
+    redis = FakeRedis()
+    redis.set_error(ConnectionError("Redis 연결 실패"))
+    store = RedisPendingOrderStore(redis)
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        pending_order_store=store,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/cancel"}})
+
+    assert len(notifier.messages) == 1
+    assert "저장소 오류" in notifier.messages[-1]
+
+
+@pytest.mark.asyncio
+async def test_app_level_expiry_drops_order_before_confirm():
+    """앱 레벨 ORDER_EXPIRES_AFTER(60초) 초과 시 confirm이 '없음' 응답을 반환한다.
+
+    Redis TTL(600초)과 별개로 앱 레벨 체크가 동작함을 고정한다.
+    """
+    store = InMemoryPendingOrderStore()
+    notifier = FakeNotifier()
+    # 주문 생성: 10:00:00
+    # confirm 시각: 10:01:01 → ORDER_EXPIRES_AFTER(60초) 초과
+    created_at = datetime(2026, 5, 20, 10, 0, 0, tzinfo=KST)
+    confirm_at = datetime(2026, 5, 20, 10, 1, 1, tzinfo=KST)
+
+    order = PendingOrder(
+        chat_id="123", stock_name="삼성전자", stock_code="005930",
+        side="BUY", quantity=1, price=70000,
+        created_at=created_at,
+        callback_token="tok",
+    )
+    await store.set("123", order)
+
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        pending_order_store=store,
+        now_factory=lambda: confirm_at,
+    )
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/confirm"}})
+
+    assert notifier.messages[-1] == "확정할 대기 주문이 없습니다."
+    # 앱 레벨 expiry가 Redis에서도 삭제했는지 확인
+    assert await store.has("123") is False
+
+
+@pytest.mark.asyncio
+async def test_confirm_cancel_flow_with_redis_store():
+    """저장→confirm/cancel 정상 흐름 통합 테스트."""
+    store = InMemoryPendingOrderStore()
+    notifier = FakeNotifier()
+
+    order = PendingOrder(
+        chat_id="123", stock_name="삼성전자", stock_code="005930",
+        side="BUY", quantity=1, price=70000,
+        created_at=datetime(2026, 5, 20, 10, 0, 0, tzinfo=KST),
+        callback_token="tok",
+    )
+    await store.set("123", order)
+
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        pending_order_store=store,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, 30, tzinfo=KST),
+    )
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/cancel"}})
+
+    assert "취소" in notifier.messages[-1]
+    assert await store.has("123") is False

--- a/backend/tests/test_pending_order_store.py
+++ b/backend/tests/test_pending_order_store.py
@@ -595,3 +595,148 @@ async def test_duplicate_confirm_calls_place_order_only_once():
     )
     assert "주문 완료" in notifier.messages[0]
     assert notifier.messages[-1] == "확정할 대기 주문이 없습니다."
+
+
+# ---------------------------------------------------------------------------
+# set_if_absent NX 시맨틱 가드 (이슈 #63, PR #223 Improvement 1)
+# ---------------------------------------------------------------------------
+
+_ORDER_A = PendingOrder(
+    chat_id="123",
+    stock_name="삼성전자",
+    stock_code="005930",
+    side="BUY",
+    quantity=1,
+    price=75000,
+    created_at=datetime(2026, 5, 20, 10, 0, 0, tzinfo=KST),
+    callback_token="tok-a",
+)
+_ORDER_B = PendingOrder(
+    chat_id="123",
+    stock_name="NAVER",
+    stock_code="035420",
+    side="BUY",
+    quantity=2,
+    price=200000,
+    created_at=datetime(2026, 5, 20, 10, 0, 1, tzinfo=KST),
+    callback_token="tok-b",
+)
+
+
+@pytest.mark.asyncio
+async def test_memory_store_set_if_absent_returns_true_when_empty():
+    """비어 있으면 True를 반환하고 주문을 저장한다.
+
+    이 테스트가 잡는 mutation: set_if_absent가 항상 False를 반환하도록 변경.
+    """
+    store = InMemoryPendingOrderStore()
+
+    result = await store.set_if_absent("123", _ORDER_A)
+
+    assert result is True
+    assert await store.get("123") is _ORDER_A
+
+
+@pytest.mark.asyncio
+async def test_memory_store_set_if_absent_returns_false_and_preserves_original():
+    """이미 대기 주문이 있으면 False를 반환하고 기존 주문이 보존된다.
+
+    이 테스트가 잡는 mutation: set_if_absent의 NX 검사 제거
+    (``if chat_id in self._store: return False`` 두 줄을 지운 경우).
+    NX 검사 없이 무조건 덮어쓰면 두 번째 /buy가 첫 번째 주문을 교체하고
+    사용자는 의도한 것과 다른 주문을 체결하게 된다.
+    """
+    store = InMemoryPendingOrderStore()
+    await store.set_if_absent("123", _ORDER_A)
+
+    result = await store.set_if_absent("123", _ORDER_B)
+
+    assert result is False
+    # 원래 주문(A)이 B로 덮어쓰이지 않아야 한다
+    stored = await store.get("123")
+    assert stored is _ORDER_A
+    assert stored.callback_token == "tok-a"
+
+
+@pytest.mark.asyncio
+async def test_redis_store_set_if_absent_returns_true_when_empty():
+    """비어 있으면 True를 반환하고 nx=True로 Redis에 저장한다.
+
+    이 테스트가 잡는 mutation: set_if_absent에서 nx=True 제거.
+    """
+    redis = FakeRedis()
+    store = RedisPendingOrderStore(redis)
+
+    result = await store.set_if_absent("123", _ORDER_A)
+
+    assert result is True
+    recovered = await store.get("123")
+    assert recovered is not None
+    assert recovered.callback_token == "tok-a"
+
+
+@pytest.mark.asyncio
+async def test_redis_store_set_if_absent_returns_false_and_preserves_original():
+    """이미 키가 있으면 False를 반환하고 기존 값이 보존된다.
+
+    이 테스트가 잡는 mutation: set_if_absent의 nx=True 제거.
+    nx=True 없이 무조건 set하면 FakeRedis가 덮어써서 두 번째 호출도 True를 반환한다.
+    """
+    redis = FakeRedis()
+    store = RedisPendingOrderStore(redis)
+    await store.set_if_absent("123", _ORDER_A)
+
+    result = await store.set_if_absent("123", _ORDER_B)
+
+    assert result is False
+    # Redis에 저장된 값이 A여야 한다(B로 덮어쓰이면 안 됨)
+    recovered = await store.get("123")
+    assert recovered is not None
+    assert recovered.callback_token == "tok-a"
+
+
+@pytest.mark.asyncio
+async def test_buy_command_second_call_rejected_after_race():
+    """/buy 두 번째 호출이 이미 대기 주문이 있을 때 거절된다 (end-to-end).
+
+    이 테스트가 잡는 mutation: has() 체크 제거 또는 set_if_absent가 항상 True를
+    반환하도록 변경 (두 번째 /buy가 주문 프롬프트를 내보내면 실패).
+    NX 시맨틱 자체(기존 값 보존)는 위의 단위 테스트들이 직접 고정한다.
+
+    시나리오: 첫 번째 /buy가 set_if_absent로 슬롯을 획득한 뒤,
+    두 번째 /buy가 has() fast-path 또는 set_if_absent NX 어느 경로에서든
+    "이미 대기 중인 주문이 있습니다."로 거절당하는 흐름을 검증한다.
+    """
+    async def mcp_runner(server_params, tool_name, arguments):
+        if tool_name == "resolve_stock_code":
+            return "삼성전자 (005930, KOSPI)"
+        if tool_name == "get_stock_quote":
+            return "현재가: 75,000원"
+        if tool_name == "get_balance":
+            return "주문가능금액: 1,000,000원"
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    store = InMemoryPendingOrderStore()
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        pending_order_store=store,
+        mcp_runner=mcp_runner,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, 0, tzinfo=KST),
+    )
+
+    # 첫 번째 /buy — 슬롯 획득
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 1 75000"}}
+    )
+    # 두 번째 /buy — has() fast-path도 있지만, 여기서는 슬롯이 있으므로 fast-path에서 막힘.
+    # set_if_absent NX 검사를 제거한 뮤턴트에서는 fast-path를 통과하더라도
+    # set_if_absent 자체가 막아야 하므로, 한 번 더 호출해 set_if_absent 경로도 검증한다.
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 1 75000"}}
+    )
+
+    # 두 번째 호출은 거절 메시지를 받아야 한다
+    assert "이미 대기 중인 주문이 있습니다" in notifier.messages[-1]
+    # 스토어에는 첫 번째 주문만 있어야 한다
+    assert await store.has("123") is True

--- a/backend/tests/test_pending_order_store.py
+++ b/backend/tests/test_pending_order_store.py
@@ -8,7 +8,7 @@
   Redis 장애 시 handler 오류 메시지 전달
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -71,6 +71,10 @@ class FakeRedis:
     async def exists(self, key):
         self._check_error()
         return 1 if key in self.store else 0
+
+    async def getdel(self, key):
+        self._check_error()
+        return self.store.pop(key, None)
 
 
 # ---------------------------------------------------------------------------
@@ -372,6 +376,7 @@ async def test_confirm_after_ttl_expiry_gives_explicit_error():
     handler = TelegramCommandHandler(
         notifier=notifier,
         pending_order_store=store,
+        order_gateway=FakeOrderGateway(),
         now_factory=lambda: datetime(2026, 5, 20, 10, 2, tzinfo=KST),
     )
 
@@ -434,6 +439,7 @@ async def test_confirm_redis_failure_sends_error_message():
     handler = TelegramCommandHandler(
         notifier=notifier,
         pending_order_store=store,
+        order_gateway=FakeOrderGateway(),
         now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
     )
 
@@ -486,6 +492,7 @@ async def test_app_level_expiry_drops_order_before_confirm():
     handler = TelegramCommandHandler(
         notifier=notifier,
         pending_order_store=store,
+        order_gateway=FakeOrderGateway(),
         now_factory=lambda: confirm_at,
     )
 
@@ -520,3 +527,71 @@ async def test_confirm_cancel_flow_with_redis_store():
 
     assert "취소" in notifier.messages[-1]
     assert await store.has("123") is False
+
+
+# ---------------------------------------------------------------------------
+# Critical 회귀: claim 원자성으로 중복 체결 방지 (이슈 #63)
+# ---------------------------------------------------------------------------
+
+from backend.trading_orders import OrderExecutionResult  # noqa: E402
+
+
+class FakeOrderGateway:
+    def __init__(self) -> None:
+        self.orders: list = []
+
+    async def place_order(self, order):
+        self.orders.append(order)
+        return OrderExecutionResult(
+            stock_code=order.stock_code,
+            stock_name=order.stock_name,
+            side=order.side,
+            quantity=order.quantity,
+            price=order.price,
+            message="주문 접수",
+            raw_result="{}",
+        )
+
+
+@pytest.mark.asyncio
+async def test_duplicate_confirm_calls_place_order_only_once():
+    """같은 confirm을 두 번 처리해도 place_order는 한 번만 호출된다.
+
+    재시작 후 동일한 Telegram update가 재전송될 때 중복 체결을 방지하는
+    claim(GETDEL) 원자성을 검증한다(이슈 #63 Critical 회귀 테스트).
+    """
+    redis = FakeRedis()
+    store = RedisPendingOrderStore(redis)
+    notifier = FakeNotifier()
+    gateway = FakeOrderGateway()
+
+    order = PendingOrder(
+        chat_id="123",
+        stock_name="삼성전자",
+        stock_code="005930",
+        side="BUY",
+        quantity=1,
+        price=75000,
+        created_at=datetime(2026, 5, 20, 10, 0, 0, tzinfo=KST),
+        callback_token="tok",
+    )
+    await store.set("123", order)
+
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        pending_order_store=store,
+        order_gateway=gateway,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, 30, tzinfo=KST),
+    )
+
+    # 첫 번째 confirm: 정상 체결
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/confirm"}})
+    # 두 번째 confirm: 재시작 후 재전송된 update 시뮬레이션
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/confirm"}})
+
+    # place_order는 정확히 한 번만 호출되어야 한다
+    assert len(gateway.orders) == 1, (
+        f"place_order가 {len(gateway.orders)}번 호출됨 — 중복 체결 회귀"
+    )
+    assert "주문 완료" in notifier.messages[0]
+    assert notifier.messages[-1] == "확정할 대기 주문이 없습니다."

--- a/backend/tests/test_pending_order_store.py
+++ b/backend/tests/test_pending_order_store.py
@@ -18,7 +18,7 @@ from backend.redis_state import (
     InMemoryPendingOrderStore,
     RedisPendingOrderStore,
 )
-from backend.trading_orders import PendingOrder
+from backend.trading_orders import OrderExecutionResult, PendingOrder
 from backend.telegram_commands import TelegramCommandHandler
 
 KST = ZoneInfo("Asia/Seoul")
@@ -364,6 +364,23 @@ class FakeNotifier:
         return True
 
 
+class FakeOrderGateway:
+    def __init__(self) -> None:
+        self.orders: list = []
+
+    async def place_order(self, order):
+        self.orders.append(order)
+        return OrderExecutionResult(
+            stock_code=order.stock_code,
+            stock_name=order.stock_name,
+            side=order.side,
+            quantity=order.quantity,
+            price=order.price,
+            message="주문 접수",
+            raw_result="{}",
+        )
+
+
 @pytest.mark.asyncio
 async def test_confirm_after_ttl_expiry_gives_explicit_error():
     """/confirm 시 Redis TTL 만료(키 없음)이면 '확정할 대기 주문이 없습니다.' 응답.
@@ -532,26 +549,6 @@ async def test_confirm_cancel_flow_with_redis_store():
 # ---------------------------------------------------------------------------
 # Critical 회귀: claim 원자성으로 중복 체결 방지 (이슈 #63)
 # ---------------------------------------------------------------------------
-
-from backend.trading_orders import OrderExecutionResult  # noqa: E402
-
-
-class FakeOrderGateway:
-    def __init__(self) -> None:
-        self.orders: list = []
-
-    async def place_order(self, order):
-        self.orders.append(order)
-        return OrderExecutionResult(
-            stock_code=order.stock_code,
-            stock_name=order.stock_name,
-            side=order.side,
-            quantity=order.quantity,
-            price=order.price,
-            message="주문 접수",
-            raw_result="{}",
-        )
-
 
 @pytest.mark.asyncio
 async def test_duplicate_confirm_calls_place_order_only_once():


### PR DESCRIPTION
## 배경

#63. `backend/telegram_commands.py`의 `pending_orders`가 **인메모리 딕셔너리 전용**이라 멀티 워커 환경 또는 컨테이너 재시작 시 확인 대기 중인 주문이 유실됩니다.

이슈가 "개발 단계에서는 단일 워커라 즉시 수정하지 않음, **프로덕션 배포 전환 시점에 반드시 처리**"로 적어둔 항목입니다. 현재 단일 워커라 증상은 보이지 않지만 멀티워커·재시작에 대비합니다.

## 변경

`RedisPendingOrderStore`를 추가하고 `pending_orders`를 그것으로 교체했습니다.

- 키 패턴: `finus:pending_order:{chat_id}`
- TTL: `PENDING_ORDER_TTL_SEC` = 600초(10분)
- 직렬화: `asdict` + `created_at`을 isoformat으로 왕복

기존 Redis 관용구(`RedisSchedulerState`, `RedisKeys`, `create_redis_client`)를 그대로 재사용했습니다.

## Redis 장애 시 — fail-closed (인메모리 폴백 없음)

이 판단이 이 PR의 핵심입니다. 근거를 코드 주석에 남겼습니다:

- **폴백을 두면 멀티워커에서 원래 버그(프로세스 간 격리)가 그대로 재현**됩니다. 고치려는 문제를 되살리는 셈입니다.
- Redis 장애 시 예외가 호출자에게 전파되고 사용자는 `주문 저장소 오류: ...`라는 **명시적 오류**를 받습니다. 금전이 오가는 경로에서는 조용한 주문 유실보다 명시적 실패가 안전합니다.

`scheduler.py`의 Redis fallback은 **fail-open**인데, 그쪽은 멱등한 모니터링 작업이라 가능한 선택입니다. 주문 확인·취소에는 같은 기준을 적용할 수 없어 의도적으로 갈랐습니다.

## TTL 만료 후 "확인"을 누르면

**조용히 넘어가지 않습니다.** 앱 레벨 만료 체크(`_drop_expired_pending_order`)가 선행하고, Redis TTL은 stale 키 안전망입니다.

두 시간 값의 관계를 확인했습니다:

```
Redis TTL   : 600초
앱 만료 기준 : 60초 (ORDER_EXPIRES_AFTER, 기존 상수)
TTL >= 앱 만료 : True
```

TTL이 더 길어야 **앱이 아직 유효하다고 보는 주문이 Redis에서 먼저 사라지지 않습니다.** 순서가 뒤집히면 사용자가 60초 안에 확인해도 실패할 수 있습니다.

만료 후 동작은 테스트로 고정했습니다:
- `test_confirm_after_ttl_expiry_gives_explicit_error`
- `test_cancel_after_ttl_expiry_gives_explicit_error`
- `test_confirm_button_after_ttl_expiry_gives_stale_callback_text`

## 기존 테스트 호환

`InMemoryPendingOrderStore`가 동기 `__getitem__` 등을 제공해 `handler.pending_orders['123']` 형태의 기존 단언이 그대로 동작합니다. **기존 테스트를 수정하거나 삭제하지 않았습니다.**

## 검증 (직접 실행)

`pytest backend/` — **321 → 347 passed, 2 skipped** (실패 0건, +26건).

뮤테이션:

| 뮤턴트 | 결과 |
| --- | --- |
| TTL 설정 제거 (영구 키) | **2 failed** ✅ |
| Redis 저장 호출 제거 | **28 failed** ✅ |
| `chat_id` 키 분리 제거 (고정 키) | **3 failed** ✅ |
| 앱 레벨 만료 체크 제거 | **1 failed** ✅ |

세 번째가 chat 간 격리를, 네 번째가 "만료된 주문이 확인되지 않는다"를 각각 고정합니다.

## 범위 밖

이슈가 함께 언급한 `to_be_fixed.md` 항목 4(KIS access token Redis 이전)는 건드리지 않았습니다.

Closes #63
