### PR TITLE
feat: 촉매 이벤트 전체 조회 API 추가 (#228)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -20,6 +20,7 @@ from .services import (
 )
 from .database import init_db, get_session
 from .models import Portfolio, TradeHistory, AgentReport, Diary, CatalystEvent
+from .timeutil import today_kst
 
 # 로깅 설정: 모든 모듈의 로그를 터미널에 출력하도록 설정
 logging.basicConfig(
@@ -226,8 +227,11 @@ async def get_db_diary(session: Session = Depends(get_session)):
 
 @app.get("/api/v1/db/catalysts", response_model=CommonResponse, tags=["Database"])
 async def get_db_catalysts(
-    stock_name: str | None = Query(None, description="종목명 정확 일치 필터. 생략 시 전체 종목 조회."),
-    from_date: date = Query(default_factory=date.today, description="이 날짜 이후(포함) 이벤트만 조회."),
+    stock_name: str | None = Query(None, min_length=1, description="종목명 정확 일치 필터. 생략 시 전체 종목 조회."),
+    # default_factory에 today_kst를 직접 넘기면 라우트 등록 시점의 함수 객체가
+    # 고정돼 테스트에서 backend.main.today_kst를 monkeypatch해도 반영되지 않는다.
+    # 람다로 감싸 요청마다 모듈 전역의 today_kst를 다시 조회하도록 한다.
+    from_date: date = Query(default_factory=lambda: today_kst(), description="이 날짜 이후(포함) 이벤트만 조회. 생략 시 KST 기준 오늘."),
     # 이슈 #228: 프론트 시간 링(캘린더 시각화)이 한 번에 그릴 이벤트 수를 과도하게
     # 받아 렌더링이 느려지는 것을 막기 위한 상한(500). 1건도 없이 호출되는 것을
     # 막기 위한 하한(1). 기본값 100은 기존 catalyst_repo.list_upcoming의 기본값(20)보다
@@ -235,19 +239,28 @@ async def get_db_catalysts(
     limit: int = Query(100, ge=1, le=500, description="결과 상한 (1~500, 기본 100)."),
     session: Session = Depends(get_session),
 ):
-    """저장된 촉매 이벤트(실적/배당/공시/주총 등)를 조회합니다.
-
-    catalyst_repo.SqliteCatalystEventRepo.list_upcoming은 stock_name이 필수 인자라
-    전체 종목 조회에 쓸 수 없다. 기존 /api/v1/db/* 4종과 동일하게 이 라우트에서
-    session.exec(select(...))를 직접 실행한다(catalyst_repo.py는 수정하지 않는다).
-    """
+    """저장된 촉매 이벤트(실적/배당/공시/주총 등)를 조회합니다."""
+    # catalyst_repo.SqliteCatalystEventRepo.list_upcoming은 stock_name이 필수 인자라
+    # 전체 종목 조회에 쓸 수 없다. 기존 /api/v1/db/* 4종과 동일하게 이 라우트에서
+    # session.exec(select(...))를 직접 실행한다(catalyst_repo.py는 수정하지 않는다).
     query = select(CatalystEvent).where(CatalystEvent.event_date >= from_date)
     if stock_name is not None:
         query = query.where(CatalystEvent.stock_name == stock_name)
-    query = query.order_by(CatalystEvent.event_date).limit(limit)
+    # event_date만으로는 동일 날짜 이벤트 간 순서가 SQL상 보장되지 않아 limit 절단이
+    # 비결정적일 수 있다. event_type, id까지 더해 완전히 결정적으로 정렬한다.
+    query = query.order_by(
+        CatalystEvent.event_date,
+        CatalystEvent.event_type,
+        CatalystEvent.id,
+    ).limit(limit + 1)
 
-    catalysts = session.exec(query).all()
-    return {"status": "success", "data": catalysts}
+    rows = session.exec(query).all()
+    truncated = len(rows) > limit
+    return {
+        "status": "success",
+        "data": rows[:limit],
+        "message": "truncated" if truncated else None,
+    }
 
 
 @app.post("/api/v1/db/diary", response_model=CommonResponse, tags=["Database"])

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,7 @@
 import os
 import logging
 from contextlib import asynccontextmanager
+from datetime import date
 from fastapi import FastAPI, Query, Depends, WebSocket, WebSocketDisconnect, Body
 from fastapi.middleware.cors import CORSMiddleware
 from sqlmodel import Session, select
@@ -18,7 +19,7 @@ from .services import (
     perform_stock_analysis
 )
 from .database import init_db, get_session
-from .models import Portfolio, TradeHistory, AgentReport, Diary
+from .models import Portfolio, TradeHistory, AgentReport, Diary, CatalystEvent
 
 # 로깅 설정: 모든 모듈의 로그를 터미널에 출력하도록 설정
 logging.basicConfig(
@@ -221,6 +222,32 @@ async def get_db_diary(session: Session = Depends(get_session)):
     """저장된 투자 일지 목록을 조회합니다."""
     diaries = session.exec(select(Diary).order_by(Diary.created_at.desc())).all()
     return {"status": "success", "data": diaries}
+
+
+@app.get("/api/v1/db/catalysts", response_model=CommonResponse, tags=["Database"])
+async def get_db_catalysts(
+    stock_name: str | None = Query(None, description="종목명 정확 일치 필터. 생략 시 전체 종목 조회."),
+    from_date: date = Query(default_factory=date.today, description="이 날짜 이후(포함) 이벤트만 조회."),
+    # 이슈 #228: 프론트 시간 링(캘린더 시각화)이 한 번에 그릴 이벤트 수를 과도하게
+    # 받아 렌더링이 느려지는 것을 막기 위한 상한(500). 1건도 없이 호출되는 것을
+    # 막기 위한 하한(1). 기본값 100은 기존 catalyst_repo.list_upcoming의 기본값(20)보다
+    # 넉넉하게 잡아 여러 종목을 한 번에 다루는 전체 조회 용도에 맞춘다.
+    limit: int = Query(100, ge=1, le=500, description="결과 상한 (1~500, 기본 100)."),
+    session: Session = Depends(get_session),
+):
+    """저장된 촉매 이벤트(실적/배당/공시/주총 등)를 조회합니다.
+
+    catalyst_repo.SqliteCatalystEventRepo.list_upcoming은 stock_name이 필수 인자라
+    전체 종목 조회에 쓸 수 없다. 기존 /api/v1/db/* 4종과 동일하게 이 라우트에서
+    session.exec(select(...))를 직접 실행한다(catalyst_repo.py는 수정하지 않는다).
+    """
+    query = select(CatalystEvent).where(CatalystEvent.event_date >= from_date)
+    if stock_name is not None:
+        query = query.where(CatalystEvent.stock_name == stock_name)
+    query = query.order_by(CatalystEvent.event_date).limit(limit)
+
+    catalysts = session.exec(query).all()
+    return {"status": "success", "data": catalysts}
 
 
 @app.post("/api/v1/db/diary", response_model=CommonResponse, tags=["Database"])

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -3,7 +3,6 @@ import logging
 import re
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
-from zoneinfo import ZoneInfo
 from typing import Any, Callable
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from sqlmodel import Session, select
@@ -19,6 +18,7 @@ from .services import (
     generate_morning_briefing,
 )
 from .models import Portfolio
+from .timeutil import KST
 from .watchlist_repo import SqliteWatchlistRepo
 from .telegram_notifier import telegram_notifier
 from .telegram_notifier import should_send_telegram_alert
@@ -26,7 +26,6 @@ from .telegram_notifier import should_send_telegram_alert
 logger = logging.getLogger(__name__)
 
 # 비동기 스케줄러 인스턴스 생성
-KST = ZoneInfo("Asia/Seoul")
 scheduler = AsyncIOScheduler(timezone=KST)
 
 # 뉴스 필터링에 사용할 모델 제공자 (ollama 또는 openai)

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -31,8 +31,8 @@ from .redis_state import (
 from .services import llm_chat, run_mcp_tool
 from .watchlist_repo import SqliteWatchlistRepo
 from .telegram_notifier import TELEGRAM_ALERT_MODES, TelegramNotifier, telegram_notifier
+from .timeutil import KST
 from .trading_orders import (
-    KST,
     McpTradingOrderGateway,
     OrderType,
     PendingOrder,

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -1,10 +1,12 @@
+from datetime import date, timedelta
+
 import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session, SQLModel, create_engine
 from sqlmodel.pool import StaticPool
 
 from ..main import app, get_session
-from ..models import Diary, AgentReport, Portfolio
+from ..models import Diary, AgentReport, Portfolio, CatalystEvent
 
 # 테스트용 인메모리 SQLite 엔진 설정
 @pytest.fixture(name="session")
@@ -293,6 +295,86 @@ def test_get_trades_empty(client: TestClient):
     assert response.status_code == 200
     assert response.json()["status"] == "success"
     assert response.json()["data"] == []
+
+
+def _make_catalyst(
+    *,
+    stock_name: str,
+    event_date: date,
+    stock_code: str = "005930",
+    event_type: str = "earnings",
+    description: str = "실적 발표",
+) -> CatalystEvent:
+    return CatalystEvent(
+        stock_name=stock_name,
+        stock_code=stock_code,
+        event_type=event_type,
+        event_date=event_date,
+        description=description,
+    )
+
+
+def test_get_catalysts_empty(client: TestClient):
+    response = client.get("/api/v1/db/catalysts")
+    assert response.status_code == 200
+    assert response.json()["status"] == "success"
+    assert response.json()["data"] == []
+
+
+def test_get_catalysts_filters_by_stock_name(client: TestClient, session: Session):
+    today = date.today()
+    session.add(_make_catalyst(stock_name="삼성전자", event_date=today))
+    session.add(_make_catalyst(stock_name="SK하이닉스", event_date=today))
+    session.commit()
+
+    response = client.get("/api/v1/db/catalysts", params={"stock_name": "삼성전자"})
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert len(data) == 1
+    assert data[0]["stock_name"] == "삼성전자"
+
+
+def test_get_catalysts_from_date_excludes_past_events(client: TestClient, session: Session):
+    today = date.today()
+    session.add(_make_catalyst(stock_name="과거", event_date=today - timedelta(days=1)))
+    session.add(_make_catalyst(stock_name="오늘", event_date=today))
+    session.add(_make_catalyst(stock_name="미래", event_date=today + timedelta(days=1)))
+    session.commit()
+
+    response = client.get("/api/v1/db/catalysts", params={"from_date": today.isoformat()})
+    assert response.status_code == 200
+    names = [row["stock_name"] for row in response.json()["data"]]
+    assert names == ["오늘", "미래"]
+
+
+def test_get_catalysts_limit_boundary(client: TestClient, session: Session):
+    today = date.today()
+    for i in range(5):
+        session.add(
+            _make_catalyst(
+                stock_name=f"종목{i}",
+                event_date=today + timedelta(days=i),
+            )
+        )
+    session.commit()
+
+    response = client.get("/api/v1/db/catalysts", params={"limit": 3})
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert len(data) == 3
+
+
+def test_get_catalysts_sorted_by_event_date_ascending(client: TestClient, session: Session):
+    today = date.today()
+    session.add(_make_catalyst(stock_name="가장늦음", event_date=today + timedelta(days=10)))
+    session.add(_make_catalyst(stock_name="가장이름", event_date=today))
+    session.add(_make_catalyst(stock_name="중간", event_date=today + timedelta(days=5)))
+    session.commit()
+
+    response = client.get("/api/v1/db/catalysts")
+    assert response.status_code == 200
+    names = [row["stock_name"] for row in response.json()["data"]]
+    assert names == ["가장이름", "중간", "가장늦음"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -434,7 +434,11 @@ def test_get_catalysts_order_by_includes_id_as_final_tie_break(
     assert response.status_code == 200
     assert captured_sql, "session.exec가 호출되지 않았다"
 
-    order_by_clause = captured_sql[0].split("ORDER BY", 1)[1]
+    sql = captured_sql[0]
+    # ORDER BY가 통째로 사라진 뮤턴트에서는 split이 IndexError로 죽어 red의 원인이
+    # 드러나지 않는다. 먼저 단언해 실패 메시지에 실제 SQL이 남게 한다.
+    assert "ORDER BY" in sql, f"ORDER BY 절이 없다: {sql}"
+    order_by_clause = sql.split("ORDER BY", 1)[1]
     assert "catalystevent.event_date" in order_by_clause
     assert "catalystevent.event_type" in order_by_clause
     assert "catalystevent.id" in order_by_clause
@@ -507,6 +511,25 @@ def test_get_catalysts_signals_truncation_when_over_limit(
     body = response.json()
     assert len(body["data"]) == 3
     assert body["message"] == "truncated"
+
+
+def test_get_catalysts_not_truncated_at_exact_limit(
+    client: TestClient, session: Session, frozen_today: date
+):
+    # 정확히 limit개일 때가 유일하게 애매한 경계다. 위 두 테스트는 각각 경계에서
+    # 2 모자라고 1 넘어서 비켜 가므로, len(rows) > limit을 >= 로 바꾼 오프바이원
+    # 뮤턴트가 둘 다 통과한다. 이 경계가 깨지면 이벤트가 정확히 limit개일 때 프론트가
+    # "더 있음"으로 오해해 없는 다음 페이지를 그린다 — 데이터는 멀쩡한데 UI만 틀린다.
+    today = frozen_today
+    for i in range(3):
+        session.add(_make_catalyst(stock_name=f"종목{i}", event_date=today + timedelta(days=i)))
+    session.commit()
+
+    response = client.get("/api/v1/db/catalysts", params={"limit": 3})
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["data"]) == 3
+    assert body["message"] is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -377,6 +377,27 @@ def test_get_catalysts_sorted_by_event_date_ascending(client: TestClient, sessio
     assert names == ["가장이름", "중간", "가장늦음"]
 
 
+def test_get_catalysts_defaults_to_today_excluding_past(client: TestClient, session: Session):
+    # from_date를 생략했을 때의 기본값(오늘)을 고정한다. 위 from_date 테스트는 값을
+    # 명시해서 호출하므로 기본값이 date.min 등으로 바뀌어도 통과한다 — 지난 촉매가
+    # 시간 링에 섞여 들어오는 회귀를 이 테스트가 잡는다.
+    today = date.today()
+    session.add(_make_catalyst(stock_name="지난주", event_date=today - timedelta(days=7)))
+    session.add(_make_catalyst(stock_name="오늘", event_date=today))
+    session.commit()
+
+    response = client.get("/api/v1/db/catalysts")
+    assert response.status_code == 200
+    names = [row["stock_name"] for row in response.json()["data"]]
+    assert names == ["오늘"]
+
+
+@pytest.mark.parametrize("limit", [0, 501])
+def test_get_catalysts_rejects_out_of_range_limit(client: TestClient, limit: int):
+    response = client.get("/api/v1/db/catalysts", params={"limit": limit})
+    assert response.status_code == 422
+
+
 @pytest.mark.asyncio
 async def test_analyze_stock_saves_report(client: TestClient, session: Session, monkeypatch):
     # A (#162): openai는 도구 없는 경로(_build_toolless_prompt + _analysis_from_toolless_text)를

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -361,7 +361,7 @@ def test_get_catalysts_limit_boundary(client: TestClient, session: Session):
     response = client.get("/api/v1/db/catalysts", params={"limit": 3})
     assert response.status_code == 200
     data = response.json()["data"]
-    assert len(data) == 3
+    assert [row["stock_name"] for row in data] == ["종목0", "종목1", "종목2"]
 
 
 def test_get_catalysts_sorted_by_event_date_ascending(client: TestClient, session: Session):
@@ -377,13 +377,37 @@ def test_get_catalysts_sorted_by_event_date_ascending(client: TestClient, sessio
     assert names == ["가장이름", "중간", "가장늦음"]
 
 
-def test_get_catalysts_defaults_to_today_excluding_past(client: TestClient, session: Session):
-    # from_date를 생략했을 때의 기본값(오늘)을 고정한다. 위 from_date 테스트는 값을
-    # 명시해서 호출하므로 기본값이 date.min 등으로 바뀌어도 통과한다 — 지난 촉매가
-    # 시간 링에 섞여 들어오는 회귀를 이 테스트가 잡는다.
+def test_get_catalysts_ties_break_by_event_type_then_id(client: TestClient, session: Session):
+    # event_date만으로 정렬하면 같은 날짜 이벤트 간 순서가 SQL상 보장되지 않아 limit
+    # 절단이 비결정적일 수 있다. event_type을 오름차순 tie-break로 추가했는지 확인한다.
+    # 삽입 순서(C, A, B)를 event_type 오름차순(A, B, C)과 반대로 둬, id(삽입 순서)로만
+    # 정렬되는 경우와 구분되게 한다.
     today = date.today()
-    session.add(_make_catalyst(stock_name="지난주", event_date=today - timedelta(days=7)))
-    session.add(_make_catalyst(stock_name="오늘", event_date=today))
+    session.add(_make_catalyst(stock_name="C", event_date=today, event_type="c_type"))
+    session.add(_make_catalyst(stock_name="A", event_date=today, event_type="a_type"))
+    session.add(_make_catalyst(stock_name="B", event_date=today, event_type="b_type"))
+    session.commit()
+
+    response = client.get("/api/v1/db/catalysts")
+    assert response.status_code == 200
+    names = [row["stock_name"] for row in response.json()["data"]]
+    assert names == ["A", "B", "C"]
+
+
+def test_get_catalysts_defaults_to_today_excluding_past(
+    client: TestClient, session: Session, monkeypatch: pytest.MonkeyPatch
+):
+    # from_date를 생략했을 때의 기본값(KST 기준 오늘)을 고정한다. 위 from_date 테스트는
+    # 값을 명시해서 호출하므로 기본값이 date.min 등으로 바뀌어도 통과한다 — 지난 촉매가
+    # 시간 링에 섞여 들어오는 회귀를 이 테스트가 잡는다.
+    #
+    # today_kst()를 고정값으로 monkeypatch한다: 서버가 date.today()(로컬 타임존)로
+    # 되돌아가도 이 테스트를 실행하는 개발자 머신이 KST라면 우연히 통과해버려
+    # 회귀를 못 잡는다. 고정 날짜로 기대값과 서버 계산을 분리해야 그 회귀가 드러난다.
+    fixed = date(2026, 5, 20)
+    monkeypatch.setattr("backend.main.today_kst", lambda: fixed)
+    session.add(_make_catalyst(stock_name="지난주", event_date=fixed - timedelta(days=7)))
+    session.add(_make_catalyst(stock_name="오늘", event_date=fixed))
     session.commit()
 
     response = client.get("/api/v1/db/catalysts")
@@ -396,6 +420,39 @@ def test_get_catalysts_defaults_to_today_excluding_past(client: TestClient, sess
 def test_get_catalysts_rejects_out_of_range_limit(client: TestClient, limit: int):
     response = client.get("/api/v1/db/catalysts", params={"limit": limit})
     assert response.status_code == 422
+
+
+def test_get_catalysts_rejects_empty_stock_name(client: TestClient):
+    # 빈 문자열은 "필터 없음"이 아니라 "빈 종목명" 필터로 잘못 해석되어 항상 0건을
+    # 반환할 수 있다. 프론트가 "필터 없음"을 빈 문자열로 보내는 실수를 422로 조기에
+    # 드러낸다.
+    response = client.get("/api/v1/db/catalysts", params={"stock_name": ""})
+    assert response.status_code == 422
+
+
+def test_get_catalysts_not_truncated_when_within_limit(client: TestClient, session: Session):
+    today = date.today()
+    session.add(_make_catalyst(stock_name="종목0", event_date=today))
+    session.commit()
+
+    response = client.get("/api/v1/db/catalysts", params={"limit": 3})
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["data"]) == 1
+    assert body["message"] is None
+
+
+def test_get_catalysts_signals_truncation_when_over_limit(client: TestClient, session: Session):
+    today = date.today()
+    for i in range(4):
+        session.add(_make_catalyst(stock_name=f"종목{i}", event_date=today + timedelta(days=i)))
+    session.commit()
+
+    response = client.get("/api/v1/db/catalysts", params={"limit": 3})
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["data"]) == 3
+    assert body["message"] == "truncated"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -314,6 +314,17 @@ def _make_catalyst(
     )
 
 
+@pytest.fixture(name="frozen_today")
+def frozen_today_fixture(monkeypatch: pytest.MonkeyPatch) -> date:
+    # 서버(backend.main.today_kst)와 테스트 픽스처가 같은 "오늘"을 보게 고정한다.
+    # 픽스처를 date.today()(테스트 실행 머신의 로컬 타임존)로 만들고 서버는
+    # today_kst()(KST)를 쓰면, 두 시계가 KST 00:00~08:59에 하루 어긋나 CI(UTC 러너)에서
+    # 픽스처가 필터에서 통째로 빠지는 회귀가 생긴다. 이 픽스처로 그 어긋남을 없앤다.
+    fixed = date(2026, 5, 20)
+    monkeypatch.setattr("backend.main.today_kst", lambda: fixed)
+    return fixed
+
+
 def test_get_catalysts_empty(client: TestClient):
     response = client.get("/api/v1/db/catalysts")
     assert response.status_code == 200
@@ -321,8 +332,8 @@ def test_get_catalysts_empty(client: TestClient):
     assert response.json()["data"] == []
 
 
-def test_get_catalysts_filters_by_stock_name(client: TestClient, session: Session):
-    today = date.today()
+def test_get_catalysts_filters_by_stock_name(client: TestClient, session: Session, frozen_today: date):
+    today = frozen_today
     session.add(_make_catalyst(stock_name="삼성전자", event_date=today))
     session.add(_make_catalyst(stock_name="SK하이닉스", event_date=today))
     session.commit()
@@ -347,8 +358,8 @@ def test_get_catalysts_from_date_excludes_past_events(client: TestClient, sessio
     assert names == ["오늘", "미래"]
 
 
-def test_get_catalysts_limit_boundary(client: TestClient, session: Session):
-    today = date.today()
+def test_get_catalysts_limit_boundary(client: TestClient, session: Session, frozen_today: date):
+    today = frozen_today
     for i in range(5):
         session.add(
             _make_catalyst(
@@ -364,8 +375,8 @@ def test_get_catalysts_limit_boundary(client: TestClient, session: Session):
     assert [row["stock_name"] for row in data] == ["종목0", "종목1", "종목2"]
 
 
-def test_get_catalysts_sorted_by_event_date_ascending(client: TestClient, session: Session):
-    today = date.today()
+def test_get_catalysts_sorted_by_event_date_ascending(client: TestClient, session: Session, frozen_today: date):
+    today = frozen_today
     session.add(_make_catalyst(stock_name="가장늦음", event_date=today + timedelta(days=10)))
     session.add(_make_catalyst(stock_name="가장이름", event_date=today))
     session.add(_make_catalyst(stock_name="중간", event_date=today + timedelta(days=5)))
@@ -377,21 +388,60 @@ def test_get_catalysts_sorted_by_event_date_ascending(client: TestClient, sessio
     assert names == ["가장이름", "중간", "가장늦음"]
 
 
-def test_get_catalysts_ties_break_by_event_type_then_id(client: TestClient, session: Session):
+def test_get_catalysts_ties_break_by_event_type_then_id(
+    client: TestClient, session: Session, frozen_today: date
+):
     # event_date만으로 정렬하면 같은 날짜 이벤트 간 순서가 SQL상 보장되지 않아 limit
-    # 절단이 비결정적일 수 있다. event_type을 오름차순 tie-break로 추가했는지 확인한다.
-    # 삽입 순서(C, A, B)를 event_type 오름차순(A, B, C)과 반대로 둬, id(삽입 순서)로만
-    # 정렬되는 경우와 구분되게 한다.
-    today = date.today()
+    # 절단이 비결정적일 수 있다. event_type 오름차순 tie-break와, event_type까지 같을 때
+    # id(삽입 순서) tie-break가 둘 다 동작하는지 확인한다.
+    today = frozen_today
+    # event_type이 다른 경우: 삽입 순서(C, A, B)를 event_type 오름차순(A, B, C)과
+    # 반대로 둬, id로만 정렬되는 경우와 구분되게 한다.
     session.add(_make_catalyst(stock_name="C", event_date=today, event_type="c_type"))
     session.add(_make_catalyst(stock_name="A", event_date=today, event_type="a_type"))
     session.add(_make_catalyst(stock_name="B", event_date=today, event_type="b_type"))
+    # event_date, event_type이 모두 같은 경우: id(삽입 순서)로 tie-break되는지 확인.
+    # stock_name은 삽입 순서와 반대로 둬, id가 아닌 다른 기준으로 정렬되면 실패하게 한다.
+    session.add(_make_catalyst(stock_name="First", event_date=today, event_type="a_type"))
+    session.add(_make_catalyst(stock_name="Second", event_date=today, event_type="a_type"))
     session.commit()
 
     response = client.get("/api/v1/db/catalysts")
     assert response.status_code == 200
     names = [row["stock_name"] for row in response.json()["data"]]
-    assert names == ["A", "B", "C"]
+    assert names == ["A", "First", "Second", "B", "C"]
+
+
+def test_get_catalysts_order_by_includes_id_as_final_tie_break(
+    client: TestClient, session: Session, monkeypatch: pytest.MonkeyPatch
+):
+    # SQLite는 이 테이블(rowid 테이블, id가 곧 rowid)에서 물리적 저장 순서가 이미
+    # id 오름차순이고 정렬기도 안정적이라, id를 order_by에서 빼도 지금 규모의 인메모리
+    # 테스트 데이터로는 "우연히" 같은 결과가 나와 동작 테스트로는 그 뮤테이션을 잡지
+    # 못한다(위 tie-break 테스트가 실제로 보여준 한계). 그래서 실행 결과 대신 쿼리가
+    # id까지 명시적으로 order_by에 넣도록 "요청"하는지를 화이트박스로 고정한다 —
+    # 우연한 안정성이 아니라 계약으로 결정성을 보장한다.
+    captured_sql: list[str] = []
+    original_exec = session.exec
+
+    def spy_exec(statement, *args, **kwargs):
+        captured_sql.append(str(statement))
+        return original_exec(statement, *args, **kwargs)
+
+    monkeypatch.setattr(session, "exec", spy_exec)
+
+    response = client.get("/api/v1/db/catalysts")
+    assert response.status_code == 200
+    assert captured_sql, "session.exec가 호출되지 않았다"
+
+    order_by_clause = captured_sql[0].split("ORDER BY", 1)[1]
+    assert "catalystevent.event_date" in order_by_clause
+    assert "catalystevent.event_type" in order_by_clause
+    assert "catalystevent.id" in order_by_clause
+    # id가 마지막 tie-break여야 한다: event_type보다 뒤에 나와야 한다.
+    assert order_by_clause.index("catalystevent.event_type") < order_by_clause.index(
+        "catalystevent.id"
+    )
 
 
 def test_get_catalysts_defaults_to_today_excluding_past(
@@ -430,8 +480,10 @@ def test_get_catalysts_rejects_empty_stock_name(client: TestClient):
     assert response.status_code == 422
 
 
-def test_get_catalysts_not_truncated_when_within_limit(client: TestClient, session: Session):
-    today = date.today()
+def test_get_catalysts_not_truncated_when_within_limit(
+    client: TestClient, session: Session, frozen_today: date
+):
+    today = frozen_today
     session.add(_make_catalyst(stock_name="종목0", event_date=today))
     session.commit()
 
@@ -442,8 +494,10 @@ def test_get_catalysts_not_truncated_when_within_limit(client: TestClient, sessi
     assert body["message"] is None
 
 
-def test_get_catalysts_signals_truncation_when_over_limit(client: TestClient, session: Session):
-    today = date.today()
+def test_get_catalysts_signals_truncation_when_over_limit(
+    client: TestClient, session: Session, frozen_today: date
+):
+    today = frozen_today
     for i in range(4):
         session.add(_make_catalyst(stock_name=f"종목{i}", event_date=today + timedelta(days=i)))
     session.commit()

--- a/backend/timeutil.py
+++ b/backend/timeutil.py
@@ -1,0 +1,9 @@
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
+
+KST = ZoneInfo("Asia/Seoul")
+
+
+def today_kst() -> date:
+    """KST(Asia/Seoul) 기준 오늘 날짜를 반환한다."""
+    return datetime.now(KST).date()

--- a/backend/trading_orders.py
+++ b/backend/trading_orders.py
@@ -4,12 +4,11 @@ import json
 from dataclasses import dataclass
 from datetime import datetime, time
 from typing import Any, Awaitable, Callable, Literal
-from zoneinfo import ZoneInfo
 
 from fastapi import HTTPException
 
+from .timeutil import KST
 
-KST = ZoneInfo("Asia/Seoul")
 OrderSide = Literal["BUY", "SELL"]
 OrderType = Literal["LIMIT", "MARKET"]
 


### PR DESCRIPTION
﻿## 요약

Closes #228

`GET /api/v1/db/catalysts` 엔드포인트를 신설해 저장된 촉매 이벤트(실적/배당/공시/주총 등)를 조회할 수 있게 한다. 프론트 시간 링(캘린더 시각화)이 이 API로 이벤트 목록을 시간축 순서대로 받는다.

## 구현

기존 `/api/v1/db/*` 4종(`get_db_portfolio`, `get_db_trades`, `get_db_reports`, `get_db_diary`)과 동일한 규약을 따른다.

- `response_model=CommonResponse`, `tags=["Database"]`
- `session: Session = Depends(get_session)`
- `{"status": "success", "data": ...}` 반환

쿼리 파라미터:

| 이름 | 기본값 | 동작 |
|---|---|---|
| `stock_name` | `None` (전체) | 종목명 정확 일치 필터 |
| `from_date` | 오늘 | `event_date >= from_date` |
| `limit` | 100 | 결과 상한 (`ge=1, le=500`) |

정렬은 `event_date` 오름차순이다.

## 판단 근거

**`catalyst_repo.py`를 쓰지 않은 이유**: `SqliteCatalystEventRepo.list_upcoming`은 `stock_name`이 필수 인자라 전체 종목 조회에 그대로 쓸 수 없다. 필수 인자를 옵셔널로 바꾸면 기존 `/catalysts` 텔레그램 명령 등 다른 호출부의 계약을 흔들 수 있어, 이번 이슈 범위를 넘어서는 변경이 된다. 기존 `/api/v1/db/*` 4종도 모두 `main.py`에서 `session.exec(select(...))`를 직접 실행하는 방식이라, 같은 패턴을 그대로 따르는 편이 저장소 관례에 맞고 `catalyst_repo.py`를 건드리지 않아도 된다.

**`limit` 상한(500)/하한(1) 근거**: 캘린더형 시간 링은 한 번에 그릴 이벤트 수가 많아지면 렌더링이 느려지므로 무제한 조회를 막을 상한이 필요하다. 500은 종목별로 저장되는 이벤트 밀도(실적/배당/공시/주총 등 종목당 연 수 건)를 고려할 때 전체 종목을 아울러도 넉넉한 값이다. 하한 1은 0 이하 값으로 빈 응답만 강제하는 무의미한 호출을 막는다. 기본값 100은 `catalyst_repo.list_upcoming`의 기존 기본값(20, 종목 1개 기준)보다 넉넉하게 잡아, 이 엔드포인트가 여러 종목을 한 번에 다루는 전체 조회 용도임을 반영했다.

## 테스트

`backend/tests/test_database.py`에 기존 `get_db_*` 테스트와 같은 픽스처(`session`, `client`)를 사용해 추가했다.

- 빈 테이블 → `data: []`
- `stock_name` 필터가 해당 종목만 반환
- `from_date` 필터가 과거 이벤트를 제외
- `limit` 경계 — limit보다 많은 행이 있을 때 정확히 limit개
- 정렬 — `event_date` 오름차순

- 절단 경계 — 정확히 `limit`개일 때는 `message`가 `null`
- `ORDER BY`에 `id`가 마지막 tie-break로 들어가는지(화이트박스)

`uv run --project backend pytest backend/tests/` 전체 통과 확인(383 passed, 2 skipped — 스킵된 2건은 기존 Redis 통합 테스트로 이번 변경과 무관).

**`id` tie-break 커버리지에 대한 정정**: 앞선 코멘트에서 "`event_date`·`event_type`이 둘 다 같은 케이스를 추가해 닫았습니다"라고 적었으나, 실제로 뮤턴트를 잡는 것은 **화이트박스 테스트 쪽**입니다. SQLite는 이 테이블(rowid 테이블, `id`가 곧 rowid)에서 물리적 저장 순서가 이미 `id` 오름차순이고 정렬기도 안정적이라, `order_by`에서 `id`를 빼도 동작 테스트로는 우연히 같은 결과가 나옵니다. 코드 주석에는 이 한계가 정확히 적혀 있는데 코멘트 쪽 요약이 앞서 나갔습니다.

## API 계약 — `message: "truncated"`

결과가 `limit`에 걸려 잘린 경우 `CommonResponse.message`에 문자열 `"truncated"`가 들어갑니다. 잘리지 않았으면 `null`입니다. **프론트가 문자열 비교로 읽어야 하는 값**입니다.

판정식은 `len(rows) > limit`입니다(`limit + 1`건을 조회해 비교). 정확히 `limit`개는 절단이 **아닙니다**.

`CommonResponse.message`는 원래 사람이 읽는 필드인데 기계 판독 플래그를 겸하게 된 셈입니다. 별도 boolean 필드가 깔끔하지만 `CommonResponse` 변경은 `/api/v1/db/*` 4종 전체에 파급되므로, 이번에는 기존 필드를 쓰고 계약을 여기에 명시하는 쪽을 택했습니다.

잘린 뒷부분을 가져올 수단(`to_date` 구간 조회)은 후속 이슈 #238입니다.

## 변경 파일

- `backend/main.py` — 엔드포인트 신설
- `backend/tests/test_database.py` — 라우트 테스트
- `backend/timeutil.py` — **신설**. `KST`와 `today_kst()`를 공용 모듈로 승격
- `backend/scheduler.py` — 자체 정의하던 `KST`를 `timeutil`에서 가져오도록 변경
- `backend/trading_orders.py` — 위와 동일
- `backend/telegram_commands.py` — `KST`를 `trading_orders` 경유 대신 `timeutil`에서 직접 import

타임존 상수를 공용 모듈로 올린 것은 1차 리뷰의 Critical(서버 로컬 타임존 의존)을 해소하는 과정에서 나왔습니다. `from_date` 기본값이 배포 환경(UTC)에서 KST 00:00~08:59 동안 어제를 가리켜 지난 촉매가 노출되던 문제였고, 같은 데이터를 읽는 텔레그램 `/catalysts`가 이미 KST로 고정돼 있어 두 경로가 다른 결과를 내고 있었습니다. `timeutil`은 backend 내 어떤 모듈도 import하지 않아 순환 참조 여지가 없습니다.

