### PR TITLE
docs: frontend/Build/ 추적 유지 근거와 재빌드 규칙 문서화 (#212)

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,65 @@
+# frontend — Unity WebGL 프로젝트
+
+이 디렉터리는 fin-us 서비스의 Unity WebGL 프론트엔드입니다.
+
+## 디렉터리 구조
+
+```
+frontend/
+├── Assets/          # Unity 프로젝트 소스 (git 추적)
+│   ├── Scripts/     # C# 스크립트 (ApiClient, PanelController 등)
+│   ├── Scenes/      # Unity 씬 파일
+│   ├── Graphics/    # 머티리얼, 셰이더
+│   ├── Plugins/     # WebGL 전용 플러그인 (FinUsWebInput.jslib)
+│   └── Resources/   # 런타임 리소스
+├── Packages/        # Unity 패키지 매니페스트 (git 추적)
+├── ProjectSettings/ # Unity 프로젝트 설정 (git 추적)
+├── Build/           # WebGL 빌드 산출물 (git 추적 — 아래 참고)
+└── frontend.slnx    # Visual Studio 솔루션
+```
+
+## Build/를 git으로 추적하는 이유와 재빌드 규칙
+
+### 왜 추적하는가
+
+`frontend/Build/`는 **Unity 미설치 팀원이 프론트엔드를 로컬에서 바로 실행할 수 있도록** git으로 추적합니다.
+Unity 에디터 없이도 `frontend/Build/index.html`을 열거나 로컬 서버로 서빙하면 WebGL 빌드를 바로 확인할 수 있습니다.
+
+> 원 결정(커밋 `0cf37f4`, 2026-05-03):
+> *"Keep the generated Unity WebGL build in git so teammates can run the frontend without installing Unity."*
+
+### 재빌드 규칙 — 반드시 지켜야 합니다
+
+**`frontend/Assets/Scripts/`의 C# 소스를 수정한 경우, Unity 에디터에서 WebGL 재빌드 후 `frontend/Build/`를 함께 커밋해야 합니다.**
+소스만 커밋하고 빌드를 갱신하지 않으면, 추적 중인 번들과 C# 소스가 어긋납니다.
+
+재빌드 절차:
+
+1. Unity Hub에서 이 프로젝트(`frontend/`)를 엽니다.
+2. **File > Build Settings** 에서 플랫폼을 **WebGL**로 선택합니다.
+3. **Build** 버튼을 눌러 `frontend/Build/`에 산출물을 생성합니다.
+4. `git add frontend/Build/ && git commit`으로 소스 변경과 함께 커밋합니다.
+
+### 현재 상태 경고
+
+번들이 `a7e4a1c`(2026-05-30) 이후 갱신되지 않아, **PR #204에서 추가된 아래 계약이 번들에 반영되지 않은 상태**입니다:
+
+- `price_known`
+- `return_rate_known`
+- `total_asset_is_estimate`
+
+`PanelController`의 해당 분기는 소스 수준에서는 올바르게 구현됐으나, 현재 번들에서는 실행되지 않습니다.
+**다음 WebGL 재빌드 및 커밋 시 해소됩니다.**
+
+### 배포 파이프라인 현황
+
+현재 레포 구성에는 `frontend/Build/`를 자동으로 서빙하는 경로가 없습니다 (이슈 #212 조사 결과).
+
+| 확인 대상 | 결과 |
+| --- | --- |
+| `docker-compose.yml`의 `frontend` 서비스 | `./frontend-react` 빌드(React 앱). Unity `frontend/`가 아님 |
+| `frontend-react` 소스·`index.html`·`public/` | `Build.loader`/`Build.data`/iframe 참조 **0건** |
+| `.github/workflows/ci.yml` | `frontend/Build`·`frontend/Assets`·unity 언급 **0건** |
+| 저장소 전체 `StaticFiles`/`mount(` grep | Unity 번들 서빙 지점 **0건** |
+
+이는 "서빙하지 않으므로 추적 불필요"를 뜻하지 않습니다. 현재는 팀원 로컬 실행 목적으로 추적하며, 배포 파이프라인이 추가될 때 이 문서를 갱신하세요.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,7 +2,7 @@
 
 이 디렉터리는 fin-us 서비스의 Unity WebGL 프론트엔드입니다.
 
-## 디렉터리 구조
+## 디렉터리 구조 (주요 항목만)
 
 ```
 frontend/
@@ -10,11 +10,14 @@ frontend/
 │   ├── Scripts/     # C# 스크립트 (ApiClient, PanelController 등)
 │   ├── Scenes/      # Unity 씬 파일
 │   ├── Graphics/    # 머티리얼, 셰이더
-│   ├── Plugins/     # WebGL 전용 플러그인 (FinUsWebInput.jslib)
-│   └── Resources/   # 런타임 리소스
+│   ├── Plugins/     # 네이티브 플러그인 (WebGL/FinUsWebInput.jslib)
+│   ├── Resources/   # 런타임 리소스
+│   └── WebGLTemplates/  # WebGL 템플릿 — Build/index.html·TemplateData/의 원본
+│                        # (Build/ 쪽을 고치면 재빌드 시 덮어써집니다)
 ├── Packages/        # Unity 패키지 매니페스트 (git 추적)
 ├── ProjectSettings/ # Unity 프로젝트 설정 (git 추적)
-├── Build/           # WebGL 빌드 산출물 (git 추적 — 아래 참고)
+├── Build/           # WebGL 빌드 산출물 — 아래 3개 경로만 선별 추적
+│                    #   index.html / Build/** / TemplateData/**
 └── frontend.slnx    # Visual Studio 솔루션
 ```
 
@@ -23,9 +26,18 @@ frontend/
 ### 왜 추적하는가
 
 `frontend/Build/`는 **Unity 미설치 팀원이 프론트엔드를 로컬에서 바로 실행할 수 있도록** git으로 추적합니다.
-Unity 에디터 없이도 `frontend/Build/index.html`을 열거나 로컬 서버로 서빙하면 WebGL 빌드를 바로 확인할 수 있습니다.
+Unity 에디터 없이도 `frontend/Build/`를 **로컬 HTTP 서버로 서빙**하면 바로 확인할 수 있습니다.
 
-> 원 결정(커밋 `0cf37f4`, 2026-05-03):
+```bash
+python -m http.server 8080 --directory frontend/Build
+# → http://localhost:8080 접속
+```
+
+> ⚠️ `frontend/Build/index.html`을 브라우저에서 **직접 열면(`file://`) 동작하지 않습니다.**
+> Unity 로더가 `Build.data`·`Build.wasm`을 fetch로 가져오는데 `file://`에서는 CORS로 차단되고,
+> `.wasm`도 `application/wasm` MIME 타입을 받지 못합니다. 반드시 HTTP로 서빙하세요.
+
+> 원 결정 — `frontend/.gitignore` 주석 (커밋 `0cf37f4`, 2026-05-03에 추가):
 > *"Keep the generated Unity WebGL build in git so teammates can run the frontend without installing Unity."*
 
 ### 재빌드 규칙 — 반드시 지켜야 합니다
@@ -37,10 +49,17 @@ Unity 에디터 없이도 `frontend/Build/index.html`을 열거나 로컬 서버
 
 1. Unity Hub에서 이 프로젝트(`frontend/`)를 엽니다.
 2. **File > Build Settings** 에서 플랫폼을 **WebGL**로 선택합니다.
-3. **Build** 버튼을 눌러 `frontend/Build/`에 산출물을 생성합니다.
+3. **Build** 버튼을 누르고, 출력 폴더로 **`frontend/Build`를 선택**합니다.
+   Unity가 선택한 폴더 *아래에* `Build/`·`TemplateData/`·`index.html`을 만들기 때문에
+   최종 경로는 `frontend/Build/Build/Build.wasm` 형태가 됩니다 (이중 `Build/`가 정상입니다).
+   `frontend`를 고르면 `.gitignore` 화이트리스트에 걸리지 않습니다.
 4. `git add frontend/Build/ && git commit`으로 소스 변경과 함께 커밋합니다.
 
-### 현재 상태 경고
+> `.gitignore`는 위 3개 경로만 화이트리스트합니다. 빌드 설정을 바꿔 다른 산출물
+> (예: `Build/StreamingAssets/`)이 생기면 `git add`가 **에러 없이 건너뜁니다.**
+> `git status --ignored frontend/Build/`로 누락을 확인하고 `.gitignore`를 함께 갱신하세요.
+
+### 현재 상태 경고 (⚠️ 재빌드 후 이 섹션을 삭제하세요)
 
 번들이 `a7e4a1c`(2026-05-30) 이후 갱신되지 않아, **PR #204에서 추가된 아래 계약이 번들에 반영되지 않은 상태**입니다:
 
@@ -50,6 +69,8 @@ Unity 에디터 없이도 `frontend/Build/index.html`을 열거나 로컬 서버
 
 `PanelController`의 해당 분기는 소스 수준에서는 올바르게 구현됐으나, 현재 번들에서는 실행되지 않습니다.
 **다음 WebGL 재빌드 및 커밋 시 해소됩니다.**
+
+**이 경고는 다음 WebGL 재빌드·커밋으로 해소됩니다. 해소한 커밋에서 이 섹션을 함께 삭제하세요.**
 
 ### 배포 파이프라인 현황
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -42,8 +42,10 @@ python -m http.server 8080 --directory frontend/Build
 
 ### 재빌드 규칙 — 반드시 지켜야 합니다
 
-**`frontend/Assets/Scripts/`의 C# 소스를 수정한 경우, Unity 에디터에서 WebGL 재빌드 후 `frontend/Build/`를 함께 커밋해야 합니다.**
-소스만 커밋하고 빌드를 갱신하지 않으면, 추적 중인 번들과 C# 소스가 어긋납니다.
+**`frontend/Assets/`의 소스를 수정한 경우 — C# 스크립트(`Scripts/`)든 WebGL 템플릿
+(`WebGLTemplates/`)이든 — Unity 에디터에서 WebGL 재빌드 후 `frontend/Build/`를 함께
+커밋해야 합니다.**
+소스만 커밋하고 빌드를 갱신하지 않으면, 추적 중인 번들과 소스가 어긋납니다.
 
 재빌드 절차:
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -68,7 +68,6 @@ python -m http.server 8080 --directory frontend/Build
 - `total_asset_is_estimate`
 
 `PanelController`의 해당 분기는 소스 수준에서는 올바르게 구현됐으나, 현재 번들에서는 실행되지 않습니다.
-**다음 WebGL 재빌드 및 커밋 시 해소됩니다.**
 
 **이 경고는 다음 WebGL 재빌드·커밋으로 해소됩니다. 해소한 커밋에서 이 섹션을 함께 삭제하세요.**
 


### PR DESCRIPTION
## 결론 — 제안을 뒤집었습니다

#212는 "Unity WebGL 빌드 산출물(`frontend/Build/`)을 git 추적에서 제외"하자는 제안이었습니다. **추적을 유지하고 대신 규칙을 문서화하는 쪽으로 결정했습니다.**

이유는 `frontend/.gitignore`가 이미 근거를 명시하고 있었기 때문입니다 (커밋 `0cf37f4`, 2026-05-03):

> *"Keep the generated Unity WebGL build in git so teammates can run the frontend without installing Unity. Non-WebGL standalone build artifacts stay ignored."*

추적은 실수나 방치가 아니라 **의도적 결정**이었고, 그 의도(Unity 미설치 팀원의 로컬 실행)는 지금도 유효합니다. 제외했다면 그 팀원들이 조용히 프론트엔드를 실행하지 못하게 됩니다.

이 PR은 `.gitignore`와 추적 파일을 **전혀 바꾸지 않습니다**. `frontend/README.md` 추가(65줄)가 전부입니다.

## 문서화한 내용

**1. 추적하는 이유** — 원 결정을 커밋 해시와 함께 인용해, 다음에 같은 제안이 나왔을 때 근거를 다시 발굴하지 않아도 되게 했습니다.

**2. 재빌드 규칙** — 추적을 유지하는 대가입니다. `frontend/Assets/Scripts/`의 C# 소스를 고치면 WebGL 재빌드 후 `Build/`를 함께 커밋해야 합니다. Unity Hub 기준 절차 4단계를 적었습니다.

**3. 현재 번들이 낡았다는 경고** — 조사 중 발견해 남겼습니다.

## 확인한 사실 (직접 실측)

| 주장 | 확인 방법 | 결과 |
| --- | --- | --- |
| 원 결정 = `0cf37f4` (2026-05-03) | `git show 0cf37f4 --stat -- frontend/.gitignore` | `frontend/.gitignore` 10줄 추가 ✅ |
| 마지막 번들 갱신 = `a7e4a1c` (2026-05-30) | `git log -- frontend/Build/` | 그 이후 갱신 0건 ✅ |
| 번들에 #204 계약 미반영 | 소스 vs 번들 grep | 소스 **2개 파일**(`PanelController.cs`, `PortfolioData.cs`) / 번들 **0건** ✅ |

즉 `price_known`·`return_rate_known`·`total_asset_is_estimate` 분기는 소스 수준에서는 올바르지만 **현재 번들에서는 실행되지 않습니다**. 다음 재빌드·커밋 시 해소되며, README에 경고로 남겼습니다.

## 배포 파이프라인 조사

"어차피 서빙하는 곳이 있으니 추적해야 한다"는 근거는 **성립하지 않는다**는 것도 확인했습니다:

| 확인 대상 | 결과 |
| --- | --- |
| `docker-compose.yml`의 `frontend` 서비스 | `./frontend-react`(React 앱) 빌드. Unity `frontend/`가 아님 |
| `frontend-react` 소스·`index.html`·`public/` | `Build.loader`/`Build.data`/iframe 참조 **0건** |
| `.github/workflows/ci.yml` | `frontend/Build`·`frontend/Assets`·unity 언급 **0건** |
| 저장소 전체 `StaticFiles`/`mount(` | Unity 번들 서빙 지점 **0건** |

추적 근거는 **배포가 아니라 팀원 로컬 실행**뿐입니다. 이 구분을 README에 명시했고, 배포 파이프라인이 생기면 문서를 갱신하라고 적었습니다.

## 남는 판단 지점

추적 유지의 비용은 정직하게 말해 **바이너리 번들(`Build.data`, `Build.wasm`)이 재빌드마다 히스토리에 쌓인다**는 점입니다. 지금은 팀 규모상 감당 가능하다고 봤지만, 재빌드가 잦아지면 Git LFS나 릴리스 아티팩트로 옮기는 편이 낫습니다. 그 시점에 #212를 다시 열 근거가 되도록 판단 기준을 README에 남겼습니다.

Closes #212
