### PR TITLE
feat: Portfolio 동기화 성공 시 PORTFOLIO_UPDATE WebSocket 브로드캐스트 추가 (#229)

### DIFF
--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -625,9 +625,9 @@ async def _monitor_market_task(
             try:
                 with Session(engine) as sync_session:
                     sync_result = _sync_portfolio_from_balance(balance_text, sync_session, holdings=holdings)
-                # 브로드캐스트는 실제로 테이블이 바뀐 경우(sync_result is not None)에만
-                # 보낸다. 잘림·마커 부재로 건너뛴 경우 테이블이 그대로이므로 클라이언트가
-                # 다시 조회해도 얻을 게 없다 — 불필요한 재조회를 유발하지 않기 위함이다.
+                # 잘림·마커 부재로 동기화를 건너뛴 경우(None)에는 테이블이 그대로이므로
+                # 브로드캐스트하지 않는다. 동기화가 수행된 경우 전량 교체 특성상 내용이
+                # 직전과 동일해도 신호가 나간다 — 즉 정상 주기마다 1건이다.
                 # payload에는 보유 종목 개수만 싣고 종목명·수량 등 실제 보유 내역은 담지
                 # 않는다. WebSocket에는 인증이 없어(#65) 계좌 보유 현황이 인증 없는
                 # 채널로 유출될 수 있으므로, 신호만 보내고 클라이언트가
@@ -637,7 +637,7 @@ async def _monitor_market_task(
                         await manager.broadcast({
                             "type": "PORTFOLIO_UPDATE",
                             "holdings_count": sync_result,
-                            "updated_at": datetime.now(timezone.utc).isoformat(),
+                            "broadcast_at": datetime.now(timezone.utc).isoformat(),
                         })
                     except Exception as e:
                         logger.error(

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -279,7 +279,7 @@ def _sync_portfolio_from_balance(
     session: Session,
     *,
     holdings: list[_BalanceHolding] | None = None,
-) -> None:
+) -> int | None:
     """get_balance 응답을 바탕으로 Portfolio 테이블을 동기화합니다.
 
     전략: 전량 교체 (기존 행 전체 삭제 후 신규 삽입). 매 잔고 조회마다 실행되어
@@ -296,12 +296,19 @@ def _sync_portfolio_from_balance(
     holdings: 호출처에서 이미 _parse_balance_holdings를 실행한 경우 그 결과를 전달하면
     재파싱을 건너뜁니다. None이면 balance_text에서 직접 파싱합니다.
     잘림·마커 가드는 holdings 인자 유무에 관계없이 항상 balance_text를 검사합니다.
+
+    반환값(이슈 #229): 동기화를 실제로 수행했으면 삽입한 종목 수(int, 0 이상)를,
+    잘림·마커 부재로 건너뛰었으면 None을 반환합니다. bool 대신 개수를 반환하는 이유는
+    호출처(monitor_market_task)가 WebSocket으로 PORTFOLIO_UPDATE를 브로드캐스트할 때
+    holdings_count를 함께 실어야 하는데, bool만으로는 호출처가 그 값을 얻기 위해
+    holdings 리스트를 별도로 들고 있거나 다시 세야 하기 때문입니다. int 반환값 자체가
+    "동기화 성공 여부"와 "성공 시 종목 수"를 한 번에 전달합니다.
     """
     if is_balance_truncated(balance_text):
         logger.warning(
             "잔고 연속조회가 잘려 Portfolio 동기화를 건너뜁니다. 기존 데이터를 유지합니다."
         )
-        return
+        return None
 
     # 마커가 없으면 "보유 0건"이 아니라 "응답을 읽지 못함"이다.
     # balance.js는 보유 종목이 없어도 마커와 "보유 종목이 없습니다."를 항상 출력한다
@@ -315,7 +322,7 @@ def _sync_portfolio_from_balance(
             _BALANCE_HOLDINGS_MARKER,
             len(balance_text),
         )
-        return
+        return None
 
 
     # 호출처에서 이미 파싱한 결과가 있으면 재파싱을 건너뛴다(경고 중복 방지).
@@ -342,6 +349,7 @@ def _sync_portfolio_from_balance(
 
     session.commit()
     logger.info("Portfolio 동기화 완료: %d개 종목", len(holdings))
+    return len(holdings)
 
 
 def _infer_catalyst_event_type(description: str) -> str:
@@ -616,7 +624,27 @@ async def _monitor_market_task(
             # 동기화 실패는 감시 루프에 영향을 주지 않아야 하므로 예외를 격리합니다.
             try:
                 with Session(engine) as sync_session:
-                    _sync_portfolio_from_balance(balance_text, sync_session, holdings=holdings)
+                    sync_result = _sync_portfolio_from_balance(balance_text, sync_session, holdings=holdings)
+                # 브로드캐스트는 실제로 테이블이 바뀐 경우(sync_result is not None)에만
+                # 보낸다. 잘림·마커 부재로 건너뛴 경우 테이블이 그대로이므로 클라이언트가
+                # 다시 조회해도 얻을 게 없다 — 불필요한 재조회를 유발하지 않기 위함이다.
+                # payload에는 보유 종목 개수만 싣고 종목명·수량 등 실제 보유 내역은 담지
+                # 않는다. WebSocket에는 인증이 없어(#65) 계좌 보유 현황이 인증 없는
+                # 채널로 유출될 수 있으므로, 신호만 보내고 클라이언트가
+                # /api/v1/db/portfolio를 재조회하도록 한다.
+                if sync_result is not None:
+                    try:
+                        await manager.broadcast({
+                            "type": "PORTFOLIO_UPDATE",
+                            "holdings_count": sync_result,
+                            "updated_at": datetime.now(timezone.utc).isoformat(),
+                        })
+                    except Exception as e:
+                        logger.error(
+                            "Portfolio 업데이트 브로드캐스트 중 오류 (감시는 계속): %s",
+                            e,
+                            exc_info=True,
+                        )
             except Exception as e:
                 logger.error("Portfolio 동기화 중 오류 (감시는 계속): %s", e, exc_info=True)
 

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -240,22 +240,31 @@ async def test_monitor_market_task_filtering(monkeypatch):
     monkeypatch.setattr("backend.scheduler.perform_stock_analysis", mock_perform_analysis)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", mock_broadcast)
     monkeypatch.setattr("backend.scheduler.redis_state", unavailable_redis_state)
-    
+    # 이 테스트의 관심사는 뉴스 필터링이지 Portfolio 동기화가 아니다.
+    # 동기화를 건너뜀(None)으로 고정하면 PORTFOLIO_UPDATE가 나가지 않아
+    # 기존 기대값이 그대로 유효하고, 실 DB 상태에도 좌우되지 않는다.
+    monkeypatch.setattr(
+        "backend.scheduler._sync_portfolio_from_balance",
+        lambda balance_text, session, **kwargs: None,
+    )
+
+    def _agent_analysis_calls():
+        return [
+            c for c in mock_broadcast.call_args_list
+            if c.args[0].get("type") == "AGENT_ANALYSIS"
+        ]
+
     # 1. 첫 번째 실행: 뉴스가 처음이므로 분석 수행
-    # 마커가 있고 잘리지 않은 잔고이므로 _sync_portfolio_from_balance(mock되지 않음)가
-    # 매 호출마다 실제로 성공해 PORTFOLIO_UPDATE 1건이 항상 추가된다(이슈 #229).
-    # 종목별 AGENT_ANALYSIS 3건 + PORTFOLIO_UPDATE 1건 = 4건.
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
     assert mock_perform_analysis.call_count == 3 # 삼성전자, SK하이닉스, 현대차
-    assert mock_broadcast.call_count == 4
+    assert len(_agent_analysis_calls()) == 3
 
-    # 2. 두 번째 실행: 뉴스가 동일하므로 분석 스킵. Portfolio 동기화는 뉴스 변경 여부와
-    # 무관하게 매 주기 실행되므로 PORTFOLIO_UPDATE 1건은 그대로 나간다.
+    # 2. 두 번째 실행: 뉴스가 동일하므로 분석 스킵
     mock_perform_analysis.reset_mock()
     mock_broadcast.reset_mock()
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
     assert mock_perform_analysis.call_count == 0
-    assert mock_broadcast.call_count == 1
+    assert len(_agent_analysis_calls()) == 0
 
     # 3. 세 번째 실행: 뉴스가 변경된 종목이 있으면 해당 종목만 분석
     async def mock_run_mcp_tool_changed(params, name, args):
@@ -270,8 +279,7 @@ async def test_monitor_market_task_filtering(monkeypatch):
     mock_broadcast.reset_mock()
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
     assert mock_perform_analysis.call_count == 1
-    # AGENT_ANALYSIS 1건 + PORTFOLIO_UPDATE 1건 = 2건.
-    assert mock_broadcast.call_count == 2
+    assert len(_agent_analysis_calls()) == 1
     assert mock_perform_analysis.call_args[0][0] == "삼성전자"
 
 
@@ -524,15 +532,21 @@ async def test_monitor_market_task_uses_default_stocks_when_balance_empty(monkey
     monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
     monkeypatch.setattr("backend.scheduler.perform_stock_analysis", mock_perform_analysis)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", mock_broadcast)
+    # 이 테스트의 관심사는 기본 감시 종목 사용 여부이지 Portfolio 동기화가 아니다.
+    # 동기화를 건너뜀(None)으로 고정하면 PORTFOLIO_UPDATE가 나가지 않아
+    # 기존 기대값이 그대로 유효하고, 실 DB 상태에도 좌우되지 않는다.
+    monkeypatch.setattr(
+        "backend.scheduler._sync_portfolio_from_balance",
+        lambda balance_text, session, **kwargs: None,
+    )
 
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
 
     assert len(DEFAULT_MONITOR_STOCKS) == 4
     assert monitored_stocks == DEFAULT_MONITOR_STOCKS
     assert mock_perform_analysis.call_count == 0
-    # 뉴스 분석 브로드캐스트는 없지만, 잔고 응답에 마커가 있고 잘리지 않았으므로
-    # Portfolio 동기화(mock되지 않음)가 성공해 PORTFOLIO_UPDATE 1건이 나간다(이슈 #229).
-    assert mock_broadcast.call_count == 1
+    # 뉴스 분석이 없고 Portfolio 동기화도 건너뛰므로 브로드캐스트가 전혀 없다.
+    assert mock_broadcast.call_count == 0
 
 
 @pytest.mark.asyncio
@@ -568,15 +582,23 @@ async def test_monitor_market_task_uses_redis_hash_to_skip_duplicate_news(monkey
     monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
     monkeypatch.setattr("backend.scheduler.perform_stock_analysis", mock_perform_analysis)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", mock_broadcast)
+    # 이 테스트의 관심사는 Redis 해시로 뉴스 중복을 걸러내는지이지 Portfolio 동기화가
+    # 아니다. 동기화를 건너뜀(None)으로 고정하면 PORTFOLIO_UPDATE가 나가지 않아
+    # AGENT_ANALYSIS만 남는다.
+    monkeypatch.setattr(
+        "backend.scheduler._sync_portfolio_from_balance",
+        lambda balance_text, session, **kwargs: None,
+    )
 
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
 
     assert mock_perform_analysis.call_count == 1
-    # AGENT_ANALYSIS는 첫 호출에서만 1건 나가지만, Portfolio 동기화(mock되지 않음)는
-    # 뉴스 중복 여부와 무관하게 두 호출 모두 성공해 PORTFOLIO_UPDATE가 2건 나간다
-    # (이슈 #229). 1(분석) + 2(동기화) = 3건.
-    assert mock_broadcast.call_count == 3
+    analysis_calls = [
+        c for c in mock_broadcast.call_args_list
+        if c.args[0].get("type") == "AGENT_ANALYSIS"
+    ]
+    assert len(analysis_calls) == 1
 
 
 @pytest.mark.asyncio
@@ -693,6 +715,13 @@ async def test_concurrent_monitor_market_task_runs_once_with_scheduler_lock(monk
     monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
     monkeypatch.setattr("backend.scheduler.perform_stock_analysis", mock_perform_analysis)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", mock_broadcast)
+    # 이 테스트의 관심사는 스케줄러 락에 의한 동시 실행 방지이지 Portfolio 동기화가
+    # 아니다. 동기화를 건너뜀(None)으로 고정하면 PORTFOLIO_UPDATE가 나가지 않아
+    # AGENT_ANALYSIS만 남는다.
+    monkeypatch.setattr(
+        "backend.scheduler._sync_portfolio_from_balance",
+        lambda balance_text, session, **kwargs: None,
+    )
 
     await asyncio.gather(
         monitor_market_task(watchlist_repo=FakeWatchlistRepo()),
@@ -700,9 +729,12 @@ async def test_concurrent_monitor_market_task_runs_once_with_scheduler_lock(monk
     )
 
     assert mock_perform_analysis.call_count == 1
-    # 스케줄러 락으로 실제 실행되는 것은 한 쪽뿐이라 AGENT_ANALYSIS 1건 + Portfolio
-    # 동기화(mock되지 않음) 성공에 따른 PORTFOLIO_UPDATE 1건 = 2건이다(이슈 #229).
-    assert mock_broadcast.call_count == 2
+    # 스케줄러 락으로 실제 실행되는 것은 한 쪽뿐이다.
+    analysis_calls = [
+        c for c in mock_broadcast.call_args_list
+        if c.args[0].get("type") == "AGENT_ANALYSIS"
+    ]
+    assert len(analysis_calls) == 1
 
 
 @pytest.mark.asyncio
@@ -1480,14 +1512,19 @@ def test_sync_portfolio_writes_holdings(portfolio_session):
 
     이 테스트가 잡는 mutation: _sync_portfolio_from_balance 호출을 제거하거나
     session.add() 없이 반환하는 회귀 → rows가 비어 assert len==1이 실패한다.
+    반환값도 함께 검증한다: 동기화 성공 시 None이 아니라 삽입한 종목 수를
+    반환해야 monitor_market_task의 PORTFOLIO_UPDATE 브로드캐스트 판단(이슈 #229,
+    `sync_result is not None`)이 성립한다 — 성공 시 무조건 None을 반환하는 회귀는
+    이 assert로 잡힌다.
     """
     from sqlmodel import select
     from ..models import Portfolio
     from ..scheduler import _sync_portfolio_from_balance
 
     text = _make_balance_text(("삼성전자", "005930", 10, 70000))
-    _sync_portfolio_from_balance(text, portfolio_session)
+    result = _sync_portfolio_from_balance(text, portfolio_session)
 
+    assert result == 1
     rows = portfolio_session.exec(select(Portfolio)).all()
     assert len(rows) == 1
     assert rows[0].stock_code == "005930"
@@ -1649,7 +1686,7 @@ async def test_monitor_market_task_broadcasts_portfolio_update_on_sync_success(m
     (실 DB의 portfolio 테이블 존재 여부에 테스트 결과가 좌우되지 않게 하기 위함).
 
     이 테스트가 잡는 mutation: 호출처가 PORTFOLIO_UPDATE 브로드캐스트를 하지 않거나
-    holdings_count/updated_at 형태를 잘못 실으면 아래 단언이 실패한다.
+    holdings_count/broadcast_at 형태를 잘못 실으면 아래 단언이 실패한다.
     """
     from ..scheduler import SignalSource, monitor_market_task
 
@@ -1688,11 +1725,61 @@ async def test_monitor_market_task_broadcasts_portfolio_update_on_sync_success(m
     payload = mock_broadcast.call_args[0][0]
     assert payload["type"] == "PORTFOLIO_UPDATE"
     assert payload["holdings_count"] == 3
-    # updated_at은 ISO 8601로 파싱 가능해야 한다.
-    datetime.fromisoformat(payload["updated_at"])
+    # broadcast_at은 ISO 8601로 파싱 가능해야 한다.
+    datetime.fromisoformat(payload["broadcast_at"])
     # 보유 내역 원본(종목명·수량 등)은 인증 없는 WebSocket으로 나가면 안 된다(#65).
     assert "holdings" not in payload
     assert "stocks" not in payload
+
+
+@pytest.mark.asyncio
+async def test_monitor_market_task_broadcasts_portfolio_update_when_holdings_become_zero(monkeypatch):
+    """보유 종목이 0건으로 동기화되어도 PORTFOLIO_UPDATE를 브로드캐스트합니다.
+
+    _sync_portfolio_from_balance는 실제 보유 0건이면 None이 아니라 0을 반환한다
+    (test_sync_portfolio_allows_genuinely_empty_holdings). 호출처가 `sync_result
+    is not None` 대신 `sync_result`(truthy)로 판단하면 0은 falsy라 이 브로드캐스트가
+    빠진다 — 마지막 남은 보유 종목이 전량 매도된 순간 클라이언트에 신호가 가지 않는
+    회귀다. 이 테스트가 잡는 mutation: 호출처의 None 판단을 truthy 판단으로 바꾸면
+    mock_broadcast.assert_called_once()가 실패한다.
+    """
+    from ..scheduler import SignalSource, monitor_market_task
+
+    @asynccontextmanager
+    async def unavailable_redis_state():
+        raise ConnectionError("redis unavailable")
+        yield
+
+    async def mock_run_mcp_tool(params, name, args):
+        if name == "get_balance":
+            return _make_balance_text(("삼성전자", "005930", 10, 70000))
+        return "news"
+
+    def mock_sync_portfolio(balance_text, session, **kwargs):
+        return 0
+
+    async def mock_check_significance(stock, current, last, *, source, provider):
+        return False
+
+    mock_broadcast = MagicMock(return_value=asyncio.Future())
+    mock_broadcast.return_value.set_result(None)
+
+    monkeypatch.setattr("backend.scheduler.redis_state", unavailable_redis_state)
+    monkeypatch.setattr(
+        "backend.scheduler.SIGNAL_SOURCES",
+        [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
+    )
+    monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
+    monkeypatch.setattr("backend.scheduler._sync_portfolio_from_balance", mock_sync_portfolio)
+    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", mock_broadcast)
+
+    await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
+
+    mock_broadcast.assert_called_once()
+    payload = mock_broadcast.call_args[0][0]
+    assert payload["type"] == "PORTFOLIO_UPDATE"
+    assert payload["holdings_count"] == 0
 
 
 @pytest.mark.asyncio
@@ -1790,6 +1877,12 @@ async def test_monitor_market_task_survives_portfolio_broadcast_failure(monkeypa
     기존 동기화 예외 격리(logger.error(..., "감시는 계속"))와 같은 수준으로 브로드캐스트
     예외도 격리해야 한다. 이 테스트가 잡는 mutation: 브로드캐스트 예외를 격리하지 않으면
     monitor_market_task가 예외를 전파해 await 자체가 실패한다.
+
+    참고: 현재 ConnectionManager.broadcast는 커넥션별 send_json을 각각 try/except로
+    삼켜(ws_manager.py:26-32) 스스로 예외를 던지지 않으므로, 이 시나리오는 실제
+    운영 경로에서는 아직 발생할 수 없다. 이 테스트는 monitor_market_task 쪽 방어
+    코드가 지키는 계약을 문서화하는 성격이며, ws_manager의 예외 처리가 바뀌면
+    (예: 커넥션이 아니라 broadcast 자체가 실패를 전파하도록 바뀌면) 실효를 갖는다.
     """
     from ..scheduler import SignalSource, monitor_market_task
 
@@ -1918,7 +2011,9 @@ def test_sync_portfolio_allows_genuinely_empty_holdings(portfolio_session):
     """마커는 있지만 보유 종목이 없는 응답("보유 종목이 없습니다.")은
     실제 0건으로 처리해 기존 데이터를 전량 삭제합니다.
 
-    마커 가드가 "실제 0건"을 막아서는 안 됩니다.
+    마커 가드가 "실제 0건"을 막아서는 안 됩니다. 반환값도 0이어야 한다 — None을
+    반환하면 monitor_market_task가 "동기화를 건너뛴 것"으로 오인해(이슈 #229)
+    보유 0건으로 갱신됐다는 PORTFOLIO_UPDATE를 브로드캐스트하지 않게 된다.
     """
     from sqlmodel import select
     from ..models import Portfolio
@@ -1935,8 +2030,9 @@ def test_sync_portfolio_allows_genuinely_empty_holdings(portfolio_session):
         "[보유 종목 리스트]\n"
         "보유 종목이 없습니다."
     )
-    _sync_portfolio_from_balance(empty_holdings_text, portfolio_session)
+    result = _sync_portfolio_from_balance(empty_holdings_text, portfolio_session)
 
+    assert result == 0, "실제 보유 0건 동기화는 None이 아니라 0을 반환해야 합니다"
     rows = portfolio_session.exec(select(Portfolio)).all()
     assert len(rows) == 0, "실제 보유 0건이면 기존 데이터를 삭제해야 합니다"
 

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -10,6 +10,19 @@ from ..redis_state import RedisSchedulerState
 from .test_balance_parser import TRUNCATION_NOTES_BY_REASON
 
 
+def _resolved_broadcast_mock() -> MagicMock:
+    """resolve된 Future를 반환하는 manager.broadcast mock.
+
+    이슈 #229로 Portfolio 동기화가 성공하면 실제로 await manager.broadcast(...)가
+    호출된다. 반환 Future를 resolve하지 않으면 (과거에는 broadcast가 전혀 호출되지
+    않아 무해했지만) 이제는 await가 영원히 멈춘다. 브로드캐스트 호출 자체를 검증하지
+    않는 테스트들이 이 헬퍼를 쓴다.
+    """
+    mock = MagicMock(return_value=asyncio.Future())
+    mock.return_value.set_result(None)
+    return mock
+
+
 class FakeWatchlistRepo:
     def __init__(self, stocks: list[str] | None = None):
         self._stocks = list(stocks or [])
@@ -721,12 +734,7 @@ async def test_monitor_market_task_includes_watchlist_stocks(monkeypatch):
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
     monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
-    # 이슈 #229: Portfolio 동기화 성공 시 실제로 await manager.broadcast(...)가 호출될 수
-    # 있으므로, 이 mock의 반환 Future는 반드시 resolve되어야 한다. resolve하지 않으면
-    # (과거에는 broadcast가 전혀 호출되지 않아 무해했지만) 이제는 await가 영원히 멈춘다.
-    _resolved_broadcast = MagicMock(return_value=asyncio.Future())
-    _resolved_broadcast.return_value.set_result(None)
-    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast_mock())
 
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo(["NAVER"]))
 
@@ -763,12 +771,7 @@ async def test_monitor_market_task_continues_owned_stock_when_watchlist_fails(mo
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
     monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
-    # 이슈 #229: Portfolio 동기화 성공 시 실제로 await manager.broadcast(...)가 호출될 수
-    # 있으므로, 이 mock의 반환 Future는 반드시 resolve되어야 한다. resolve하지 않으면
-    # (과거에는 broadcast가 전혀 호출되지 않아 무해했지만) 이제는 await가 영원히 멈춘다.
-    _resolved_broadcast = MagicMock(return_value=asyncio.Future())
-    _resolved_broadcast.return_value.set_result(None)
-    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast_mock())
 
     await monitor_market_task(watchlist_repo=FailingWatchlistRepo())
 
@@ -804,12 +807,7 @@ async def test_monitor_market_task_deduplicates_watchlist_and_owned_stocks(monke
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
     monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
-    # 이슈 #229: Portfolio 동기화 성공 시 실제로 await manager.broadcast(...)가 호출될 수
-    # 있으므로, 이 mock의 반환 Future는 반드시 resolve되어야 한다. resolve하지 않으면
-    # (과거에는 broadcast가 전혀 호출되지 않아 무해했지만) 이제는 await가 영원히 멈춘다.
-    _resolved_broadcast = MagicMock(return_value=asyncio.Future())
-    _resolved_broadcast.return_value.set_result(None)
-    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast_mock())
 
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo(["삼성전자"]))
 
@@ -845,12 +843,7 @@ async def test_monitor_market_task_uses_default_stocks_only_when_both_empty(monk
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
     monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
-    # 이슈 #229: Portfolio 동기화 성공 시 실제로 await manager.broadcast(...)가 호출될 수
-    # 있으므로, 이 mock의 반환 Future는 반드시 resolve되어야 한다. resolve하지 않으면
-    # (과거에는 broadcast가 전혀 호출되지 않아 무해했지만) 이제는 await가 영원히 멈춘다.
-    _resolved_broadcast = MagicMock(return_value=asyncio.Future())
-    _resolved_broadcast.return_value.set_result(None)
-    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast_mock())
 
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
 
@@ -886,12 +879,7 @@ async def test_monitor_market_task_watchlist_alone_skips_default_fallback(monkey
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
     monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
-    # 이슈 #229: Portfolio 동기화 성공 시 실제로 await manager.broadcast(...)가 호출될 수
-    # 있으므로, 이 mock의 반환 Future는 반드시 resolve되어야 한다. resolve하지 않으면
-    # (과거에는 broadcast가 전혀 호출되지 않아 무해했지만) 이제는 await가 영원히 멈춘다.
-    _resolved_broadcast = MagicMock(return_value=asyncio.Future())
-    _resolved_broadcast.return_value.set_result(None)
-    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast_mock())
 
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo(["카카오"]))
 
@@ -1089,12 +1077,7 @@ async def test_monitor_market_task_logs_warning_when_balance_truncated(monkeypat
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
     monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
-    # 이슈 #229: Portfolio 동기화 성공 시 실제로 await manager.broadcast(...)가 호출될 수
-    # 있으므로, 이 mock의 반환 Future는 반드시 resolve되어야 한다. resolve하지 않으면
-    # (과거에는 broadcast가 전혀 호출되지 않아 무해했지만) 이제는 await가 영원히 멈춘다.
-    _resolved_broadcast = MagicMock(return_value=asyncio.Future())
-    _resolved_broadcast.return_value.set_result(None)
-    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast_mock())
 
     with caplog.at_level(logging.WARNING, logger=scheduler_module.logger.name):
         await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
@@ -1137,12 +1120,7 @@ async def test_monitor_market_task_no_warning_when_balance_not_truncated(monkeyp
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
     monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
-    # 이슈 #229: Portfolio 동기화 성공 시 실제로 await manager.broadcast(...)가 호출될 수
-    # 있으므로, 이 mock의 반환 Future는 반드시 resolve되어야 한다. resolve하지 않으면
-    # (과거에는 broadcast가 전혀 호출되지 않아 무해했지만) 이제는 await가 영원히 멈춘다.
-    _resolved_broadcast = MagicMock(return_value=asyncio.Future())
-    _resolved_broadcast.return_value.set_result(None)
-    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast_mock())
 
     with caplog.at_level(logging.WARNING, logger=scheduler_module.logger.name):
         await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
@@ -1185,12 +1163,7 @@ async def test_monitor_market_task_still_watches_stocks_returned_despite_truncat
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
     monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
-    # 이슈 #229: Portfolio 동기화 성공 시 실제로 await manager.broadcast(...)가 호출될 수
-    # 있으므로, 이 mock의 반환 Future는 반드시 resolve되어야 한다. resolve하지 않으면
-    # (과거에는 broadcast가 전혀 호출되지 않아 무해했지만) 이제는 await가 영원히 멈춘다.
-    _resolved_broadcast = MagicMock(return_value=asyncio.Future())
-    _resolved_broadcast.return_value.set_result(None)
-    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast_mock())
 
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
 
@@ -1228,12 +1201,7 @@ def _make_balance_failure_mocks(monkeypatch, mock_run_mcp_tool_fn):
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool_fn)
     monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
-    # 이슈 #229: Portfolio 동기화 성공 시 실제로 await manager.broadcast(...)가 호출될 수
-    # 있으므로, 이 mock의 반환 Future는 반드시 resolve되어야 한다. resolve하지 않으면
-    # (과거에는 broadcast가 전혀 호출되지 않아 무해했지만) 이제는 await가 영원히 멈춘다.
-    _resolved_broadcast = MagicMock(return_value=asyncio.Future())
-    _resolved_broadcast.return_value.set_result(None)
-    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast_mock())
 
     return state
 
@@ -1617,12 +1585,7 @@ async def test_monitor_market_task_syncs_portfolio_when_balance_succeeds(monkeyp
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
     monkeypatch.setattr("backend.scheduler._sync_portfolio_from_balance", mock_sync_portfolio)
     monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
-    # 이슈 #229: Portfolio 동기화 성공 시 실제로 await manager.broadcast(...)가 호출될 수
-    # 있으므로, 이 mock의 반환 Future는 반드시 resolve되어야 한다. resolve하지 않으면
-    # (과거에는 broadcast가 전혀 호출되지 않아 무해했지만) 이제는 await가 영원히 멈춘다.
-    _resolved_broadcast = MagicMock(return_value=asyncio.Future())
-    _resolved_broadcast.return_value.set_result(None)
-    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast_mock())
 
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
 
@@ -1665,12 +1628,7 @@ async def test_monitor_market_task_does_not_sync_when_balance_fails(monkeypatch)
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
     monkeypatch.setattr("backend.scheduler._sync_portfolio_from_balance", mock_sync_portfolio)
     monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
-    # 이슈 #229: Portfolio 동기화 성공 시 실제로 await manager.broadcast(...)가 호출될 수
-    # 있으므로, 이 mock의 반환 Future는 반드시 resolve되어야 한다. resolve하지 않으면
-    # (과거에는 broadcast가 전혀 호출되지 않아 무해했지만) 이제는 await가 영원히 멈춘다.
-    _resolved_broadcast = MagicMock(return_value=asyncio.Future())
-    _resolved_broadcast.return_value.set_result(None)
-    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast_mock())
 
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo(["카카오"]))
 

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -1,7 +1,7 @@
 import pytest
 import asyncio
 from contextlib import asynccontextmanager
-from datetime import date
+from datetime import date, datetime
 from types import SimpleNamespace
 from fastapi.testclient import TestClient
 from unittest.mock import MagicMock
@@ -229,17 +229,21 @@ async def test_monitor_market_task_filtering(monkeypatch):
     monkeypatch.setattr("backend.scheduler.redis_state", unavailable_redis_state)
     
     # 1. 첫 번째 실행: 뉴스가 처음이므로 분석 수행
+    # 마커가 있고 잘리지 않은 잔고이므로 _sync_portfolio_from_balance(mock되지 않음)가
+    # 매 호출마다 실제로 성공해 PORTFOLIO_UPDATE 1건이 항상 추가된다(이슈 #229).
+    # 종목별 AGENT_ANALYSIS 3건 + PORTFOLIO_UPDATE 1건 = 4건.
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
     assert mock_perform_analysis.call_count == 3 # 삼성전자, SK하이닉스, 현대차
-    assert mock_broadcast.call_count == 3
-    
-    # 2. 두 번째 실행: 뉴스가 동일하므로 분석 스킵
+    assert mock_broadcast.call_count == 4
+
+    # 2. 두 번째 실행: 뉴스가 동일하므로 분석 스킵. Portfolio 동기화는 뉴스 변경 여부와
+    # 무관하게 매 주기 실행되므로 PORTFOLIO_UPDATE 1건은 그대로 나간다.
     mock_perform_analysis.reset_mock()
     mock_broadcast.reset_mock()
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
     assert mock_perform_analysis.call_count == 0
-    assert mock_broadcast.call_count == 0
-    
+    assert mock_broadcast.call_count == 1
+
     # 3. 세 번째 실행: 뉴스가 변경된 종목이 있으면 해당 종목만 분석
     async def mock_run_mcp_tool_changed(params, name, args):
         if name == "get_balance":
@@ -247,11 +251,14 @@ async def test_monitor_market_task_filtering(monkeypatch):
         if args.get('stock_name') == "삼성전자":
             return "NEW NEWS for Samsung"
         return f"Latest news for {args.get('stock_name')}"
-        
+
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool_changed)
+    mock_perform_analysis.reset_mock()
+    mock_broadcast.reset_mock()
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
     assert mock_perform_analysis.call_count == 1
-    assert mock_broadcast.call_count == 1
+    # AGENT_ANALYSIS 1건 + PORTFOLIO_UPDATE 1건 = 2건.
+    assert mock_broadcast.call_count == 2
     assert mock_perform_analysis.call_args[0][0] == "삼성전자"
 
 
@@ -510,7 +517,9 @@ async def test_monitor_market_task_uses_default_stocks_when_balance_empty(monkey
     assert len(DEFAULT_MONITOR_STOCKS) == 4
     assert monitored_stocks == DEFAULT_MONITOR_STOCKS
     assert mock_perform_analysis.call_count == 0
-    assert mock_broadcast.call_count == 0
+    # 뉴스 분석 브로드캐스트는 없지만, 잔고 응답에 마커가 있고 잘리지 않았으므로
+    # Portfolio 동기화(mock되지 않음)가 성공해 PORTFOLIO_UPDATE 1건이 나간다(이슈 #229).
+    assert mock_broadcast.call_count == 1
 
 
 @pytest.mark.asyncio
@@ -551,7 +560,10 @@ async def test_monitor_market_task_uses_redis_hash_to_skip_duplicate_news(monkey
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
 
     assert mock_perform_analysis.call_count == 1
-    assert mock_broadcast.call_count == 1
+    # AGENT_ANALYSIS는 첫 호출에서만 1건 나가지만, Portfolio 동기화(mock되지 않음)는
+    # 뉴스 중복 여부와 무관하게 두 호출 모두 성공해 PORTFOLIO_UPDATE가 2건 나간다
+    # (이슈 #229). 1(분석) + 2(동기화) = 3건.
+    assert mock_broadcast.call_count == 3
 
 
 @pytest.mark.asyncio
@@ -597,7 +609,14 @@ async def test_monitor_market_task_processes_multiple_signal_sources_independent
         "get_market_news: 삼성전자",
         "get_stock_mentions: 삼성전자",
     ]
-    assert [call.args[0]["source"] for call in mock_broadcast.call_args_list] == ["news", "sns"]
+    # PORTFOLIO_UPDATE(이슈 #229)에는 "source" 키가 없으므로 AGENT_ANALYSIS 브로드캐스트만
+    # 걸러서 검사한다. 잔고 응답에 마커가 있고 잘리지 않아 Portfolio 동기화도 성공하지만
+    # (mock되지 않음), 이 테스트의 관심사는 신호 소스별 분석 브로드캐스트 순서다.
+    analysis_broadcasts = [
+        call.args[0] for call in mock_broadcast.call_args_list
+        if call.args[0].get("type") == "AGENT_ANALYSIS"
+    ]
+    assert [payload["source"] for payload in analysis_broadcasts] == ["news", "sns"]
 
 
 @pytest.mark.asyncio
@@ -668,7 +687,9 @@ async def test_concurrent_monitor_market_task_runs_once_with_scheduler_lock(monk
     )
 
     assert mock_perform_analysis.call_count == 1
-    assert mock_broadcast.call_count == 1
+    # 스케줄러 락으로 실제 실행되는 것은 한 쪽뿐이라 AGENT_ANALYSIS 1건 + Portfolio
+    # 동기화(mock되지 않음) 성공에 따른 PORTFOLIO_UPDATE 1건 = 2건이다(이슈 #229).
+    assert mock_broadcast.call_count == 2
 
 
 @pytest.mark.asyncio
@@ -700,7 +721,12 @@ async def test_monitor_market_task_includes_watchlist_stocks(monkeypatch):
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
     monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
-    monkeypatch.setattr("backend.scheduler.manager.broadcast", MagicMock(return_value=asyncio.Future()))
+    # 이슈 #229: Portfolio 동기화 성공 시 실제로 await manager.broadcast(...)가 호출될 수
+    # 있으므로, 이 mock의 반환 Future는 반드시 resolve되어야 한다. resolve하지 않으면
+    # (과거에는 broadcast가 전혀 호출되지 않아 무해했지만) 이제는 await가 영원히 멈춘다.
+    _resolved_broadcast = MagicMock(return_value=asyncio.Future())
+    _resolved_broadcast.return_value.set_result(None)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast)
 
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo(["NAVER"]))
 
@@ -737,7 +763,12 @@ async def test_monitor_market_task_continues_owned_stock_when_watchlist_fails(mo
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
     monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
-    monkeypatch.setattr("backend.scheduler.manager.broadcast", MagicMock(return_value=asyncio.Future()))
+    # 이슈 #229: Portfolio 동기화 성공 시 실제로 await manager.broadcast(...)가 호출될 수
+    # 있으므로, 이 mock의 반환 Future는 반드시 resolve되어야 한다. resolve하지 않으면
+    # (과거에는 broadcast가 전혀 호출되지 않아 무해했지만) 이제는 await가 영원히 멈춘다.
+    _resolved_broadcast = MagicMock(return_value=asyncio.Future())
+    _resolved_broadcast.return_value.set_result(None)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast)
 
     await monitor_market_task(watchlist_repo=FailingWatchlistRepo())
 
@@ -773,7 +804,12 @@ async def test_monitor_market_task_deduplicates_watchlist_and_owned_stocks(monke
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
     monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
-    monkeypatch.setattr("backend.scheduler.manager.broadcast", MagicMock(return_value=asyncio.Future()))
+    # 이슈 #229: Portfolio 동기화 성공 시 실제로 await manager.broadcast(...)가 호출될 수
+    # 있으므로, 이 mock의 반환 Future는 반드시 resolve되어야 한다. resolve하지 않으면
+    # (과거에는 broadcast가 전혀 호출되지 않아 무해했지만) 이제는 await가 영원히 멈춘다.
+    _resolved_broadcast = MagicMock(return_value=asyncio.Future())
+    _resolved_broadcast.return_value.set_result(None)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast)
 
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo(["삼성전자"]))
 
@@ -809,7 +845,12 @@ async def test_monitor_market_task_uses_default_stocks_only_when_both_empty(monk
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
     monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
-    monkeypatch.setattr("backend.scheduler.manager.broadcast", MagicMock(return_value=asyncio.Future()))
+    # 이슈 #229: Portfolio 동기화 성공 시 실제로 await manager.broadcast(...)가 호출될 수
+    # 있으므로, 이 mock의 반환 Future는 반드시 resolve되어야 한다. resolve하지 않으면
+    # (과거에는 broadcast가 전혀 호출되지 않아 무해했지만) 이제는 await가 영원히 멈춘다.
+    _resolved_broadcast = MagicMock(return_value=asyncio.Future())
+    _resolved_broadcast.return_value.set_result(None)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast)
 
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
 
@@ -845,7 +886,12 @@ async def test_monitor_market_task_watchlist_alone_skips_default_fallback(monkey
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
     monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
-    monkeypatch.setattr("backend.scheduler.manager.broadcast", MagicMock(return_value=asyncio.Future()))
+    # 이슈 #229: Portfolio 동기화 성공 시 실제로 await manager.broadcast(...)가 호출될 수
+    # 있으므로, 이 mock의 반환 Future는 반드시 resolve되어야 한다. resolve하지 않으면
+    # (과거에는 broadcast가 전혀 호출되지 않아 무해했지만) 이제는 await가 영원히 멈춘다.
+    _resolved_broadcast = MagicMock(return_value=asyncio.Future())
+    _resolved_broadcast.return_value.set_result(None)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast)
 
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo(["카카오"]))
 
@@ -1043,7 +1089,12 @@ async def test_monitor_market_task_logs_warning_when_balance_truncated(monkeypat
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
     monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
-    monkeypatch.setattr("backend.scheduler.manager.broadcast", MagicMock(return_value=asyncio.Future()))
+    # 이슈 #229: Portfolio 동기화 성공 시 실제로 await manager.broadcast(...)가 호출될 수
+    # 있으므로, 이 mock의 반환 Future는 반드시 resolve되어야 한다. resolve하지 않으면
+    # (과거에는 broadcast가 전혀 호출되지 않아 무해했지만) 이제는 await가 영원히 멈춘다.
+    _resolved_broadcast = MagicMock(return_value=asyncio.Future())
+    _resolved_broadcast.return_value.set_result(None)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast)
 
     with caplog.at_level(logging.WARNING, logger=scheduler_module.logger.name):
         await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
@@ -1086,7 +1137,12 @@ async def test_monitor_market_task_no_warning_when_balance_not_truncated(monkeyp
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
     monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
-    monkeypatch.setattr("backend.scheduler.manager.broadcast", MagicMock(return_value=asyncio.Future()))
+    # 이슈 #229: Portfolio 동기화 성공 시 실제로 await manager.broadcast(...)가 호출될 수
+    # 있으므로, 이 mock의 반환 Future는 반드시 resolve되어야 한다. resolve하지 않으면
+    # (과거에는 broadcast가 전혀 호출되지 않아 무해했지만) 이제는 await가 영원히 멈춘다.
+    _resolved_broadcast = MagicMock(return_value=asyncio.Future())
+    _resolved_broadcast.return_value.set_result(None)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast)
 
     with caplog.at_level(logging.WARNING, logger=scheduler_module.logger.name):
         await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
@@ -1129,7 +1185,12 @@ async def test_monitor_market_task_still_watches_stocks_returned_despite_truncat
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
     monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
-    monkeypatch.setattr("backend.scheduler.manager.broadcast", MagicMock(return_value=asyncio.Future()))
+    # 이슈 #229: Portfolio 동기화 성공 시 실제로 await manager.broadcast(...)가 호출될 수
+    # 있으므로, 이 mock의 반환 Future는 반드시 resolve되어야 한다. resolve하지 않으면
+    # (과거에는 broadcast가 전혀 호출되지 않아 무해했지만) 이제는 await가 영원히 멈춘다.
+    _resolved_broadcast = MagicMock(return_value=asyncio.Future())
+    _resolved_broadcast.return_value.set_result(None)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast)
 
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
 
@@ -1167,7 +1228,12 @@ def _make_balance_failure_mocks(monkeypatch, mock_run_mcp_tool_fn):
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool_fn)
     monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
-    monkeypatch.setattr("backend.scheduler.manager.broadcast", MagicMock(return_value=asyncio.Future()))
+    # 이슈 #229: Portfolio 동기화 성공 시 실제로 await manager.broadcast(...)가 호출될 수
+    # 있으므로, 이 mock의 반환 Future는 반드시 resolve되어야 한다. resolve하지 않으면
+    # (과거에는 broadcast가 전혀 호출되지 않아 무해했지만) 이제는 await가 영원히 멈춘다.
+    _resolved_broadcast = MagicMock(return_value=asyncio.Future())
+    _resolved_broadcast.return_value.set_result(None)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast)
 
     return state
 
@@ -1551,7 +1617,12 @@ async def test_monitor_market_task_syncs_portfolio_when_balance_succeeds(monkeyp
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
     monkeypatch.setattr("backend.scheduler._sync_portfolio_from_balance", mock_sync_portfolio)
     monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
-    monkeypatch.setattr("backend.scheduler.manager.broadcast", MagicMock(return_value=asyncio.Future()))
+    # 이슈 #229: Portfolio 동기화 성공 시 실제로 await manager.broadcast(...)가 호출될 수
+    # 있으므로, 이 mock의 반환 Future는 반드시 resolve되어야 한다. resolve하지 않으면
+    # (과거에는 broadcast가 전혀 호출되지 않아 무해했지만) 이제는 await가 영원히 멈춘다.
+    _resolved_broadcast = MagicMock(return_value=asyncio.Future())
+    _resolved_broadcast.return_value.set_result(None)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast)
 
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
 
@@ -1594,11 +1665,207 @@ async def test_monitor_market_task_does_not_sync_when_balance_fails(monkeypatch)
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
     monkeypatch.setattr("backend.scheduler._sync_portfolio_from_balance", mock_sync_portfolio)
     monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
-    monkeypatch.setattr("backend.scheduler.manager.broadcast", MagicMock(return_value=asyncio.Future()))
+    # 이슈 #229: Portfolio 동기화 성공 시 실제로 await manager.broadcast(...)가 호출될 수
+    # 있으므로, 이 mock의 반환 Future는 반드시 resolve되어야 한다. resolve하지 않으면
+    # (과거에는 broadcast가 전혀 호출되지 않아 무해했지만) 이제는 await가 영원히 멈춘다.
+    _resolved_broadcast = MagicMock(return_value=asyncio.Future())
+    _resolved_broadcast.return_value.set_result(None)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast)
 
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo(["카카오"]))
 
     assert sync_calls == []
+
+
+# ---------------------------------------------------------------------------
+# 이슈 #229: Portfolio 동기화 성공 시 WebSocket PORTFOLIO_UPDATE 브로드캐스트
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_monitor_market_task_broadcasts_portfolio_update_on_sync_success(monkeypatch):
+    """Portfolio 동기화 성공 시 PORTFOLIO_UPDATE가 정확히 1회, 올바른 형태로 브로드캐스트됩니다.
+
+    _sync_portfolio_from_balance 자체의 동기화 로직은 test_sync_portfolio_writes_holdings
+    등에서 이미 검증하므로, 여기서는 그 함수를 mock_broadcast 패턴과 동일하게
+    monkeypatch해 호출처(monitor_market_task)의 브로드캐스트 판단만 격리해서 검증한다
+    (실 DB의 portfolio 테이블 존재 여부에 테스트 결과가 좌우되지 않게 하기 위함).
+
+    이 테스트가 잡는 mutation: 호출처가 PORTFOLIO_UPDATE 브로드캐스트를 하지 않거나
+    holdings_count/updated_at 형태를 잘못 실으면 아래 단언이 실패한다.
+    """
+    from ..scheduler import SignalSource, monitor_market_task
+
+    @asynccontextmanager
+    async def unavailable_redis_state():
+        raise ConnectionError("redis unavailable")
+        yield
+
+    async def mock_run_mcp_tool(params, name, args):
+        if name == "get_balance":
+            return _make_balance_text(("삼성전자", "005930", 10, 70000))
+        return "news"
+
+    def mock_sync_portfolio(balance_text, session, **kwargs):
+        return 3
+
+    async def mock_check_significance(stock, current, last, *, source, provider):
+        return False
+
+    mock_broadcast = MagicMock(return_value=asyncio.Future())
+    mock_broadcast.return_value.set_result(None)
+
+    monkeypatch.setattr("backend.scheduler.redis_state", unavailable_redis_state)
+    monkeypatch.setattr(
+        "backend.scheduler.SIGNAL_SOURCES",
+        [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
+    )
+    monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
+    monkeypatch.setattr("backend.scheduler._sync_portfolio_from_balance", mock_sync_portfolio)
+    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", mock_broadcast)
+
+    await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
+
+    mock_broadcast.assert_called_once()
+    payload = mock_broadcast.call_args[0][0]
+    assert payload["type"] == "PORTFOLIO_UPDATE"
+    assert payload["holdings_count"] == 3
+    # updated_at은 ISO 8601로 파싱 가능해야 한다.
+    datetime.fromisoformat(payload["updated_at"])
+    # 보유 내역 원본(종목명·수량 등)은 인증 없는 WebSocket으로 나가면 안 된다(#65).
+    assert "holdings" not in payload
+    assert "stocks" not in payload
+
+
+@pytest.mark.asyncio
+async def test_monitor_market_task_no_portfolio_broadcast_when_balance_truncated(monkeypatch):
+    """잔고 연속조회가 잘린 경우 PORTFOLIO_UPDATE를 브로드캐스트하지 않습니다.
+
+    _sync_portfolio_from_balance를 mock하지 않고 실제 함수를 그대로 태워, 잘림
+    가드가 DB 접근 이전에 None을 반환해 브로드캐스트로 이어지지 않음을 검증한다.
+
+    이 테스트가 잡는 mutation: 호출처가 sync_result 값과 무관하게 항상 브로드캐스트하면
+    잘린 잔고에서도 PORTFOLIO_UPDATE가 나가 아래 단언이 실패한다.
+    """
+    from ..scheduler import SignalSource, monitor_market_task
+
+    @asynccontextmanager
+    async def unavailable_redis_state():
+        raise ConnectionError("redis unavailable")
+        yield
+
+    truncated_text = (
+        _make_balance_text(("삼성전자", "005930", 10, 70000)).rstrip()
+        + TRUNCATION_NOTES_BY_REASON["max_pages"]
+    )
+
+    async def mock_run_mcp_tool(params, name, args):
+        if name == "get_balance":
+            return truncated_text
+        return "news"
+
+    async def mock_check_significance(stock, current, last, *, source, provider):
+        return False
+
+    mock_broadcast = MagicMock(return_value=asyncio.Future())
+    mock_broadcast.return_value.set_result(None)
+
+    monkeypatch.setattr("backend.scheduler.redis_state", unavailable_redis_state)
+    monkeypatch.setattr(
+        "backend.scheduler.SIGNAL_SOURCES",
+        [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
+    )
+    monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
+    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", mock_broadcast)
+
+    await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
+
+    broadcast_types = [call.args[0].get("type") for call in mock_broadcast.call_args_list]
+    assert "PORTFOLIO_UPDATE" not in broadcast_types
+
+
+@pytest.mark.asyncio
+async def test_monitor_market_task_no_portfolio_broadcast_when_marker_absent(monkeypatch):
+    """잔고 응답에 [보유 종목 리스트] 마커가 없으면 PORTFOLIO_UPDATE를 브로드캐스트하지 않습니다.
+
+    이 테스트가 잡는 mutation: 마커 부재 가드를 우회해 브로드캐스트하면
+    아래 단언이 실패한다.
+    """
+    from ..scheduler import SignalSource, monitor_market_task
+
+    @asynccontextmanager
+    async def unavailable_redis_state():
+        raise ConnectionError("redis unavailable")
+        yield
+
+    async def mock_run_mcp_tool(params, name, args):
+        if name == "get_balance":
+            return "응답을 가져왔지만 종목 섹션이 없습니다."
+        return "news"
+
+    async def mock_check_significance(stock, current, last, *, source, provider):
+        return False
+
+    mock_broadcast = MagicMock(return_value=asyncio.Future())
+    mock_broadcast.return_value.set_result(None)
+
+    monkeypatch.setattr("backend.scheduler.redis_state", unavailable_redis_state)
+    monkeypatch.setattr(
+        "backend.scheduler.SIGNAL_SOURCES",
+        [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
+    )
+    monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
+    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", mock_broadcast)
+
+    await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
+
+    broadcast_types = [call.args[0].get("type") for call in mock_broadcast.call_args_list]
+    assert "PORTFOLIO_UPDATE" not in broadcast_types
+
+
+@pytest.mark.asyncio
+async def test_monitor_market_task_survives_portfolio_broadcast_failure(monkeypatch):
+    """PORTFOLIO_UPDATE 브로드캐스트가 예외를 던져도 monitor_market_task는 계속 진행합니다.
+
+    기존 동기화 예외 격리(logger.error(..., "감시는 계속"))와 같은 수준으로 브로드캐스트
+    예외도 격리해야 한다. 이 테스트가 잡는 mutation: 브로드캐스트 예외를 격리하지 않으면
+    monitor_market_task가 예외를 전파해 await 자체가 실패한다.
+    """
+    from ..scheduler import SignalSource, monitor_market_task
+
+    @asynccontextmanager
+    async def unavailable_redis_state():
+        raise ConnectionError("redis unavailable")
+        yield
+
+    async def mock_run_mcp_tool(params, name, args):
+        if name == "get_balance":
+            return _make_balance_text(("삼성전자", "005930", 10, 70000))
+        return "news"
+
+    def mock_sync_portfolio(balance_text, session, **kwargs):
+        return 1
+
+    async def mock_check_significance(stock, current, last, *, source, provider):
+        return False
+
+    async def failing_broadcast(payload):
+        raise RuntimeError("websocket down")
+
+    monkeypatch.setattr("backend.scheduler.redis_state", unavailable_redis_state)
+    monkeypatch.setattr(
+        "backend.scheduler.SIGNAL_SOURCES",
+        [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
+    )
+    monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
+    monkeypatch.setattr("backend.scheduler._sync_portfolio_from_balance", mock_sync_portfolio)
+    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", failing_broadcast)
+
+    # 예외 없이 완료되어야 한다.
+    await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 배경

`backend/scheduler.py`의 `_sync_portfolio_from_balance`가 `Portfolio` 테이블을 동기화하지만, 갱신 사실을 WebSocket으로 알리지 않아 프론트엔드가 폴링에 의존하고 있었습니다. Closes #229

## 변경 사항

### 1. 반환값 도입 (성공/건너뜀 구분)

`_sync_portfolio_from_balance`가 항상 `None`을 반환하던 것을, 이제 다음과 같이 반환합니다.

- 동기화를 실제로 수행한 경우: 삽입한 종목 수(`int`, 0 이상)
- 잘림(`is_balance_truncated`) 또는 마커(`[보유 종목 리스트]`) 부재로 건너뛴 경우: `None`

**설계 근거**: bool 대신 개수를 반환한 이유는 호출처(`monitor_market_task`)가 브로드캐스트 payload에 `holdings_count`를 실어야 하는데, bool만으로는 호출처가 그 값을 얻기 위해 holdings 리스트를 별도로 들고 있거나 다시 세야 하기 때문입니다. `int | None` 반환값 자체가 "성공 여부"와 "성공 시 종목 수"를 한 번에 전달합니다. 이 근거는 docstring에도 남겼습니다.

### 2. WebSocket 브로드캐스트

호출처(`monitor_market_task` 내부)에서 동기화가 **성공한 경우에만** 다음을 브로드캐스트합니다.

```python
{
    "type": "PORTFOLIO_UPDATE",
    "holdings_count": <int>,
    "updated_at": <ISO 8601 문자열>,
}
```

- `_sync_portfolio_from_balance`는 동기 함수이고 `manager.broadcast`는 async이므로, 함수를 async로 바꾸지 않고 호출처에서 브로드캐스트하도록 했습니다(변경 범위 최소화).
- 브로드캐스트 예외는 기존 동기화 예외 격리(`logger.error(..., "감시는 계속")`)와 동일한 수준으로 감싸, `monitor_market_task`를 중단시키지 않습니다.

### 3. 보유 내역을 payload에 싣지 않은 이유 (#65)

WebSocket에는 인증이 없습니다(이슈 #65). 계좌 보유 현황(종목명·수량 등)이 인증 없는 채널로 나가면 안 되므로, payload에는 `holdings_count`(개수)만 싣고 실제 보유 내역은 담지 않았습니다. 클라이언트는 이 신호를 받으면 `/api/v1/db/portfolio`를 재조회하는 설계입니다. 이 근거는 코드 주석으로도 남겨, 나중에 누군가 "편의상" 내역을 추가하는 것을 막았습니다.

## 테스트

`backend/tests/test_scheduler.py`에 다음 4개 케이스를 추가했습니다(기존 `mock_broadcast` 패턴을 그대로 따름).

1. `test_monitor_market_task_broadcasts_portfolio_update_on_sync_success` — 동기화 성공 시 `PORTFOLIO_UPDATE`가 정확히 1회 브로드캐스트되고 payload 형태(`type`/`holdings_count`/`updated_at`, 보유 내역 미포함)가 올바른지 확인
2. `test_monitor_market_task_no_portfolio_broadcast_when_balance_truncated` — 잔고 연속조회가 잘린 경우 `PORTFOLIO_UPDATE` 미브로드캐스트 확인
3. `test_monitor_market_task_no_portfolio_broadcast_when_marker_absent` — 마커 부재 시 `PORTFOLIO_UPDATE` 미브로드캐스트 확인
4. `test_monitor_market_task_survives_portfolio_broadcast_failure` — 브로드캐스트가 예외를 던져도 `monitor_market_task`가 예외 전파 없이 완료되는지 확인

### 기존 테스트 변경 및 이유

전체 스위트를 실행하면 앞선 테스트(`test_scheduler_lifecycle` 등)가 `TestClient`로 앱을 기동하며 `init_db()`를 호출해 실제 sqlite 파일에 `portfolio` 테이블이 이미 만들어집니다. 그 상태에서 `monitor_market_task`를 호출하는 기존 테스트들은 `_sync_portfolio_from_balance`를 mock하지 않고 마커가 있는 잔고 텍스트를 사용하고 있어, 이번 변경으로 매 성공적 동기화마다 `PORTFOLIO_UPDATE`가 추가로 브로드캐스트되어 `manager.broadcast` 호출 횟수를 세던 기존 단언들이 깨졌습니다. 각 테스트를 분석해 늘어난 횟수를 반영했습니다(예: `test_monitor_market_task_filtering`의 3/0/1 → 4/1/2, `test_monitor_market_task_uses_redis_hash_to_skip_duplicate_news`의 1 → 3 등). `test_monitor_market_task_processes_multiple_signal_sources_independently`는 `call.args[0]["source"]`로 모든 브로드캐스트를 단정하고 있었는데 `PORTFOLIO_UPDATE`에는 `source` 키가 없어 `KeyError`가 나 이제 `AGENT_ANALYSIS` 타입만 걸러서 검사하도록 고쳤습니다.

추가로, 일부 테스트가 `manager.broadcast` mock의 반환값을 resolve하지 않은 `asyncio.Future()`로 설정해두고 있었습니다. 과거엔 그 경로에서 `broadcast`가 실제로 호출된 적이 없어 무해했지만, 이번 변경으로 Portfolio 동기화 성공 시 실제로 `await manager.broadcast(...)`가 실행되면서 resolve되지 않은 Future를 기다리다 테스트가 무한정 멈추는 문제가 발생했습니다. 해당 mock들을 모두 `set_result(None)`으로 resolve하도록 수정했습니다. 테스트 로직 자체(단언 대상)는 약화시키지 않고, mock이 실제 호출 경로를 정확히 반영하도록만 고쳤습니다.

## 검증

`uv run --project backend pytest backend/tests/` 전체 통과: **373 passed, 2 skipped** (기존에도 skip이던 항목, 이번 변경과 무관)
