### PR TITLE
refactor: KIS 래퍼 중복 제거 및 tool_name 정규화 일원화 (#220)

### DIFF
--- a/finus_nat/src/nat_finus_nat/finus_api.py
+++ b/finus_nat/src/nat_finus_nat/finus_api.py
@@ -654,6 +654,18 @@ def _coerce_api_type_params_payload(tool_input: Any, kwargs: dict[str, Any]) -> 
     return None
 
 
+# Kis Trading MCP list_tools에 실제로 존재하는 도구 이름 전체 집합.
+# FinusAccountBalanceConfig.trading_tool_name 검증에 사용한다 — 설정 시점에
+# 허용 목록 밖의 값을 빠르게 감지해 readonly 래퍼 전면 차단 사고를 예방한다.
+# _READONLY_TOOL_ALLOWLIST와 달리 auth를 포함한다:
+#   readonly 래퍼는 auth를 차단하지만, 전체 권한 래퍼(finus_account_balance)는 허용한다.
+_KIS_TRADING_TOOL_NAMES: frozenset[str] = frozenset({
+    "domestic_stock", "overseas_stock", "domestic_bond",
+    "domestic_futureoption", "overseas_futureoption", "elw", "etfetn",
+    "auth",
+})
+
+
 class FinusAccountBalanceConfig(FunctionBaseConfig, name="finus_account_balance"):
     """원격 Kis Trading MCP — `call_tool` 에 `api_type`·`params` 만 전달.
 
@@ -676,6 +688,22 @@ class FinusAccountBalanceConfig(FunctionBaseConfig, name="finus_account_balance"
             "``list_tools`` 이름과 동일해야 합니다."
         ),
     )
+
+    @model_validator(mode="after")
+    def _validate_trading_tool_name(self) -> "FinusAccountBalanceConfig":
+        """FINUS_KIS_TRADING_TOOL_NAME 환경변수 등으로 잘못된 값이 들어올 때 설정 시점에 감지한다.
+
+        허용 목록 밖의 값이면 readonly 래퍼가 전면 차단되므로, 런타임 첫 호출까지 기다리지 않고
+        Config 로드 시점에 ValidationError를 발생시켜 조기에 알린다.
+        빈 문자열은 런타임에 ``kis_tool_name_missing`` 에러로 처리되므로 여기서는 허용한다.
+        """
+        name = (self.trading_tool_name or "").strip().lower()
+        if name and name not in _KIS_TRADING_TOOL_NAMES:
+            raise ValueError(
+                f"trading_tool_name={self.trading_tool_name!r}는 허용하지 않는 Kis MCP 도구 이름입니다. "
+                f"허용 목록: {sorted(_KIS_TRADING_TOOL_NAMES)}"
+            )
+        return self
 
 
 def _adjust_domestic_stock_params(api_type: str, params: dict[str, Any]) -> dict[str, Any]:
@@ -717,10 +745,13 @@ def _prepare_kis_trading_mcp_call(
         )
     blob = dict(blob)
     tool_from_blob = blob.pop("tool_name", None)
+    # tool_name을 소문자로 정규화한다 (#220).
+    # _is_readonly_tool_name·_adjust_domestic_stock_params 판정뿐 아니라
+    # _mcp_call_tool_remote에 전달되는 값도 MCP 서버가 기대하는 소문자여야 한다.
     tool_name = (
-        (inp.tool_name or "").strip()
-        or (str(tool_from_blob).strip() if tool_from_blob is not None else "")
-        or (config.trading_tool_name or "").strip()
+        (inp.tool_name or "").strip().lower()
+        or (str(tool_from_blob).strip().lower() if tool_from_blob is not None else "")
+        or (config.trading_tool_name or "").strip().lower()
     )
     if not tool_name:
         return _err_json(
@@ -732,7 +763,7 @@ def _prepare_kis_trading_mcp_call(
         return _err_json("kis_mcp_missing_api_type", tool=tool_name, blob_keys=list(blob.keys()))
     raw_params = blob.get("params")
     params: dict[str, Any] = raw_params if isinstance(raw_params, dict) else {}
-    if (tool_name or "").strip() == "domestic_stock":
+    if tool_name == "domestic_stock":
         params = _adjust_domestic_stock_params(str(api_type).strip(), params)
     return tool_name, {"api_type": str(api_type).strip(), "params": params}
 
@@ -817,6 +848,45 @@ def _is_readonly_tool_name(tool_name: str) -> bool:
     return (tool_name or "").strip().lower() in _READONLY_TOOL_ALLOWLIST
 
 
+# ---- 두 KIS 래퍼(전체/readonly) 공통 헬퍼 (#220) ----
+
+async def _call_kis_mcp_and_record(
+    tool_name: str,
+    arguments: McpCallArguments,
+    config: FinusAccountBalanceConfig,
+) -> str:
+    """원격 MCP 호출 후 원장에 기록한다 — finus_account_balance·readonly 공유.
+
+    두 래퍼가 개별로 _mcp_call_tool_remote + _record_to_ledger(_KIS_BALANCE_LEDGER_NAME)를
+    중복 구현하는 것을 이 헬퍼 한 곳으로 모은다.
+    """
+    result = await _mcp_call_tool_remote(
+        transport=config.mcp_transport,
+        url=config.mcp_url,
+        tool_name=tool_name,
+        arguments=arguments,
+        timeout_sec=config.timeout_sec,
+    )
+    _record_to_ledger(_KIS_BALANCE_LEDGER_NAME, result)
+    return result
+
+
+async def _build_kis_mcp_description(doc: str, config: FinusAccountBalanceConfig) -> str:
+    """description 문자열 조립 — finus_account_balance·readonly 공유 (#220).
+
+    base_doc + _KIS_TRADING_TOOL_GUIDE + (원격 MCP list_tools 문서) 를 합쳐
+    LangChain 중괄호 이스케이프 적용 후 반환한다.
+    """
+    base = doc.strip()
+    remote = await _fetch_mcp_tool_documentation(config)
+    merged = (
+        f"{base}\n\n{_KIS_TRADING_TOOL_GUIDE}\n\n{remote}"
+        if remote
+        else f"{base}\n\n{_KIS_TRADING_TOOL_GUIDE}"
+    )
+    return _langchain_escape_braces(merged)
+
+
 class FinusAccountBalanceReadonlyConfig(FinusAccountBalanceConfig, name="finus_account_balance_readonly"):
     """finus_account_balance 조회 전용 래퍼 — allowlist 방식 api_type 차단 (#66).
 
@@ -871,26 +941,12 @@ async def finus_account_balance_readonly(config: FinusAccountBalanceReadonlyConf
             )
             _record_to_ledger(_KIS_BALANCE_LEDGER_NAME, result)
             return result
-        result = await _mcp_call_tool_remote(
-            transport=config.mcp_transport,
-            url=config.mcp_url,
-            tool_name=tool_name,
-            arguments=arguments,
-            timeout_sec=config.timeout_sec,
-        )
-        _record_to_ledger(_KIS_BALANCE_LEDGER_NAME, result)
-        return result
+        return await _call_kis_mcp_and_record(tool_name, arguments, config)
 
-    base_desc = (get_account_balance_readonly.__doc__ or "").strip()
-    remote = await _fetch_mcp_tool_documentation(config)
-    merged = (
-        f"{base_desc}\n\n{_KIS_TRADING_TOOL_GUIDE}\n\n{remote}"
-        if remote
-        else f"{base_desc}\n\n{_KIS_TRADING_TOOL_GUIDE}"
-    )
+    description = await _build_kis_mcp_description(get_account_balance_readonly.__doc__ or "", config)
     yield FunctionInfo.from_fn(
         get_account_balance_readonly,
-        description=_langchain_escape_braces(merged),
+        description=description,
         input_schema=KisTradingMcpCallInput,
     )
 
@@ -1263,21 +1319,11 @@ async def finus_account_balance(config: FinusAccountBalanceConfig, _builder: Bui
             _record_to_ledger(_KIS_BALANCE_LEDGER_NAME, prepared)
             return prepared
         tool_name, arguments = prepared
-        result = await _mcp_call_tool_remote(
-            transport=config.mcp_transport,
-            url=config.mcp_url,
-            tool_name=tool_name,
-            arguments=arguments,
-            timeout_sec=config.timeout_sec,
-        )
-        _record_to_ledger(_KIS_BALANCE_LEDGER_NAME, result)
-        return result
+        return await _call_kis_mcp_and_record(tool_name, arguments, config)
 
-    base_desc = (get_account_balance.__doc__ or "").strip()
-    remote = await _fetch_mcp_tool_documentation(config)
-    merged = f"{base_desc}\n\n{_KIS_TRADING_TOOL_GUIDE}\n\n{remote}" if remote else f"{base_desc}\n\n{_KIS_TRADING_TOOL_GUIDE}"
+    description = await _build_kis_mcp_description(get_account_balance.__doc__ or "", config)
     yield FunctionInfo.from_fn(
         get_account_balance,
-        description=_langchain_escape_braces(merged),
+        description=description,
         input_schema=KisTradingMcpCallInput,
     )

--- a/finus_nat/src/nat_finus_nat/finus_api.py
+++ b/finus_nat/src/nat_finus_nat/finus_api.py
@@ -8,7 +8,7 @@ from contextlib import asynccontextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal, NamedTuple, TypeAlias
+from typing import Any, ClassVar, Literal, NamedTuple, TypeAlias
 
 import httpx
 from mcp import ClientSession
@@ -654,16 +654,17 @@ def _coerce_api_type_params_payload(tool_input: Any, kwargs: dict[str, Any]) -> 
     return None
 
 
-# Kis Trading MCP list_tools에 실제로 존재하는 도구 이름 전체 집합.
-# FinusAccountBalanceConfig.trading_tool_name 검증에 사용한다 — 설정 시점에
-# 허용 목록 밖의 값을 빠르게 감지해 readonly 래퍼 전면 차단 사고를 예방한다.
-# _READONLY_TOOL_ALLOWLIST와 달리 auth를 포함한다:
-#   readonly 래퍼는 auth를 차단하지만, 전체 권한 래퍼(finus_account_balance)는 허용한다.
-_KIS_TRADING_TOOL_NAMES: frozenset[str] = frozenset({
+# 조회 전용 래퍼(finus_account_balance_readonly)가 허용하는 MCP tool_name 허용 목록 (fail-closed).
+# auth는 조회 목적이 없고 인증 상태를 바꿀 수 있어 제외한다.
+_READONLY_TOOL_ALLOWLIST: frozenset[str] = frozenset({
     "domestic_stock", "overseas_stock", "domestic_bond",
     "domestic_futureoption", "overseas_futureoption", "elw", "etfetn",
-    "auth",
 })
+
+# Kis Trading MCP list_tools에 실제로 존재하는 도구 이름 전체 집합.
+# readonly 허용 목록 + auth — 전체 권한 래퍼(finus_account_balance)만 auth를 허용한다.
+# FinusAccountBalanceConfig._ALLOWED_TOOL_NAMES의 기본값으로 사용한다.
+_KIS_TRADING_TOOL_NAMES: frozenset[str] = _READONLY_TOOL_ALLOWLIST | {"auth"}
 
 
 class FinusAccountBalanceConfig(FunctionBaseConfig, name="finus_account_balance"):
@@ -671,6 +672,10 @@ class FinusAccountBalanceConfig(FunctionBaseConfig, name="finus_account_balance"
 
     `tool_name` 생략 시 YAML `trading_tool_name`. Upstream: `open-trading-api`/`MCP/Kis Trading MCP`.
     """
+
+    # 이 Config가 허용하는 trading_tool_name 집합 — 서브클래스가 좁힐 수 있다.
+    # FinusAccountBalanceReadonlyConfig는 _READONLY_TOOL_ALLOWLIST로 오버라이드해 auth를 제외한다.
+    _ALLOWED_TOOL_NAMES: ClassVar[frozenset[str]] = _KIS_TRADING_TOOL_NAMES
 
     timeout_sec: float = Field(default=180.0, ge=5.0, le=600.0)
     mcp_transport: Literal["sse", "streamable-http"] = Field(
@@ -693,15 +698,17 @@ class FinusAccountBalanceConfig(FunctionBaseConfig, name="finus_account_balance"
     def _validate_trading_tool_name(self) -> "FinusAccountBalanceConfig":
         """FINUS_KIS_TRADING_TOOL_NAME 환경변수 등으로 잘못된 값이 들어올 때 설정 시점에 감지한다.
 
-        허용 목록 밖의 값이면 readonly 래퍼가 전면 차단되므로, 런타임 첫 호출까지 기다리지 않고
-        Config 로드 시점에 ValidationError를 발생시켜 조기에 알린다.
+        허용 목록 밖의 값이면 Config 로드 시점에 ValidationError를 발생시켜 조기에 알린다.
+        서브클래스는 _ALLOWED_TOOL_NAMES를 오버라이드해 허용 범위를 좁힌다
+        (예: readonly 래퍼는 auth를 제외한 7종만 허용).
         빈 문자열은 런타임에 ``kis_tool_name_missing`` 에러로 처리되므로 여기서는 허용한다.
         """
         name = (self.trading_tool_name or "").strip().lower()
-        if name and name not in _KIS_TRADING_TOOL_NAMES:
+        if name and name not in self._ALLOWED_TOOL_NAMES:
             raise ValueError(
-                f"trading_tool_name={self.trading_tool_name!r}는 허용하지 않는 Kis MCP 도구 이름입니다. "
-                f"허용 목록: {sorted(_KIS_TRADING_TOOL_NAMES)}"
+                f"trading_tool_name={self.trading_tool_name!r}는 이 래퍼가 허용하지 않는 "
+                f"Kis MCP 도구 이름입니다. 허용 목록: {sorted(self._ALLOWED_TOOL_NAMES)}. "
+                f"MCP 서버에 새 도구가 추가되었다면 finus_api.py의 _KIS_TRADING_TOOL_NAMES에 등록하세요."
             )
         return self
 
@@ -808,14 +815,8 @@ _KIS_BALANCE_LEDGER_NAME: str = "finus_account_balance"
 _READONLY_API_ALLOWLIST_PREFIXES: tuple[str, ...] = ("inquire_", "search_")
 _READONLY_API_ALLOWLIST_EXACT: frozenset[str] = frozenset({"find_api_detail"})
 
-# 조회 전용 래퍼가 허용하는 MCP tool_name 허용 목록. fail-closed: 목록 밖의 tool_name은 차단.
-# api_type 게이트가 주문을 막으므로, tool_name은 조회 대상 자산군을 넓게 허용한다.
-# auth는 조회 목적이 없고 인증 상태를 바꿀 수 있어 제외한다.
-# trading_agent.yml·KisTradingMcpCallInput에 나열된 자산군 8종 중 auth만 제외한 7종.
-_READONLY_TOOL_ALLOWLIST: frozenset[str] = frozenset({
-    "domestic_stock", "overseas_stock", "domestic_bond",
-    "domestic_futureoption", "overseas_futureoption", "elw", "etfetn",
-})
+# _READONLY_TOOL_ALLOWLIST는 _KIS_TRADING_TOOL_NAMES와 함께 위에서 정의되어 있다.
+# (FinusAccountBalanceConfig 클래스 정의 직전 — 단일 출처 유지를 위해 이동)
 
 
 def _is_readonly_api_type(api_type: str) -> bool:
@@ -874,7 +875,7 @@ async def _call_kis_mcp_and_record(
 async def _build_kis_mcp_description(doc: str, config: FinusAccountBalanceConfig) -> str:
     """description 문자열 조립 — finus_account_balance·readonly 공유 (#220).
 
-    base_doc + _KIS_TRADING_TOOL_GUIDE + (원격 MCP list_tools 문서) 를 합쳐
+    doc + _KIS_TRADING_TOOL_GUIDE + (원격 MCP list_tools 문서) 를 합쳐
     LangChain 중괄호 이스케이프 적용 후 반환한다.
     """
     base = doc.strip()
@@ -893,6 +894,9 @@ class FinusAccountBalanceReadonlyConfig(FinusAccountBalanceConfig, name="finus_a
     비-trading 에이전트(news/recommend/strategy/diary)가 잔고·시세 조회 능력은 유지하되
     허용 목록(inquire_*, search_*, find_api_detail)에 없는 api_type은 fail-closed로 차단한다.
     """
+
+    # readonly 래퍼는 auth를 런타임에 차단하므로, 설정 시점에도 받지 않는다.
+    _ALLOWED_TOOL_NAMES: ClassVar[frozenset[str]] = _READONLY_TOOL_ALLOWLIST
 
 
 @register_function(config_type=FinusAccountBalanceReadonlyConfig)

--- a/finus_nat/tests/test_agent_configs.py
+++ b/finus_nat/tests/test_agent_configs.py
@@ -387,6 +387,69 @@ def test_readonly_tool_name_case_and_whitespace(tool_name: str, expected: bool):
     )
 
 
+# ---------------------------------------------------------------------------
+# #220 정규화 일원화 — _prepare_kis_trading_mcp_call 이 tool_name을 소문자로 반환하는지 고정
+# ---------------------------------------------------------------------------
+
+def test_prepare_kis_normalizes_tool_name_to_lowercase():
+    """#220: _prepare_kis_trading_mcp_call은 대소문자·앞뒤 공백을 정규화해 소문자 tool_name을 반환해야 한다.
+
+    _is_readonly_tool_name 게이트 통과 여부만이 아니라 실제로 MCP 에 전달되는 값을 검증한다.
+    정규화가 없으면 "DOMESTIC_STOCK"은 게이트를 통과하지만 MCP 서버가 unknown tool로 거부한다.
+    """
+    from nat_finus_nat.finus_api import (
+        FinusAccountBalanceConfig,
+        KisTradingMcpCallInput,
+        _prepare_kis_trading_mcp_call,
+    )
+
+    config = FinusAccountBalanceConfig()
+    for raw, expected_lower in [
+        ("DOMESTIC_STOCK", "domestic_stock"),
+        ("Overseas_Stock", "overseas_stock"),
+        ("  ETFETN  ", "etfetn"),
+    ]:
+        inp = KisTradingMcpCallInput(tool_name=raw, api_type="inquire_balance", params={})
+        result = _prepare_kis_trading_mcp_call(inp, config)
+        assert isinstance(result, tuple), (
+            f"{raw!r} → 에러 문자열이 아닌 (tool_name, arguments) 튜플이어야 한다: {result!r}"
+        )
+        actual_tool_name, _ = result
+        assert actual_tool_name == expected_lower, (
+            f"{raw!r} → {expected_lower!r} 정규화 기대, 실제: {actual_tool_name!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# #220 trading_tool_name 설정 시점 검증 — 허용 목록 밖의 값은 ValidationError
+# ---------------------------------------------------------------------------
+
+def test_trading_tool_name_invalid_raises_validation_error():
+    """#220: trading_tool_name에 허용 목록 밖의 값을 넣으면 Config 로드 시점에 ValidationError가 발생해야 한다.
+
+    FINUS_KIS_TRADING_TOOL_NAME 환경변수 오설정으로 readonly 에이전트가 전면 차단되는 사고를
+    런타임 첫 호출 전에 잡는다. allowlist 판정을 항상 통과로 뒤집으면 이 테스트가 red가 된다.
+    """
+    import pytest
+    from pydantic import ValidationError
+    from nat_finus_nat.finus_api import FinusAccountBalanceConfig
+
+    with pytest.raises(ValidationError, match="trading_tool_name"):
+        FinusAccountBalanceConfig(trading_tool_name="invalid_tool_xyz")
+
+
+@pytest.mark.parametrize("name", [
+    "domestic_stock", "overseas_stock", "domestic_bond",
+    "domestic_futureoption", "overseas_futureoption", "elw", "etfetn", "auth",
+], ids=lambda x: x)
+def test_trading_tool_name_valid_values_accepted(name: str):
+    """#220: 허용 목록 8종은 trading_tool_name에 지정해도 ValidationError 없이 로드된다."""
+    from nat_finus_nat.finus_api import FinusAccountBalanceConfig
+
+    config = FinusAccountBalanceConfig(trading_tool_name=name)
+    assert config.trading_tool_name == name
+
+
 def test_kis_agents_share_identical_system_prompt():
     """monitoring/strategy/trading 프롬프트는 의도적으로 동일하다 - 한 곳만 수정되는 드리프트를 막는다."""
     import nat_finus_nat.register  # noqa: F401 - 등록 트리거만 필요

--- a/finus_nat/tests/test_agent_configs.py
+++ b/finus_nat/tests/test_agent_configs.py
@@ -391,7 +391,12 @@ def test_readonly_tool_name_case_and_whitespace(tool_name: str, expected: bool):
 # #220 정규화 일원화 — _prepare_kis_trading_mcp_call 이 tool_name을 소문자로 반환하는지 고정
 # ---------------------------------------------------------------------------
 
-def test_prepare_kis_normalizes_tool_name_to_lowercase():
+@pytest.mark.parametrize("raw,expected", [
+    ("DOMESTIC_STOCK", "domestic_stock"),
+    ("Overseas_Stock", "overseas_stock"),
+    ("  ETFETN  ", "etfetn"),
+], ids=lambda x: repr(x) if isinstance(x, str) else str(x))
+def test_prepare_kis_normalizes_tool_name_to_lowercase(raw: str, expected: str):
     """#220: _prepare_kis_trading_mcp_call은 대소문자·앞뒤 공백을 정규화해 소문자 tool_name을 반환해야 한다.
 
     _is_readonly_tool_name 게이트 통과 여부만이 아니라 실제로 MCP 에 전달되는 값을 검증한다.
@@ -404,20 +409,15 @@ def test_prepare_kis_normalizes_tool_name_to_lowercase():
     )
 
     config = FinusAccountBalanceConfig()
-    for raw, expected_lower in [
-        ("DOMESTIC_STOCK", "domestic_stock"),
-        ("Overseas_Stock", "overseas_stock"),
-        ("  ETFETN  ", "etfetn"),
-    ]:
-        inp = KisTradingMcpCallInput(tool_name=raw, api_type="inquire_balance", params={})
-        result = _prepare_kis_trading_mcp_call(inp, config)
-        assert isinstance(result, tuple), (
-            f"{raw!r} → 에러 문자열이 아닌 (tool_name, arguments) 튜플이어야 한다: {result!r}"
-        )
-        actual_tool_name, _ = result
-        assert actual_tool_name == expected_lower, (
-            f"{raw!r} → {expected_lower!r} 정규화 기대, 실제: {actual_tool_name!r}"
-        )
+    inp = KisTradingMcpCallInput(tool_name=raw, api_type="inquire_balance", params={})
+    result = _prepare_kis_trading_mcp_call(inp, config)
+    assert isinstance(result, tuple), (
+        f"{raw!r} → 에러 문자열이 아닌 (tool_name, arguments) 튜플이어야 한다: {result!r}"
+    )
+    actual_tool_name, _ = result
+    assert actual_tool_name == expected, (
+        f"{raw!r} → {expected!r} 정규화 기대, 실제: {actual_tool_name!r}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -430,7 +430,6 @@ def test_trading_tool_name_invalid_raises_validation_error():
     FINUS_KIS_TRADING_TOOL_NAME 환경변수 오설정으로 readonly 에이전트가 전면 차단되는 사고를
     런타임 첫 호출 전에 잡는다. allowlist 판정을 항상 통과로 뒤집으면 이 테스트가 red가 된다.
     """
-    import pytest
     from pydantic import ValidationError
     from nat_finus_nat.finus_api import FinusAccountBalanceConfig
 
@@ -447,6 +446,31 @@ def test_trading_tool_name_valid_values_accepted(name: str):
     from nat_finus_nat.finus_api import FinusAccountBalanceConfig
 
     config = FinusAccountBalanceConfig(trading_tool_name=name)
+    assert config.trading_tool_name == name
+
+
+def test_readonly_config_rejects_auth():
+    """#225: FinusAccountBalanceReadonlyConfig은 auth를 설정 시점에 ValidationError로 차단해야 한다.
+
+    readonly 래퍼는 런타임에 auth를 차단하므로, 설정 시점에도 받지 않는다.
+    두 YAML이 같은 환경변수(FINUS_KIS_TRADING_TOOL_NAME)를 공유하므로 실제로 발생 가능한 경로다.
+    """
+    from pydantic import ValidationError
+    from nat_finus_nat.finus_api import FinusAccountBalanceReadonlyConfig
+
+    with pytest.raises(ValidationError, match="trading_tool_name"):
+        FinusAccountBalanceReadonlyConfig(trading_tool_name="auth")
+
+
+@pytest.mark.parametrize("name", [
+    "domestic_stock", "overseas_stock", "domestic_bond",
+    "domestic_futureoption", "overseas_futureoption", "elw", "etfetn",
+], ids=lambda x: x)
+def test_readonly_config_accepts_asset_classes(name: str):
+    """#225: readonly Config는 자산군 7종을 설정 시점에 허용해야 한다."""
+    from nat_finus_nat.finus_api import FinusAccountBalanceReadonlyConfig
+
+    config = FinusAccountBalanceReadonlyConfig(trading_tool_name=name)
     assert config.trading_tool_name == name
 
 


### PR DESCRIPTION
## 배경

#220 (PR #217 리뷰 3라운드에서 합의된 범위 제외 항목). 리뷰어가 "후속 이슈 권장"으로 명시한 4건입니다.

## 1. 두 KIS 래퍼 중복 제거

`finus_account_balance_readonly`와 `finus_account_balance`가 게이트 한 블록을 빼면 본문·description 조립·ledger 기록이 동일해 약 35줄이 중복이었습니다. 공통 경로를 헬퍼로 뽑았습니다.

`_record_to_ledger("finus_account_balance", ...)` 리터럴이 양쪽에 흩어져 있던 것도 `_KIS_BALANCE_LEDGER_NAME` 상수로 모았습니다. **값은 바꾸지 않았습니다** — PR #205/#209의 원장 판정 테이블(`_SIDE_EFFECT_TOOLS`, `_EMPTY_RESULT_LITERALS`)과 키가 어긋나면 안 되기 때문입니다.

## 2. `tool_name` 정규화 일원화 (핵심)

리뷰어가 지적한 **"게이트는 통과하지만 반드시 실패하는" 경로**를 닫았습니다.

기존에는 `_is_readonly_tool_name`이 `.strip().lower()`로 판정만 하고, 통과한 값은 **원래 대소문자 그대로** 전달됐습니다. 그래서 `"DOMESTIC_STOCK"`은 게이트를 통과한 뒤:
- `== "domestic_stock"`(대소문자 구분)을 못 맞춰 `_adjust_domestic_stock_params`가 건너뛰어지고
- `_mcp_call_tool_remote`에 대문자로 전달돼 MCP가 unknown tool로 거부

정규화를 `_prepare_kis_trading_mcp_call` 한 곳으로 모았습니다. **실측:**

```
'DOMESTIC_STOCK'       -> 전달 tool_name='domestic_stock'
'  domestic_stock  '   -> 전달 tool_name='domestic_stock'
'ETFETN'               -> 전달 tool_name='etfetn'
```

리뷰어가 "테스트로 승인된 상태"라고 지적한 부분은 **기존 테스트를 고치지 않고 새 테스트를 추가**하는 방식으로 다뤘습니다. `test_readonly_tool_name_case_and_whitespace`는 게이트 함수 단위 명세로 그대로 두고(그 함수에 대해서는 정확한 단언입니다), 그 아래에 `_prepare_kis_trading_mcp_call`이 **실제로 반환하는 정규화된 값**을 고정하는 테스트를 별도로 넣었습니다.

## 3·4. 설정 검증 / 프롬프트 드리프트 가드

`FINUS_KIS_TRADING_TOOL_NAME` 폴백 검증과 `strategy_agent` 드리프트 가드도 회귀 테스트로 추가했습니다.

## 검증 (직접 실행)

`pytest tests/` — **213 passed, 1 skipped** (실패 0건).

**PR #217 회귀 없음** — 병합된 두 라우터 모두:

| | `_type` |
| --- | --- |
| `kis-trading-mcp-tool` | `finus_account_balance` |
| `kis-trading-mcp-tool-readonly` | `finus_account_balance_readonly` |

`trading_agent_react`·`monitoring_agent` → 전체 권한 / `news`·`recommend`·`strategy` → readonly / `diary_agent` → 없음.

**게이트 13종 유지:**

| 대상 | 결과 |
| --- | --- |
| `api_type`: `inquire_balance`·`search_x`·`find_api_detail` | 허용 ✅ |
| `api_type`: `order_cash`·`overseas_stock_order`·`domestic_order`·`foo_bar_unknown` | 차단 ✅ |
| `tool_name`: `domestic_stock`·`etfetn`·`elw`·`  DOMESTIC_STOCK  ` | 허용 ✅ |
| `tool_name`: `auth`·`foo_bar` | 차단 ✅ |

**PR #205/#209 원장 키 정합성:** `_KIS_BALANCE_LEDGER_NAME == "finus_account_balance"`, `_SIDE_EFFECT_TOOLS`·`_EMPTY_RESULT_LITERALS` 키 불변 확인.

뮤테이션:

| 뮤턴트 | 결과 |
| --- | --- |
| `tool_name` 정규화(`.lower()`) 제거 | **1 failed** ✅ |
| `api_type` allowlist 무조건 통과 | **7 failed** ✅ |
| `tool_name` 게이트 무조건 통과 | **4 failed** ✅ |

## 확인한 한계 — `_KIS_BALANCE_LEDGER_NAME` 값 변경은 잡히지 않습니다

솔직하게 남깁니다. 상수 값을 다른 문자열로 바꾸는 뮤턴트는 **213 passed로 통과**합니다.

이유를 확인해보니 오늘 기준으로는 이 이름이 실제 판정에 쓰이지 않습니다 — `finus_account_balance`는 `_SIDE_EFFECT_TOOLS`에도 `_EMPTY_RESULT_LITERALS`에도 키가 없는 "미분류(보수적 통과)" 도구라(PR #216에서 의도적으로 그렇게 결정), 이름이 바뀌어도 두 테이블 조회 결과가 달라지지 않습니다.

즉 이 상수화는 **드리프트 방지·문서화 목적**이며 현재 살아 있는 불변식을 지키는 것은 아닙니다. 값을 고정하는 테스트를 넣으면 사실상 자기 자신을 단언하는 형태가 되어 넣지 않았습니다. 나중에 `finus_account_balance`가 어느 테이블에든 등재되면 그때는 실제 불변식이 되므로 가드를 붙이는 것이 맞습니다.

Closes #220

