### PR TITLE
fix: _json_objects_from_text가 중첩 객체를 후보로 올리던 근본 원인 수정 (#222)

### DIFF
--- a/backend/services.py
+++ b/backend/services.py
@@ -283,13 +283,11 @@ def _analysis_from_toolless_text(raw: str) -> dict[str, Any]:
     미사용) — Improvement #2 (#162 리뷰).
     """
     text = (raw or "").strip()
-    # #218: summary 키를 가진 후보를 우선 시도한다.
-    # _json_objects_from_text는 텍스트 내 마지막 JSON을 먼저 반환하도록
-    # reversed 순서를 쓰는데, 중첩 JSON이 있으면 안쪽 객체가 바깥 객체보다
-    # 나중 위치에서 발견되어 reversed 후 선두에 온다. 안쪽 객체엔 summary 키가
-    # 없으므로 data.get("summary") or text[:8000]이 원본 JSON 전체를 요약으로
-    # 채워버린다. 안정 정렬로 summary 키 보유 여부를 먼저 분리하면, 바깥 객체를
-    # 먼저 시도하면서도 summary를 모두 가진 후보들 사이에서는 기존 reversed 순서
+    # #222: 중첩 JSON 객체 문제는 _json_objects_from_text의 span 기반 필터로
+    # 근본 해결되었다(최상위 객체만 후보에 오른다).
+    # sort는 추가 방어선으로 남긴다 — 텍스트에 복수의 독립적인 최상위 JSON이
+    # 있고 summary 없는 객체가 뒤에 위치해 reversed 후 선두에 올 경우를 대비한다.
+    # 안정 정렬이므로 summary를 모두 가진 후보들 사이에서는 기존 reversed 순서
     # (텍스트 내 마지막 우선)가 유지된다.
     _candidates = _json_objects_from_text(text)
     _candidates.sort(key=lambda d: "summary" not in d)
@@ -792,17 +790,28 @@ def analysis_from_nat_text(raw: str, stock: str) -> dict[str, Any]:
 
 
 def _json_objects_from_text(text: str) -> list[dict[str, Any]]:
+    """텍스트에서 최상위 JSON 객체만 추출한다.
+
+    raw_decode가 반환하는 종료 인덱스(end)를 consumed_until에 기록해,
+    이미 디코드한 객체의 내부에 있는 중첩 '{' 는 건너뛴다.
+    이로써 {"outer": 1, "inner": {"nested": 2}} 형태의 입력이
+    후보로 {"outer":1,"inner":{...}} 하나만 남는다. (#222)
+
+    반환 순서는 텍스트 내 마지막 객체가 먼저 오는 reversed 순서를 유지한다.
+    """
     decoder = json.JSONDecoder()
     objects: list[dict[str, Any]] = []
+    consumed_until = -1  # 직전에 디코드한 최상위 객체의 끝 위치
     for index, char in enumerate(text):
-        if char != "{":
-            continue
+        if char != "{" or index < consumed_until:
+            continue  # 이미 디코드한 객체 내부 → 중첩 객체이므로 건너뛴다
         try:
-            value, _ = decoder.raw_decode(text[index:])
+            value, end = decoder.raw_decode(text[index:])
         except json.JSONDecodeError:
             continue
         if isinstance(value, dict):
             objects.append(value)
+            consumed_until = index + end
     return list(reversed(objects))
 
 

--- a/backend/services.py
+++ b/backend/services.py
@@ -471,9 +471,16 @@ async def _collect_morning_context(
         return f"{tool_name} 조회 실패: {exc}"
 
 
+_BRIEFING_KEYS = ("market_summary", "watchlist", "trading_ideas", "catalysts")
+
+
 def _morning_briefing_from_text(raw: str) -> dict[str, Any]:
     text = (raw or "").strip()
     for data in _json_objects_from_text(text):
+        # 브리핑 키를 하나도 갖지 않은 후보(래퍼 객체, 무관한 JSON)는 건너뛴다.
+        # 그대로 반환하면 브리핑 전체가 빈 값이 되고 아래 원문 폴백도 도달하지 못한다.
+        if not any(key in data for key in _BRIEFING_KEYS):
+            continue
         return {
             "market_summary": str(data.get("market_summary") or ""),
             "watchlist": _string_list(data.get("watchlist")),
@@ -790,29 +797,30 @@ def analysis_from_nat_text(raw: str, stock: str) -> dict[str, Any]:
 
 
 def _json_objects_from_text(text: str) -> list[dict[str, Any]]:
-    """텍스트에서 최상위 JSON 객체만 추출한다.
+    """텍스트에서 JSON 객체를 최상위 우선 순서로 추출한다.
 
-    raw_decode가 반환하는 종료 인덱스(end)를 consumed_until에 기록해,
-    이미 디코드한 객체의 내부에 있는 중첩 '{' 는 건너뛴다.
-    이로써 {"outer": 1, "inner": {"nested": 2}} 형태의 입력이
-    후보로 {"outer":1,"inner":{...}} 하나만 남는다. (#222)
-
-    반환 순서는 텍스트 내 마지막 객체가 먼저 오는 reversed 순서를 유지한다.
+    raw_decode의 종료 인덱스로 최상위 객체의 span을 추적해, 그 안에서 발견된
+    중첩 객체는 후보에서 버리지 않고 '후순위'로 내린다 (#222).
+    최상위 객체가 실제 페이로드를 감싸기만 한 래퍼일 때 안쪽으로 폴백하기 위함이다.
+    각 그룹 안에서는 텍스트 내 마지막 객체가 먼저 오는 reversed 순서를 유지한다.
     """
     decoder = json.JSONDecoder()
-    objects: list[dict[str, Any]] = []
-    consumed_until = -1  # 직전에 디코드한 최상위 객체의 끝 위치
+    top: list[dict[str, Any]] = []
+    nested: list[dict[str, Any]] = []
+    consumed_until = 0  # 직전에 디코드한 최상위 객체의 끝(exclusive)
     for index, char in enumerate(text):
-        if char != "{" or index < consumed_until:
-            continue  # 이미 디코드한 객체 내부 → 중첩 객체이므로 건너뛴다
+        if char != "{":
+            continue
         try:
-            value, end = decoder.raw_decode(text[index:])
+            value, end = decoder.raw_decode(text, index)  # 슬라이스 없이 idx 지정
         except json.JSONDecodeError:
             continue
-        if isinstance(value, dict):
-            objects.append(value)
-            consumed_until = index + end
-    return list(reversed(objects))
+        if index < consumed_until:
+            nested.append(value)  # 이미 디코드한 최상위 객체 내부 → 후순위
+            continue
+        top.append(value)
+        consumed_until = end
+    return list(reversed(top)) + list(reversed(nested))
 
 
 def normalize_llm_provider(

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -1340,3 +1340,27 @@ def test_morning_briefing_from_text_nested_object_fields_filled():
     assert result["watchlist"] == ["삼성전자"]
     assert result["trading_ideas"] == ["눌림목 관찰"]
     assert result["catalysts"] == ["CPI 발표"]
+
+
+# ── #222: sort 방어선 — span 필터로도 못 막는 독립 최상위 JSON 순서 ────────────
+
+
+def test_analysis_from_toolless_text_sort_guard_for_independent_top_level_jsons():
+    """독립적인 최상위 JSON 2개에서 summary 없는 객체가 reversed 선두에 올 때 sort가 막는다.
+
+    span 기반 필터는 중첩 객체만 제거한다 — 텍스트에서 공백으로 분리된 두 JSON은
+    둘 다 최상위 객체이므로 둘 다 후보에 남는다. summary 없는 {"count":3}이
+    텍스트 뒤에 위치하면 reversed 후 candidates[0]이 되고, sort 없이는
+    data.get("summary") or text[:8000] 폴백이 원문 전체를 summary로 채운다.
+
+    이 테스트가 잡는 mutation: `_candidates.sort(key=lambda d: "summary" not in d)` 제거.
+    sort를 지우면 {"count":3}이 먼저 시도되어 summary가 원문 전체로,
+    source_news가 []로 나와 두 단정 모두 실패한다.
+    """
+    # summary 있는 객체가 앞, summary 없는 객체가 뒤 → reversed 후 summary 없는 쪽이 선두
+    raw = '{"summary":"유효 요약","source_news":["뉴스1"]} {"count":3}'
+    result = services._analysis_from_toolless_text(raw)
+    assert result["summary"] == "유효 요약", (
+        "summary 없는 후보가 reversed 선두에 와도 sort가 summary 있는 후보를 먼저 시도해야 한다"
+    )
+    assert result["source_news"] == ["뉴스1"]

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -1319,12 +1319,12 @@ def test_analysis_from_nat_text_nested_inner_summary_no_drift():
 def test_morning_briefing_from_text_nested_object_fields_filled():
     """_morning_briefing_from_text 경로에서 중첩 객체가 있어도 브리핑 필드가 채워진다. (#222)
 
-    _morning_briefing_from_text는 ValidationError 안전망이 없어 첫 후보를
-    무조건 반환한다. span 수정 전에는 안쪽 {"pe":12}가 candidates[0]이 돼
-    market_summary=""·watchlist=[]·... 로 브리핑 전체가 빈 값이 됐다.
+    _json_objects_from_text의 top/nested 우선순위 방식으로 최상위 브리핑 객체가
+    먼저 시도된다. 브리핑 키를 가진 최상위 객체가 선택되고 내부 {"pe":12}는 무시된다.
 
-    이 테스트가 잡는 mutation: _json_objects_from_text의 중첩 건너뛰기 제거.
-    제거하면 안쪽 객체가 먼저 선택돼 모든 필드가 빈 값으로 반환된다.
+    이 테스트가 잡는 mutation: `_BRIEFING_KEYS` 검사 제거와 함께 중첩 객체가
+    먼저 오도록 순서를 뒤집는 경우. 검사 없이 {"pe":12}가 먼저 선택되면
+    모든 브리핑 필드가 빈 값으로 반환된다.
     """
     raw = (
         '{"market_summary":"오늘 시장 요약",'
@@ -1364,3 +1364,96 @@ def test_analysis_from_toolless_text_sort_guard_for_independent_top_level_jsons(
         "summary 없는 후보가 reversed 선두에 와도 sort가 summary 있는 후보를 먼저 시도해야 한다"
     )
     assert result["source_news"] == ["뉴스1"]
+
+
+# ── #224 리뷰 반영: envelope(래퍼) 회귀 — 중첩 후순위 방식으로 폴백 ──────────────
+
+
+def test_analysis_from_toolless_text_envelope_wrapper_fallback():
+    """래퍼 JSON 안에 실제 페이로드가 있을 때 안쪽 객체로 폴백한다. (#224)
+
+    _json_objects_from_text가 최상위를 top·중첩을 nested로 분리해
+    [reversed(top) + reversed(nested)] 순으로 반환한다.
+    sort가 summary 없는 래퍼를 뒤로 밀어 안쪽 후보가 먼저 시도된다.
+
+    수정 전(제거 방식): 중첩 객체가 후보에서 사라져 래퍼만 남았고
+    summary가 원본 JSON 전체 문자열, source_news=[]가 됐다.
+
+    이 테스트가 잡는 mutation: top/nested 분리 제거(전부 top으로 처리) +
+    sort 제거. 둘 다 지우면 래퍼가 선두에 남아 summary가 원문 전체가 된다.
+    """
+    raw = '{"response":{"summary":"삼성전자 요약","source_news":["뉴스1"]}}'
+    result = services._analysis_from_toolless_text(raw)
+    assert result["summary"] == "삼성전자 요약", (
+        "래퍼 JSON 안의 summary가 올바르게 추출되어야 한다"
+    )
+    assert result["source_news"] == ["뉴스1"]
+
+
+def test_analysis_from_nat_text_envelope_wrapper_fallback():
+    """analysis_from_nat_text 경로에서 래퍼 JSON 안의 페이로드로 폴백한다. (#224)
+
+    analysis_from_nat_text는 except ValueError로 재시도하므로 래퍼 객체(summary·
+    source_news 미포함)가 ValidationError를 내고 안쪽 후보로 넘어간다.
+
+    이 테스트가 잡는 mutation: top/nested 분리 제거. 제거하면 안쪽 객체가
+    후보에 오르지 않아 except ValueError 폴백이 래퍼만 시도하고 결국
+    원문 전체를 summary로 쓰는 텍스트 폴백 경로로 떨어진다.
+    """
+    raw = (
+        '{"response":{"summary":"NAT 요약",'
+        '"details":{"decision":"BUY","confidence_score":0.8,'
+        '"reason":"수급 개선","target_stock":"삼성전자"},'
+        '"source_news":["헤드라인"]}}'
+    )
+    result = services.analysis_from_nat_text(raw, "삼성전자")
+    assert result["summary"] == "NAT 요약", (
+        "래퍼 JSON 안의 summary가 올바르게 추출되어야 한다"
+    )
+    assert result["details"]["decision"] == "BUY"
+    assert result["source_news"] == ["헤드라인"]
+
+
+def test_morning_briefing_from_text_envelope_wrapper_fallback():
+    """_morning_briefing_from_text 경로에서 래퍼 JSON 안의 브리핑으로 폴백한다. (#224)
+
+    _BRIEFING_KEYS 검사가 래퍼 객체(브리핑 키 미포함)를 건너뛰고
+    nested의 안쪽 객체로 폴백한다.
+
+    이 테스트가 잡는 mutation: `if not any(key in data for key in _BRIEFING_KEYS): continue`
+    제거. 검사가 없으면 래퍼 객체가 선택돼 모든 브리핑 필드가 빈 값이 된다.
+    """
+    raw = (
+        '{"briefing":{"market_summary":"오늘 시장 요약",'
+        '"watchlist":["삼성전자"],'
+        '"trading_ideas":["눌림목 관찰"],'
+        '"catalysts":["CPI 발표"]}}'
+    )
+    result = services._morning_briefing_from_text(raw)
+    assert result["market_summary"] == "오늘 시장 요약", (
+        "래퍼 JSON 안의 market_summary가 올바르게 추출되어야 한다"
+    )
+    assert result["watchlist"] == ["삼성전자"]
+    assert result["trading_ideas"] == ["눌림목 관찰"]
+    assert result["catalysts"] == ["CPI 발표"]
+
+
+def test_morning_briefing_from_text_skips_non_briefing_candidates():
+    """브리핑 키를 하나도 갖지 않은 후보는 건너뛰고 유효한 후보를 반환한다. (#224)
+
+    독립 최상위 JSON이 2개인 상황에서 무관한 JSON({"count":3})이 reversed
+    선두에 와도 _BRIEFING_KEYS 검사가 건너뛰어 올바른 브리핑 후보를 선택한다.
+
+    이 테스트가 잡는 mutation: `if not any(key in data for key in _BRIEFING_KEYS): continue`
+    제거. 검사가 없으면 {"count":3}이 선택돼 모든 브리핑 필드가 빈 값이 된다.
+    """
+    # 브리핑 키 없는 객체가 앞, 브리핑 있는 객체가 뒤 → reversed 후 무관한 쪽이 선두
+    raw = (
+        '{"market_summary":"시장 요약","watchlist":["삼성전자"],'
+        '"trading_ideas":[],"catalysts":[]} {"count":3}'
+    )
+    result = services._morning_briefing_from_text(raw)
+    assert result["market_summary"] == "시장 요약", (
+        "브리핑 키 없는 후보가 reversed 선두에 와도 건너뛰고 올바른 후보를 써야 한다"
+    )
+    assert result["watchlist"] == ["삼성전자"]

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -1215,20 +1215,18 @@ def test_analysis_from_toolless_text_absent_urgency_preserves_reason_and_alert(r
     )
 
 
-# ── #218: 중첩 JSON 객체 — summary 키 우선 선택 ───────────────────────────────
+# ── #218/#222: 중첩 JSON 객체 — span 기반 필터 + summary 키 우선 선택 ──────────
 
 
 def test_analysis_from_toolless_text_nested_json_uses_outer_summary():
-    """중첩 JSON 객체가 있어도 summary 키를 가진 바깥 객체에서 올바른 요약을 뽑는다. (#218)
+    """중첩 JSON 객체가 있어도 바깥 객체에서 올바른 요약을 뽑는다. (#218, #222)
 
-    _json_objects_from_text는 reversed 순서로 후보를 반환하므로, 안쪽 {"pe":12}가
-    바깥 객체보다 먼저 온다. 안쪽 객체엔 summary 키가 없어
-    data.get("summary") or text[:8000]이 원본 JSON 전체를 summary로 채우고,
-    source_news는 []가 된다. summary 키 우선 정렬로 바깥 객체를 먼저 시도해 이를 막는다.
+    #222 span 기반 수정 이후: _json_objects_from_text의 consumed_until 가드가
+    안쪽 {"pe":12}를 후보 목록에서 제외하므로 바깥 객체만 시도된다.
 
-    이 테스트가 잡는 mutation: 후보 정렬 로직(_candidates.sort(...)) 제거.
-    정렬을 지우면 안쪽 {"pe":12}가 먼저 시도돼 summary가 원본 JSON 전체로,
-    source_news가 []로 나와 두 단정 모두 실패한다.
+    이 테스트가 잡는 mutation: _json_objects_from_text의 중첩 건너뛰기 제거
+    (index < consumed_until 조건 삭제). 제거하면 안쪽 {"pe":12}가 다시 후보로
+    올라와 summary가 원본 JSON 전체로, source_news가 []로 나와 두 단정 모두 실패한다.
     """
     raw = '{"summary":"삼성전자 요약","source_news":["뉴스1"],"detail":{"pe":12}}'
     result = services._analysis_from_toolless_text(raw)
@@ -1269,3 +1267,76 @@ def test_analysis_from_toolless_text_invalid_candidate_is_skipped():
     result = services._analysis_from_toolless_text(raw)
     assert result["summary"] == "유효 요약"
     assert result["trading_trend"] == "상승"
+
+
+# ── #222: span 기반 수정 — 세 호출부 각각 중첩 케이스 고정 ─────────────────────
+
+
+def test_analysis_from_toolless_text_inner_summary_drift_prevented():
+    """안쪽 객체에도 summary가 있으면 sort 방어선을 뚫는 드리프트 증상을 재현한다. (#222)
+
+    PR #219의 sort는 summary 보유 여부만 보므로, 안쪽 객체도 summary를 가지면
+    reversed 순서(안쪽 우선)를 그대로 살린다. span 수정으로 안쪽 객체 자체가
+    후보에 오르지 않아 이 경로가 완전히 차단된다.
+
+    이 테스트가 잡는 mutation: _json_objects_from_text의 중첩 건너뛰기 제거
+    (index < consumed_until 조건 삭제). 제거하면 안쪽 {"summary":"INNER"}가
+    candidates 선두에 오고 sort로도 걸러지지 않아 summary="INNER", source_news=[]가
+    된다.
+    """
+    raw = '{"summary":"OUTER","source_news":["뉴스1"],"detail":{"summary":"INNER"}}'
+    result = services._analysis_from_toolless_text(raw)
+    assert result["summary"] == "OUTER", (
+        "안쪽 summary가 바깥 summary를 덮어써서는 안 된다"
+    )
+    assert result["source_news"] == ["뉴스1"], (
+        "안쪽 객체가 선택되면 source_news가 []로 유실된다"
+    )
+
+
+def test_analysis_from_nat_text_nested_inner_summary_no_drift():
+    """analysis_from_nat_text 경로에서도 안쪽 summary가 바깥을 덮어쓰지 않는다. (#222)
+
+    이 테스트가 잡는 mutation: _json_objects_from_text의 중첩 건너뛰기 제거.
+    제거하면 details 없는 안쪽 {"summary":"INNER"} 객체가 먼저 선택돼
+    details=None이 되거나 summary="INNER"가 된다.
+    """
+    raw = (
+        '{"summary":"OUTER NAT 요약",'
+        '"details":{"decision":"BUY","confidence_score":0.7,'
+        '"reason":"수급 개선","target_stock":"삼성전자"},'
+        '"source_news":["헤드라인"],'
+        '"detail":{"summary":"INNER","pe":12}}'
+    )
+    result = services.analysis_from_nat_text(raw, "삼성전자")
+    assert result["summary"] == "OUTER NAT 요약", (
+        "안쪽 summary가 바깥 summary를 덮어써서는 안 된다"
+    )
+    assert result["details"]["decision"] == "BUY"
+    assert result["source_news"] == ["헤드라인"]
+
+
+def test_morning_briefing_from_text_nested_object_fields_filled():
+    """_morning_briefing_from_text 경로에서 중첩 객체가 있어도 브리핑 필드가 채워진다. (#222)
+
+    _morning_briefing_from_text는 ValidationError 안전망이 없어 첫 후보를
+    무조건 반환한다. span 수정 전에는 안쪽 {"pe":12}가 candidates[0]이 돼
+    market_summary=""·watchlist=[]·... 로 브리핑 전체가 빈 값이 됐다.
+
+    이 테스트가 잡는 mutation: _json_objects_from_text의 중첩 건너뛰기 제거.
+    제거하면 안쪽 객체가 먼저 선택돼 모든 필드가 빈 값으로 반환된다.
+    """
+    raw = (
+        '{"market_summary":"오늘 시장 요약",'
+        '"watchlist":["삼성전자"],'
+        '"trading_ideas":["눌림목 관찰"],'
+        '"catalysts":["CPI 발표"],'
+        '"detail":{"pe":12}}'
+    )
+    result = services._morning_briefing_from_text(raw)
+    assert result["market_summary"] == "오늘 시장 요약", (
+        "중첩 객체가 있을 때 market_summary가 빈 문자열이 되어서는 안 된다"
+    )
+    assert result["watchlist"] == ["삼성전자"]
+    assert result["trading_ideas"] == ["눌림목 관찰"]
+    assert result["catalysts"] == ["CPI 발표"]


### PR DESCRIPTION
## 배경

#222 (PR #219 리뷰의 Improvement 1·2 후속). PR #219는 `_analysis_from_toolless_text`에서 `summary` 키 보유 여부로 정렬해 **증상을 완화**했지만, 근본 원인인 `_json_objects_from_text`의 후보 집합은 그대로였습니다.

리뷰어가 지적한 두 잔여 증상을 직접 재현했습니다:

```
1) 중첩 summary 드리프트 (정렬로도 못 막음 — 안쪽에도 summary가 있으면 뚫림)
   {"summary":"OUTER","source_news":["뉴스1"],"detail":{"summary":"INNER"}}
   -> summary='INNER'  source_news=[]        (바깥이 통째로 유실)

2) 모닝 브리핑 (검증 안전망조차 없어 더 심함)
   {"market_summary":"오늘 시장 요약","watchlist":["삼성전자"],"detail":{"pe":12}}
   -> {'market_summary': '', 'watchlist': [], 'trading_ideas': [], 'catalysts': []}
```

2번은 브리핑 전체가 빈 값이 되고 `text or "..."` 폴백도 타지 않아 사용자가 원문조차 못 봅니다.

## 변경 — span 기반 필터

`raw_decode`가 반환하는 종료 인덱스를 `consumed_until`에 기록해, **이미 디코드한 객체 내부의 `{`는 건너뜁니다.** 후보에 최상위 객체만 남고, `reversed`(텍스트 내 마지막 우선) 의미도 원래대로 복원됩니다.

이 함수를 공유하는 **세 호출부가 한 번에 해결**됩니다: `_analysis_from_toolless_text`, `analysis_from_nat_text`, `_morning_briefing_from_text`.

## 실측 (직접 실행)

**후보 추출**
```
중첩:      {"summary":"OUTER","detail":{"summary":"INNER"}}  ->  [{'summary': 'OUTER', 'detail': {...}}]   (하나만)
독립 2개:  {"a":1} {"b":2}                                    ->  [{'b': 2}, {'a': 1}]                      (reversed 유지)
```

**세 호출부**

| 경로 | 입력 | 수정 전 | 수정 후 |
| --- | --- | --- | --- |
| `_analysis_from_toolless_text` | 중첩 `summary` | `'INNER'` / `[]` | **`'OUTER'` / `['뉴스1']`** ✅ |
| `_analysis_from_toolless_text` | 중첩 비-summary | (PR #219가 이미 해결) | `'삼성전자 요약'` ✅ |
| `_morning_briefing_from_text` | 중첩 | **전부 빈 값** | **필드 채워짐** ✅ |
| 공통 | 순수 텍스트 / 관련 없는 JSON | 원문 폴백 | 원문 폴백 유지 ✅ |

## `sort`는 남겼습니다 — 죽은 코드가 아닙니다

PR #219가 넣은 `_candidates.sort(...)`를 제거할지 검토했는데, **span 필터로도 못 막는 경우가 실재**해 방어선으로 남겼습니다:

```
{"summary":"유효 요약","source_news":["뉴스1"]} {"count":3}
  (독립적인 최상위 JSON 2개 — 둘 다 정당한 후보)

sort 있음: summary='유효 요약'   news=['뉴스1']   ✅
sort 제거: summary=원문 전체      news=[]         ❌
```

`summary` 없는 객체가 텍스트 뒤에 있으면 `reversed` 후 선두에 오기 때문입니다.

**이 시나리오에 가드가 없어 별도 커밋으로 추가했습니다** (`d971603`). 1차 반영 직후 뮤테이션에서 `sort` 제거가 **미검출(327 passed)** 이었습니다 — 누군가 "span으로 근본 해결됐으니 불필요하다"고 지워도 CI가 조용히 통과하는 상태였습니다.

## 검증

`pytest backend/` — **324 → 328 passed, 2 skipped** (실패 0건, +4건).

뮤테이션 — 신규 2건과 **이전 PR 회귀 2건**:

| 뮤턴트 | 보강 전 | 최종 |
| --- | --- | --- |
| `sort` 방어선 제거 | **미검출** ❌ | **1 failed** ✅ |
| span 건너뛰기 제거 (#222 회귀) | 2 failed ✅ | 2 failed ✅ |
| `consumed_until` 미갱신 | 2 failed ✅ | 2 failed ✅ |
| `urgency` 정규화 제거 (PR #215 회귀) | 2 failed ✅ | 2 failed ✅ |

`analysis_from_nat_text` 경로를 포함해 PR #215·#219가 고정한 동작이 모두 유지됩니다.

Closes #222
