### PR TITLE
fix: 종목코드 형태 입력을 로컬 마스터와 대조해 존재 확인 없는 저장 차단 (#151)

### DIFF
--- a/backend/services.py
+++ b/backend/services.py
@@ -22,7 +22,12 @@ from .config import (
 )
 from .schemas import TradingSignal, AnalysisReport
 from .models import AgentReport
-from .stock_code import _STOCK_CODE_EXTRACT_RE, _has_code_digit, _looks_like_stock_code
+from .stock_code import (
+    _STOCK_CODE_EXTRACT_RE,
+    _has_code_digit,
+    _is_known_master_code,
+    _looks_like_stock_code,
+)
 
 logger = logging.getLogger(__name__)
 _NAT_RESPONSE_LOG_PREVIEW_CHARS = 800
@@ -79,12 +84,23 @@ def _normalize_stock_input(stock: str) -> str:
 async def _resolve_stock_code(stock: str) -> str:
     """종목명(또는 이미 종목코드인 값)을 종목코드로 변환합니다.
 
-    이미 종목코드 형태이면 MCP 호출 없이 그대로 사용합니다.
+    이미 종목코드 형태이면서 종목마스터(mcp-trading/data/stocks.json)에 실재하면
+    MCP 호출 없이 그대로 사용합니다(#151). 코드 형태이지만 마스터에 없으면
+    지름길을 포기하고 아래 MCP 경로로 흘려보내 이름·별칭 매칭을 시도합니다.
     조회 실패/예외 시 리포트 저장을 막지 않도록 빈 문자열로 폴백합니다.
     """
     stock = _normalize_stock_input(stock)
     if _looks_like_stock_code(stock):
-        return stock.upper()
+        shortcut_code = stock.upper()
+        if _is_known_master_code(shortcut_code):
+            return shortcut_code
+        # 마스터에 없는 코드 형태 입력(#151): 지름길을 포기하고 아래 MCP 경로로
+        # 흘려보낸다. 백엔드와 MCP가 같은 stocks.json을 보므로(모듈 상단 주석
+        # 참고) MCP의 Step 1(코드 일치)도 결국 실패하지만, Step 2(이름·별칭
+        # 매칭)는 이 코드 형태 입력이 우연히 실제 종목명과 같은 경우를 잡아낼
+        # 수 있어 그대로 흘려보낸다. Step 2도 실패하면 stock-master.js Step 3가
+        # market="UNKNOWN"으로 존재 검증 없이 에코하므로, 아래에서 그 에코를
+        # 감지해 실패로 취급하고 ''로 폴백한다.
 
     cached = _stock_code_cache.get(stock)
     if cached is not None:
@@ -99,21 +115,24 @@ async def _resolve_stock_code(stock: str) -> str:
         resolved_text = str(resolved)
         match = _STOCK_CODE_EXTRACT_RE.search(resolved_text)
         code = match.group(1) if match else None
-        if code is None or not _has_code_digit(code):
+        # stock-master.js Step 3는 코드 형태 입력이 마스터에 코드로도 이름·별칭으로도
+        # 없을 때 market="UNKNOWN"으로 그대로 에코한다("SIMPAC (SIMPAC, UNKNOWN)",
+        # "999999 (999999, UNKNOWN)") — 존재 검증이 아니라 그저 되돌려주는 것이므로
+        # 이걸 성공으로 오인하면 안 된다. 실제 마스터의 market은 KOSPI/KOSDAQ뿐이라
+        # (mcp-trading/data/stocks.json 전수 확인) "UNKNOWN" 접미사는 이 에코의
+        # 신뢰 가능한 신호다. #151 이전에는 _looks_like_stock_code가 숫자를 포함한
+        # 코드 형태 입력을 MCP로 보내지 않아 이 에코가 도달할 일이 없었지만, #151에서
+        # 마스터에 없는 코드 형태 입력을 이 MCP 경로로 흘려보내게 되면서 숫자가 있는
+        # 에코("999999")도 여기 도달할 수 있다 — _has_code_digit만으로는 걸러지지
+        # 않으므로 아래에서 별도로 감지한다.
+        is_unresolved_echo = resolved_text.rstrip().endswith(", UNKNOWN)")
+        if code is None or not _has_code_digit(code) or is_unresolved_echo:
             logger.warning(
                 "종목코드 추출 실패, 빈 문자열로 폴백: stock=%s, response=%s",
                 stock,
                 resolved,
             )
             return ""
-        # Step 3 에코("SIMPAC (SIMPAC, UNKNOWN)")는 숫자가 없어 위 _has_code_digit
-        # 가드에서 이미 걸러진다.
-        # 에코(stock-master.js Step 3)는 코드 형태 입력이 마스터에 코드로도 이름·별칭
-        # 으로도 없을 때만 나므로, 마스터에 실재하는 종목명·코드 입력으로는 발생하지
-        # 않는다(오타처럼 마스터에 없는 코드 형태 입력이면 실제로 발생한다). #174에서
-        # 코드 완전일치가 이름·별칭 매칭보다 먼저로 바뀐 뒤에도 이 결론은 그대로다.
-        # 게다가 위 _looks_like_stock_code가 숫자를 포함한 6·7·9자 입력을 MCP에 보내지
-        # 않아, 여기 도달할 수 있는 에코는 숫자 없는 코드뿐이라 _has_code_digit이 잡는다.
         # 상한 도달은 정상 조건이 아니다 — 종목마스터 4,353종 규모에서는 일어나지
         # 않아야 하며, 발생했다면 입력 정규화가 stock-master.js와 다시 어긋났다는
         # 신호다. dict는 자동으로 비우지 않으므로 침묵한 채 자라기만 하면 상한을

--- a/backend/services.py
+++ b/backend/services.py
@@ -26,6 +26,7 @@ from .stock_code import (
     _STOCK_CODE_EXTRACT_RE,
     _has_code_digit,
     _is_known_master_code,
+    _is_unresolved_echo,
     _looks_like_stock_code,
 )
 
@@ -115,18 +116,13 @@ async def _resolve_stock_code(stock: str) -> str:
         resolved_text = str(resolved)
         match = _STOCK_CODE_EXTRACT_RE.search(resolved_text)
         code = match.group(1) if match else None
-        # stock-master.js Step 3는 코드 형태 입력이 마스터에 코드로도 이름·별칭으로도
-        # 없을 때 market="UNKNOWN"으로 그대로 에코한다("SIMPAC (SIMPAC, UNKNOWN)",
-        # "999999 (999999, UNKNOWN)") — 존재 검증이 아니라 그저 되돌려주는 것이므로
-        # 이걸 성공으로 오인하면 안 된다. 실제 마스터의 market은 KOSPI/KOSDAQ뿐이라
-        # (mcp-trading/data/stocks.json 전수 확인) "UNKNOWN" 접미사는 이 에코의
-        # 신뢰 가능한 신호다. #151 이전에는 _looks_like_stock_code가 숫자를 포함한
-        # 코드 형태 입력을 MCP로 보내지 않아 이 에코가 도달할 일이 없었지만, #151에서
-        # 마스터에 없는 코드 형태 입력을 이 MCP 경로로 흘려보내게 되면서 숫자가 있는
-        # 에코("999999")도 여기 도달할 수 있다 — _has_code_digit만으로는 걸러지지
-        # 않으므로 아래에서 별도로 감지한다.
-        is_unresolved_echo = resolved_text.rstrip().endswith(", UNKNOWN)")
-        if code is None or not _has_code_digit(code) or is_unresolved_echo:
+        # stock-master.js Step 3의 미해석 에코("999999 (999999, UNKNOWN)")를 성공으로
+        # 오인하면 안 된다 — 판정 근거는 stock_code._is_unresolved_echo에 있다.
+        # #151 이전에는 _looks_like_stock_code가 숫자를 포함한 코드 형태 입력을 MCP로
+        # 보내지 않아 이 에코가 도달할 일이 없었지만, #151에서 마스터에 없는 코드 형태
+        # 입력을 이 MCP 경로로 흘려보내게 되면서 숫자가 있는 에코("999999")도 여기
+        # 도달할 수 있다 — _has_code_digit만으로는 걸러지지 않으므로 따로 감지한다.
+        if code is None or not _has_code_digit(code) or _is_unresolved_echo(resolved_text):
             logger.warning(
                 "종목코드 추출 실패, 빈 문자열로 폴백: stock=%s, response=%s",
                 stock,

--- a/backend/stock_code.py
+++ b/backend/stock_code.py
@@ -6,6 +6,7 @@ services.py와 telegram_commands.py가 각자 중복 구현하던 정규식과 �
 import json
 import logging
 import re
+from pathlib import Path
 
 from .config import _TRADING_MCP_DIR
 
@@ -70,7 +71,15 @@ _ORDERABLE_STOCK_CODE_RE = re.compile(r"\A[0-9]{6,7}\Z")
 # MCP는 이미지 안 /opt/mcp-trading). 특히 레포 바깥을 가리키면 backend 쪽 경로에
 # 파일이 없어 fail-open으로 #151 검증이 조용히 꺼진다.
 # config는 stock_code를 import하지 않으므로 순환 import는 발생하지 않는다.
-_MASTER_STOCKS_PATH = _TRADING_MCP_DIR / "data" / "stocks.json"
+#
+# 파생 규칙을 순수 함수로 뽑아둔다 — importlib.reload(config) + reload(stock_code)로
+# 이 경로 계산을 검증하면 두 모듈의 전역 바인딩을 다른 테스트가 붙잡고 있는 채로
+# 영향을 준다. 함수 대상으로 테스트하면 reload 없이 같은 계약을 고정할 수 있다.
+def _master_stocks_path(mcp_dir: Path) -> Path:
+    return mcp_dir / "data" / "stocks.json"
+
+
+_MASTER_STOCKS_PATH = _master_stocks_path(_TRADING_MCP_DIR)
 
 # 마스터 로드 실패(fail-open)를 "성공했지만 빈 집합"과 구분하기 위한 센티널.
 _MASTER_LOAD_FAILED = object()

--- a/backend/stock_code.py
+++ b/backend/stock_code.py
@@ -79,7 +79,16 @@ def _master_stocks_path(mcp_dir: Path) -> Path:
     return mcp_dir / "data" / "stocks.json"
 
 
-_MASTER_STOCKS_PATH = _master_stocks_path(_TRADING_MCP_DIR)
+# 경로를 모듈 상수로 한 번만 굳히지 않는다(과거 _MASTER_STOCKS_PATH 방식) — 그러면
+# _TRADING_MCP_DIR이 나중에 바뀌어도(예: 테스트가 몽키패치) 이미 계산된 값은 따라가지
+# 않아, importlib.reload 없이는 "마스터 경로가 TRADING_MCP_DIR을 따라가는가"라는
+# 배선 자체를 테스트로 고정할 방법이 없다. 대신 _load_master_codes가 매 호출
+# _master_stocks_path(_TRADING_MCP_DIR)를 그 자리에서 계산해 쓴다 — _TRADING_MCP_DIR은
+# 평범한 모듈 전역이라 매 호출 새로 조회되므로, 테스트가 reload 없이
+# stock_code._TRADING_MCP_DIR을 직접 몽키패치하는 것만으로 이 배선을 검증할 수
+# 있다(test_master_path_wiring_follows_trading_mcp_dir_without_reload).
+# _master_stocks_path 자체는 Path 조인뿐이라 매 호출 다시 계산해도 비용이 없다 —
+# 실제 디스크 I/O는 아래 캐시가 여전히 막는다.
 
 # 마스터 로드 실패(fail-open)를 "성공했지만 빈 집합"과 구분하기 위한 센티널.
 _MASTER_LOAD_FAILED = object()
@@ -87,7 +96,13 @@ _MASTER_LOAD_FAILED = object()
 # 지연 로딩 캐시: None=아직 로드 안 함, frozenset=로드 성공, _MASTER_LOAD_FAILED=로드 실패.
 # 요청마다 489K짜리 stocks.json을 다시 파싱하면 지름길을 둔 이유(MCP 왕복 생략)가
 # 사라지므로, 프로세스 수명 동안 한 번만 읽고 캐시한다.
+# _master_codes_cache_path는 캐시가 어느 경로에서 만들어졌는지 기록한다 — 경로 계산을
+# 매 호출로 바꾸면서 함께 필요해졌다. 경로가 바뀌면(_TRADING_MCP_DIR 변경) 캐시를
+# 무효화해야 한다 — 그러지 않으면 이전 경로에서 읽은 캐시를 새 경로에도 그대로
+# 돌려줘, 테스트 간 캐시 오염이나 실제 배포에서 경로가 바뀐 뒤에도 옛 마스터를
+# 계속 쓰는 문제가 생긴다.
 _master_codes_cache: object = None
+_master_codes_cache_path: Path | None = None
 
 
 def _load_master_codes():
@@ -101,11 +116,12 @@ def _load_master_codes():
     개별 항목의 결손은 그 항목만 건너뛰고 나머지로 계속하되, 코드를 하나도
     읽지 못한 경우는 로드 실패로 취급합니다(빈 집합은 모든 코드를 거부하므로).
     """
-    global _master_codes_cache
-    if _master_codes_cache is not None:
+    global _master_codes_cache, _master_codes_cache_path
+    path = _master_stocks_path(_TRADING_MCP_DIR)
+    if _master_codes_cache is not None and _master_codes_cache_path == path:
         return _master_codes_cache
     try:
-        raw = _MASTER_STOCKS_PATH.read_text(encoding="utf-8")
+        raw = path.read_text(encoding="utf-8")
         stocks = json.loads(raw)
         # 항목 단위로 건너뛴다. 마스터는 외부 KIS 파일에서 생성되므로 code 키가 빠진
         # 항목이 섞일 수 있는데, 하나의 KeyError로 4,353건 전체 검증이 fail-open되면
@@ -125,10 +141,11 @@ def _load_master_codes():
     except Exception as exc:
         logger.warning(
             "종목마스터 로드 실패, 지름길 존재 검증을 건너뜁니다(fail-open): path=%s, error=%s",
-            _MASTER_STOCKS_PATH,
+            path,
             exc,
         )
         _master_codes_cache = _MASTER_LOAD_FAILED
+        _master_codes_cache_path = path
         return _master_codes_cache
     if len(codes) < total:
         # 캐시 때문에 이 경고는 프로세스 수명 동안 한 번만 찍힌다 — 얼마나 건졌는지를
@@ -136,11 +153,12 @@ def _load_master_codes():
         # 마스터의 코드는 유일하므로(stock-master.js Step 1의 전제) 차이는 곧 누락 건수다.
         logger.warning(
             "종목마스터 일부 항목에서 코드를 읽지 못했습니다: path=%s, %d/%d건만 사용합니다",
-            _MASTER_STOCKS_PATH,
+            path,
             len(codes),
             total,
         )
     _master_codes_cache = codes
+    _master_codes_cache_path = path
     return codes
 
 

--- a/backend/stock_code.py
+++ b/backend/stock_code.py
@@ -3,7 +3,12 @@
 services.py와 telegram_commands.py가 각자 중복 구현하던 정규식과 함수를
 이 모듈로 통합한다. 두 파일에서 import해 사용한다.
 """
+import json
+import logging
 import re
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 # ──────────────────────────────────────────────────────────────────────────
 # MCP 응답에서 종목코드 추출
@@ -52,6 +57,63 @@ _STOCK_CODE_RE = re.compile(r"\A(?:[0-9A-Z]{6,7}|[0-9A-Z]{9})\Z")
 _ORDERABLE_STOCK_CODE_RE = re.compile(r"\A[0-9]{6,7}\Z")
 
 
+# ──────────────────────────────────────────────────────────────────────────
+# 종목마스터 코드 존재 검증 (#151) — _looks_like_stock_code 지름길이 MCP 존재
+# 확인 없이 코드를 확정해 버리는 문제를 로컬 코드 집합 대조로 막는다.
+# ──────────────────────────────────────────────────────────────────────────
+# mcp-trading/stock-master.js:8의 DEFAULT_STOCKS_PATH와
+# mcp-trading/scripts/update_stock_master.py:12가 쓰는 경로가 동일하므로,
+# 백엔드가 이 파일을 직접 읽어도 MCP가 보는 마스터와 어긋날 수 없다(같은 파일).
+_MASTER_STOCKS_PATH = Path(__file__).resolve().parents[1] / "mcp-trading" / "data" / "stocks.json"
+
+# 마스터 로드 실패(fail-open)를 "성공했지만 빈 집합"과 구분하기 위한 센티널.
+_MASTER_LOAD_FAILED = object()
+
+# 지연 로딩 캐시: None=아직 로드 안 함, frozenset=로드 성공, _MASTER_LOAD_FAILED=로드 실패.
+# 요청마다 489K짜리 stocks.json을 다시 파싱하면 지름길을 둔 이유(MCP 왕복 생략)가
+# 사라지므로, 프로세스 수명 동안 한 번만 읽고 캐시한다.
+_master_codes_cache: object = None
+
+
+def _load_master_codes():
+    """종목마스터 코드 집합을 지연 로딩해 프로세스 메모리에 캐시합니다.
+
+    파일이 없거나 파싱에 실패하면 예외를 던지지 않고 _MASTER_LOAD_FAILED를
+    캐시해 반환합니다(fail-open) — 이 경로는 리포트 저장 판정에 쓰이지
+    주문에는 쓰이지 않으므로, 마스터를 못 읽는다고 분석 기능 전체가 죽으면
+    안 됩니다.
+    """
+    global _master_codes_cache
+    if _master_codes_cache is not None:
+        return _master_codes_cache
+    try:
+        raw = _MASTER_STOCKS_PATH.read_text(encoding="utf-8")
+        stocks = json.loads(raw)
+        codes = frozenset(str(stock["code"]).upper() for stock in stocks)
+    except Exception as exc:
+        logger.warning(
+            "종목마스터 로드 실패, 지름길 존재 검증을 건너뜁니다(fail-open): path=%s, error=%s",
+            _MASTER_STOCKS_PATH,
+            exc,
+        )
+        _master_codes_cache = _MASTER_LOAD_FAILED
+        return _master_codes_cache
+    _master_codes_cache = codes
+    return codes
+
+
+def _is_known_master_code(code: str) -> bool:
+    """code(이미 upper() 정규화된 값)가 종목마스터에 실재하는 코드인지 확인합니다.
+
+    마스터를 읽을 수 없으면(fail-open) 검증을 생략하고 True를 반환해 #151
+    이전의 지름길 동작(검증 없이 통과)을 유지합니다.
+    """
+    codes = _load_master_codes()
+    if codes is _MASTER_LOAD_FAILED:
+        return True
+    return code in codes
+
+
 def _has_code_digit(value: str) -> bool:
     """실제 종목코드는 항상 숫자를 포함한다(종목마스터 4,353종 전수 확인, 0건 예외).
 
@@ -80,8 +142,9 @@ def _looks_like_stock_code(stock: str) -> bool:
     이 함수를 재검토해야 한다.
 
     #140 영향: {6,7} → {6,7}|{9} 확대로 F70100026 같은 9자 펀드 코드가 이제 지름길을 탄다.
-    이 코드들은 MCP 검증 없이 통과하므로, 실재하지 않는 9자 코드를 직접 입력하면
-    존재 확인 없이 저장된다(#151 — 별도 이슈로 다룸).
+    이 함수 자체는 마스터를 보지 않으므로 실재 여부를 가리지 못한다 — 그 존재
+    검증은 이 함수의 True를 소비하는 쪽(services._resolve_stock_code의
+    _is_known_master_code 호출)이 담당한다(#151).
     """
     value = stock.strip().upper()
     return bool(_STOCK_CODE_RE.match(value)) and _has_code_digit(value)

--- a/backend/stock_code.py
+++ b/backend/stock_code.py
@@ -6,7 +6,8 @@ services.py와 telegram_commands.py가 각자 중복 구현하던 정규식과 �
 import json
 import logging
 import re
-from pathlib import Path
+
+from .config import _TRADING_MCP_DIR
 
 logger = logging.getLogger(__name__)
 
@@ -61,10 +62,15 @@ _ORDERABLE_STOCK_CODE_RE = re.compile(r"\A[0-9]{6,7}\Z")
 # 종목마스터 코드 존재 검증 (#151) — _looks_like_stock_code 지름길이 MCP 존재
 # 확인 없이 코드를 확정해 버리는 문제를 로컬 코드 집합 대조로 막는다.
 # ──────────────────────────────────────────────────────────────────────────
-# mcp-trading/stock-master.js:8의 DEFAULT_STOCKS_PATH와
-# mcp-trading/scripts/update_stock_master.py:12가 쓰는 경로가 동일하므로,
-# 백엔드가 이 파일을 직접 읽어도 MCP가 보는 마스터와 어긋날 수 없다(같은 파일).
-_MASTER_STOCKS_PATH = Path(__file__).resolve().parents[1] / "mcp-trading" / "data" / "stocks.json"
+# 경로를 config._TRADING_MCP_DIR에서 파생시킨다. 백엔드가 MCP를 띄우는 디렉터리와
+# 마스터를 읽는 디렉터리가 *같은 계산*에서 나오므로, 백엔드가 읽는 파일은 MCP가
+# stock-master.js:8(DEFAULT_STOCKS_PATH)로 읽는 파일과 정의상 같다.
+# 이 파일 위치(backend/)에 고정하면 안 된다 — TRADING_MCP_DIR로 MCP 디렉터리를 옮긴
+# 구성에서 둘이 갈라진다(backend/Dockerfile: 백엔드 소스는 /app에 bind mount,
+# MCP는 이미지 안 /opt/mcp-trading). 특히 레포 바깥을 가리키면 backend 쪽 경로에
+# 파일이 없어 fail-open으로 #151 검증이 조용히 꺼진다.
+# config는 stock_code를 import하지 않으므로 순환 import는 발생하지 않는다.
+_MASTER_STOCKS_PATH = _TRADING_MCP_DIR / "data" / "stocks.json"
 
 # 마스터 로드 실패(fail-open)를 "성공했지만 빈 집합"과 구분하기 위한 센티널.
 _MASTER_LOAD_FAILED = object()
@@ -82,6 +88,9 @@ def _load_master_codes():
     캐시해 반환합니다(fail-open) — 이 경로는 리포트 저장 판정에 쓰이지
     주문에는 쓰이지 않으므로, 마스터를 못 읽는다고 분석 기능 전체가 죽으면
     안 됩니다.
+
+    개별 항목의 결손은 그 항목만 건너뛰고 나머지로 계속하되, 코드를 하나도
+    읽지 못한 경우는 로드 실패로 취급합니다(빈 집합은 모든 코드를 거부하므로).
     """
     global _master_codes_cache
     if _master_codes_cache is not None:
@@ -89,7 +98,21 @@ def _load_master_codes():
     try:
         raw = _MASTER_STOCKS_PATH.read_text(encoding="utf-8")
         stocks = json.loads(raw)
-        codes = frozenset(str(stock["code"]).upper() for stock in stocks)
+        # 항목 단위로 건너뛴다. 마스터는 외부 KIS 파일에서 생성되므로 code 키가 빠진
+        # 항목이 섞일 수 있는데, 하나의 KeyError로 4,353건 전체 검증이 fail-open되면
+        # 그 한 건 때문에 #151이 통째로 꺼진다. stock-master.js도 String(s.code ?? "")로
+        # 항목 단위로 방어한다.
+        codes = frozenset(
+            str(stock["code"]).upper()
+            for stock in stocks
+            if isinstance(stock, dict) and stock.get("code")
+        )
+        total = len(stocks)
+        if not codes:
+            # 파일 형태가 통째로 바뀌어 코드를 하나도 못 읽으면 빈 집합이 되는데, 그러면
+            # _is_known_master_code가 모든 코드를 조용히 거부한다 — fail-open보다 나쁘다.
+            # 센티널과 구분되지 않으므로 여기서 로드 실패로 되돌린다.
+            raise ValueError("종목마스터에서 코드를 하나도 읽지 못했습니다")
     except Exception as exc:
         logger.warning(
             "종목마스터 로드 실패, 지름길 존재 검증을 건너뜁니다(fail-open): path=%s, error=%s",
@@ -98,6 +121,16 @@ def _load_master_codes():
         )
         _master_codes_cache = _MASTER_LOAD_FAILED
         return _master_codes_cache
+    if len(codes) < total:
+        # 캐시 때문에 이 경고는 프로세스 수명 동안 한 번만 찍힌다 — 얼마나 건졌는지를
+        # 함께 남겨야 "일부만 검증 중"인 상태를 나중에 알아볼 수 있다.
+        # 마스터의 코드는 유일하므로(stock-master.js Step 1의 전제) 차이는 곧 누락 건수다.
+        logger.warning(
+            "종목마스터 일부 항목에서 코드를 읽지 못했습니다: path=%s, %d/%d건만 사용합니다",
+            _MASTER_STOCKS_PATH,
+            len(codes),
+            total,
+        )
     _master_codes_cache = codes
     return codes
 
@@ -112,6 +145,31 @@ def _is_known_master_code(code: str) -> bool:
     if codes is _MASTER_LOAD_FAILED:
         return True
     return code in codes
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# 미해석 에코 판정 (#151) — stock-master.js Step 3
+# ──────────────────────────────────────────────────────────────────────────
+# resolveStock은 코드 형태 입력이 마스터에 코드로도 이름·별칭으로도 없으면
+# market="UNKNOWN"으로 입력을 그대로 되돌려준다(stock-master.js:91-93).
+# 존재 검증이 아니라 에코이므로 이걸 성공으로 오인하면 #151이 재발한다.
+# 실제 마스터의 market은 KOSPI/KOSDAQ뿐이라(mcp-trading/data/stocks.json 전수 확인)
+# "(코드, UNKNOWN)" 조합은 이 에코의 신뢰 가능한 신호다.
+#
+# _STOCK_CODE_EXTRACT_RE와 같은 "괄호+코드" 지점에 앵커한다. 문자열 끝에 앵커하면
+# index.js:559가 응답 뒤에 무언가를 덧붙이는 순간 코드 추출은 계속 성공하는데
+# 에코 감지만 조용히 멈춰 #151이 되돌아온다.
+_UNRESOLVED_ECHO_RE = re.compile(r"\([0-9A-Z]{6,}, UNKNOWN\)")
+
+
+def _is_unresolved_echo(resolved_text: str) -> bool:
+    """resolve_stock_code 응답이 stock-master.js Step 3의 미해석 에코인지 판정합니다.
+
+    리포트 저장(services._resolve_stock_code)과 주문 준비(telegram_commands)가
+    같은 판정을 쓰도록 여기 둔다 — 한쪽에만 적용하면 같은 미해석 입력이 위험도가
+    높은 주문 경로로만 통과한다.
+    """
+    return bool(_UNRESOLVED_ECHO_RE.search(resolved_text))
 
 
 def _has_code_digit(value: str) -> bool:

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -39,7 +39,11 @@ from .trading_orders import (
     TradeRecorder,
     is_korean_market_open,
 )
-from .stock_code import _ORDERABLE_STOCK_CODE_RE, _STOCK_CODE_EXTRACT_RE
+from .stock_code import (
+    _ORDERABLE_STOCK_CODE_RE,
+    _STOCK_CODE_EXTRACT_RE,
+    _is_unresolved_echo,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -719,6 +723,18 @@ class TelegramCommandHandler:
             if stock_code is None:
                 await self._send_text_or_raise("주문 준비 실패: 종목코드를 확인할 수 없습니다.")
                 return
+            # 추출 성공 != 존재 확인. stock-master.js Step 3는 마스터에 없는 코드 형태
+            # 입력을 market="UNKNOWN"으로 그대로 에코하므로("999999 (999999, UNKNOWN)")
+            # 코드 추출은 성공하고 아래 숫자 6~7자 검사도 통과한다. 백엔드가 여기서
+            # 끊지 않으면 실재 여부 확인이 KIS 왕복이나 /confirm 시점 브로커 거절로
+            # 미뤄진다 — 리포트 저장 경로(services._resolve_stock_code)는 이미 같은
+            # 판정으로 막고 있으므로, 위험도가 더 높은 주문 경로도 같은 선에서 막는다.
+            if _is_unresolved_echo(str(resolved)):
+                await self._send_text_or_raise(
+                    f"주문 불가: {stock_name}({stock_code}) — 종목마스터에 없는 종목입니다. "
+                    "종목코드를 확인하거나 mcp-trading/data/stocks.json을 갱신하세요."
+                )
+                return
             # 추출 성공 != 주문 가능. mcp-trading/order.js의 buildCashOrderBody()가
             # 숫자 코드만 주문을 받으므로(#73에서 확정된 정책), 시세·잔고 조회와 60초
             # 대기 슬롯을 쓰기 전에 여기서 끊는다. 이 검사가 없으면 /confirm 이후에야
@@ -1124,6 +1140,9 @@ class TelegramCommandHandler:
         if balance:
             lines.append(balance)
 
+        # 미해석 에코(name == code)는 이제 주문 준비 단계에서 _is_unresolved_echo가
+        # 끊으므로 여기까지 오지 않는다(#151). 마스터에 name == code인 항목이 생기는
+        # 경우에 대비한 방어선으로만 남긴다 — 현재 마스터 4,353종에는 0건이다.
         if order.stock_name == order.stock_code:
             lines.append(UNRESOLVED_STOCK_WARNING)
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -17,9 +17,13 @@ def _clear_stock_code_cache():
 @pytest.fixture(autouse=True)
 def _clear_master_code_cache():
     # #151: _is_known_master_code의 지연 로딩 캐시도 테스트 간에 새면 안 된다 —
-    # 한 테스트가 _MASTER_STOCKS_PATH를 몽키패치해 로드 실패(fail-open)를
+    # 한 테스트가 _TRADING_MCP_DIR을 몽키패치해 로드 실패(fail-open)를
     # 캐시해 버리면, 몽키패치가 되돌아간 뒤에도 다음 테스트가 그 실패 상태를
     # 그대로 물려받아 실제 마스터 대조를 건너뛰게 된다.
+    # _master_codes_cache_path는 _master_codes_cache가 None이면 어차피 무시되지만
+    # (첫 조건에서 단락 평가), 둘을 짝으로 리셋해 상태를 명확히 남긴다.
     stock_code._master_codes_cache = None
+    stock_code._master_codes_cache_path = None
     yield
     stock_code._master_codes_cache = None
+    stock_code._master_codes_cache_path = None

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-from backend import services
+from backend import services, stock_code
 
 
 @pytest.fixture(autouse=True)
@@ -12,3 +12,14 @@ def _clear_stock_code_cache():
     services._stock_code_cache.clear()
     yield
     services._stock_code_cache.clear()
+
+
+@pytest.fixture(autouse=True)
+def _clear_master_code_cache():
+    # #151: _is_known_master_code의 지연 로딩 캐시도 테스트 간에 새면 안 된다 —
+    # 한 테스트가 _MASTER_STOCKS_PATH를 몽키패치해 로드 실패(fail-open)를
+    # 캐시해 버리면, 몽키패치가 되돌아간 뒤에도 다음 테스트가 그 실패 상태를
+    # 그대로 물려받아 실제 마스터 대조를 건너뛰게 된다.
+    stock_code._master_codes_cache = None
+    yield
+    stock_code._master_codes_cache = None

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -548,6 +548,67 @@ async def test_perform_stock_analysis_skips_mcp_when_stock_is_already_code(monke
 
 
 @pytest.mark.asyncio
+async def test_perform_stock_analysis_skips_mcp_for_known_master_fund_code(monkeypatch):
+    """#151과 별개로 #140의 지름길(9자 펀드 코드)을 회귀시키면 안 된다.
+
+    F70100026은 종목마스터 실제 항목(수용 기준: 존재하는 펀드 코드는 정상 해석).
+    """
+
+    async def fake_llm_chat(provider, prompt, *, conversation_id=None):
+        return "plain analysis"
+
+    async def unexpected_run_mcp_tool(params, tool_name, arguments):
+        raise AssertionError("마스터에 실재하는 코드는 MCP를 호출하면 안 된다")
+
+    monkeypatch.setattr(services, "llm_chat", fake_llm_chat)
+    monkeypatch.setattr(services, "run_mcp_tool", unexpected_run_mcp_tool)
+
+    fake_session = FakeSession()
+    await services.perform_stock_analysis("F70100026", "openai", fake_session)
+
+    assert fake_session.report.stock_code == "F70100026"
+
+
+@pytest.mark.asyncio
+async def test_perform_stock_analysis_master_unknown_code_not_saved_without_verification(
+    monkeypatch, caplog
+):
+    """#151 수용 기준: 마스터에 없는 코드 형태 입력(999999)은 존재 확인 없이
+    저장되면 안 된다.
+
+    지름길이 마스터 대조에서 걸러지면 아래 MCP 경로로 흘러간다. 999999는
+    stock-master.js CODE_SHAPE_PATTERN에 걸리는 6자 숫자라 Step 3가 예외 없이
+    market="UNKNOWN"으로 그대로 에코하므로(존재 검증이 아니라 되돌려주는 것),
+    이 에코를 성공으로 오인하면 #151이 재발한다.
+
+    뮤테이션 ①(마스터 대조 제거)이 들어가면 이 테스트는 MCP를 호출하지 않고
+    stock_code == "999999"를 저장해 red가 된다.
+    """
+
+    async def fake_llm_chat(provider, prompt, *, conversation_id=None):
+        return "plain analysis"
+
+    mcp_calls = []
+
+    async def fake_run_mcp_tool(params, tool_name, arguments):
+        mcp_calls.append(arguments)
+        return "999999 (999999, UNKNOWN)"
+
+    monkeypatch.setattr(services, "llm_chat", fake_llm_chat)
+    monkeypatch.setattr(services, "run_mcp_tool", fake_run_mcp_tool)
+
+    fake_session = FakeSession()
+    with caplog.at_level(logging.WARNING, logger=services.logger.name):
+        await services.perform_stock_analysis("999999", "openai", fake_session)
+
+    # 마스터 대조에서 걸러져 지름길을 포기하고 실제로 MCP 경로를 탔는지 확인한다.
+    assert mcp_calls == [{"stock_name": "999999"}]
+    # market="UNKNOWN" 에코를 성공으로 오인하지 않고 빈 문자열로 폴백해야 한다.
+    assert fake_session.report.stock_code == ""
+    assert "종목코드 추출 실패" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_perform_stock_analysis_bom_prefixed_name_caches_under_normalized_key(
     monkeypatch,
 ):

--- a/backend/tests/test_stock_code.py
+++ b/backend/tests/test_stock_code.py
@@ -5,12 +5,15 @@ _STOCK_CODE_EXTRACT_RE, _STOCK_CODE_RE / _looks_like_stock_code, _ORDERABLE_STOC
 telegram_commands.py의 조기 거절)은 각자의 테스트 파일에 남아 있다.
 """
 import json
+import logging
 from pathlib import Path
 
+from backend import stock_code
 from backend.stock_code import (
     _ORDERABLE_STOCK_CODE_RE,
     _STOCK_CODE_EXTRACT_RE,
     _has_code_digit,
+    _is_known_master_code,
     _looks_like_stock_code,
 )
 
@@ -193,6 +196,70 @@ class TestOrderableStockCodeRe:
         Python의 `\d`는 전각 숫자를 포함하므로 `[0-9]`로 명시한 이유를 고정한다.
         """
         assert not _ORDERABLE_STOCK_CODE_RE.fullmatch("００５９３０")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _is_known_master_code — 지름길 코드가 종목마스터에 실재하는지 대조 (#151)
+# ──────────────────────────────────────────────────────────────────────────
+
+class TestIsKnownMasterCode:
+    """_looks_like_stock_code 지름길이 MCP 존재 확인 없이 코드를 확정해 버리던
+    문제(#151)를 로컬 종목마스터 코드 집합과 대조해 막는다.
+    """
+
+    def test_known_numeric_code_returns_true(self):
+        """실측: 005930(삼성전자)은 종목마스터에 실재한다."""
+        assert _is_known_master_code("005930") is True
+
+    def test_known_nine_char_fund_code_returns_true(self):
+        """#140 회귀 가드: 마스터에 실재하는 9자 펀드 코드는 계속 지름길을 통과해야 한다."""
+        assert _is_known_master_code("F70100026") is True
+
+    def test_unknown_numeric_code_returns_false(self):
+        """#151 재현 케이스: 마스터에 없는 숫자 6자는 존재하지 않는다고 판정해야 한다."""
+        assert _is_known_master_code("999999") is False
+
+    def test_unknown_alphanumeric_code_returns_false(self):
+        assert _is_known_master_code("ZZZZ99") is False
+
+    def test_fail_open_when_master_file_missing(self, tmp_path, monkeypatch, caplog):
+        """마스터 파일을 읽을 수 없으면 예외를 던지지 않고 검증을 생략(True)한다.
+
+        이 경로는 리포트 저장 판정이지 주문이 아니므로, 마스터를 못 읽는다고
+        분석 기능 전체가 죽으면 안 된다(fail-open).
+        뮤테이션 ③: fail-open을 예외 전파로 바꾸면 이 테스트가 예외로 red가 되어야 한다.
+        """
+        monkeypatch.setattr(stock_code, "_MASTER_STOCKS_PATH", tmp_path / "missing.json")
+        with caplog.at_level(logging.WARNING, logger=stock_code.logger.name):
+            assert _is_known_master_code("999999") is True
+        assert "종목마스터 로드 실패" in caplog.text
+
+    def test_fail_open_when_master_file_malformed(self, tmp_path, monkeypatch):
+        """마스터 파일이 있어도 JSON 파싱에 실패하면 마찬가지로 fail-open한다."""
+        broken_path = tmp_path / "broken.json"
+        broken_path.write_text("이것은 JSON이 아닙니다", encoding="utf-8")
+        monkeypatch.setattr(stock_code, "_MASTER_STOCKS_PATH", broken_path)
+        assert _is_known_master_code("999999") is True
+
+    def test_master_codes_loaded_from_disk_at_most_once(self, monkeypatch):
+        """지름길 경로가 요청마다 stocks.json(489K)을 다시 파싱하면 지름길을 둔
+        이유(MCP 왕복 생략)가 무색해진다 — 첫 호출 이후로는 캐시만 써야 한다.
+        """
+        read_calls = []
+        original_read_text = Path.read_text
+
+        def counting_read_text(self, *args, **kwargs):
+            if self == stock_code._MASTER_STOCKS_PATH:
+                read_calls.append(1)
+            return original_read_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", counting_read_text)
+
+        assert _is_known_master_code("005930") is True
+        assert _is_known_master_code("999999") is False
+        assert _is_known_master_code("F70100026") is True
+
+        assert len(read_calls) == 1
 
 
 # ──────────────────────────────────────────────────────────────────────────

--- a/backend/tests/test_stock_code.py
+++ b/backend/tests/test_stock_code.py
@@ -391,6 +391,47 @@ def test_master_path_wiring_follows_trading_mcp_dir_without_reload(tmp_path, mon
     assert _is_known_master_code("005930") is False
 
 
+def test_master_code_cache_invalidates_when_path_changes(tmp_path, monkeypatch):
+    """캐시가 경로별로 무효화되는지 확인한다 — _load_master_codes의
+    `if _master_codes_cache is not None and _master_codes_cache_path == path:`에서
+    `and _master_codes_cache_path == path` 절이 실제로 지키는 계약이다.
+
+    conftest.py의 autouse 픽스처(_clear_master_code_cache)가 매 테스트 시작·종료마다
+    캐시를 비우므로, 테스트 사이에는 이 절이 있으나 없으나 차이가 드러나지 않는다 —
+    이 절이 지키는 건 "한 테스트 안에서 _TRADING_MCP_DIR이 바뀌는" 경우다. 그러지
+    않으면 경로가 바뀐 뒤에도 이전 경로에서 읽은 캐시를 그대로 돌려준다.
+
+    양방향을 모두 단언한다 — 새 경로의 코드가 보이는지(A의 캐시를 그대로 썼다면
+    안 보임)와 이전 경로의 코드가 더 이상 보이지 않는지(A의 캐시를 그대로 썼다면
+    계속 보임) 중 한쪽만 확인하면 반쪽짜리 계약이 된다.
+
+    뮤테이션: `and _master_codes_cache_path == path`를 지우면(캐시 유효성 검사를
+    `_master_codes_cache is not None`만으로 완화하면) 아래 두 단정 모두 red가 된다 —
+    경로 B로 바꾼 뒤에도 경로 A에서 읽은 캐시를 그대로 반환하기 때문이다.
+    """
+    dir_a = tmp_path / "mcp-a"
+    (dir_a / "data").mkdir(parents=True)
+    (dir_a / "data" / "stocks.json").write_text(
+        json.dumps([{"code": "111111", "name": "A마스터종목", "market": "KOSPI"}], ensure_ascii=False),
+        encoding="utf-8",
+    )
+    dir_b = tmp_path / "mcp-b"
+    (dir_b / "data").mkdir(parents=True)
+    (dir_b / "data" / "stocks.json").write_text(
+        json.dumps([{"code": "222222", "name": "B마스터종목", "market": "KOSPI"}], ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(stock_code, "_TRADING_MCP_DIR", dir_a)
+    assert _is_known_master_code("111111") is True
+
+    monkeypatch.setattr(stock_code, "_TRADING_MCP_DIR", dir_b)
+    # 캐시가 무효화되지 않으면 A의 캐시(111111만 포함)를 그대로 돌려줘 False가 된다.
+    assert _is_known_master_code("222222") is True
+    # 캐시가 무효화되지 않으면 A의 캐시를 그대로 돌려줘 True가 된다.
+    assert _is_known_master_code("111111") is False
+
+
 # ──────────────────────────────────────────────────────────────────────────
 # _is_unresolved_echo — stock-master.js Step 3 미해석 에코 판정 (#151)
 # ──────────────────────────────────────────────────────────────────────────

--- a/backend/tests/test_stock_code.py
+++ b/backend/tests/test_stock_code.py
@@ -231,16 +231,19 @@ class TestIsKnownMasterCode:
         분석 기능 전체가 죽으면 안 된다(fail-open).
         뮤테이션 ③: fail-open을 예외 전파로 바꾸면 이 테스트가 예외로 red가 되어야 한다.
         """
-        monkeypatch.setattr(stock_code, "_MASTER_STOCKS_PATH", tmp_path / "missing.json")
+        # 경로는 이제 _TRADING_MCP_DIR에서 매 호출 파생되므로(#151 리뷰 후속), 없는
+        # 파일을 가리키려면 마스터가 없는 빈 디렉터리로 _TRADING_MCP_DIR을 옮긴다.
+        monkeypatch.setattr(stock_code, "_TRADING_MCP_DIR", tmp_path)
         with caplog.at_level(logging.WARNING, logger=stock_code.logger.name):
             assert _is_known_master_code("999999") is True
         assert "종목마스터 로드 실패" in caplog.text
 
     def test_fail_open_when_master_file_malformed(self, tmp_path, monkeypatch):
         """마스터 파일이 있어도 JSON 파싱에 실패하면 마찬가지로 fail-open한다."""
-        broken_path = tmp_path / "broken.json"
+        broken_path = tmp_path / "data" / "stocks.json"
+        broken_path.parent.mkdir(parents=True)
         broken_path.write_text("이것은 JSON이 아닙니다", encoding="utf-8")
-        monkeypatch.setattr(stock_code, "_MASTER_STOCKS_PATH", broken_path)
+        monkeypatch.setattr(stock_code, "_TRADING_MCP_DIR", tmp_path)
         assert _is_known_master_code("999999") is True
 
     def test_entry_without_code_does_not_disable_validation(
@@ -252,7 +255,8 @@ class TestIsKnownMasterCode:
         try로 묶으면 결손 1건의 KeyError가 4,353건 전부를 fail-open으로 만들고,
         실패는 캐시되므로 경고조차 프로세스 수명 동안 한 번만 찍힌다.
         """
-        master = tmp_path / "stocks.json"
+        master = tmp_path / "data" / "stocks.json"
+        master.parent.mkdir(parents=True)
         master.write_text(
             json.dumps(
                 [
@@ -265,7 +269,7 @@ class TestIsKnownMasterCode:
             ),
             encoding="utf-8",
         )
-        monkeypatch.setattr(stock_code, "_MASTER_STOCKS_PATH", master)
+        monkeypatch.setattr(stock_code, "_TRADING_MCP_DIR", tmp_path)
 
         with caplog.at_level(logging.WARNING, logger=stock_code.logger.name):
             # 읽어낸 항목은 정상 대조되고, 못 읽은 항목 때문에 fail-open되지 않는다.
@@ -283,12 +287,13 @@ class TestIsKnownMasterCode:
         거부한다 — 실재하는 종목까지 저장이 막히므로 fail-open보다 나쁘다.
         뮤테이션: `if not codes: raise`를 지우면 아래 True 단정이 red가 된다.
         """
-        master = tmp_path / "stocks.json"
+        master = tmp_path / "data" / "stocks.json"
+        master.parent.mkdir(parents=True)
         master.write_text(
             json.dumps({"stocks": [{"code": "005930"}]}, ensure_ascii=False),
             encoding="utf-8",
         )
-        monkeypatch.setattr(stock_code, "_MASTER_STOCKS_PATH", master)
+        monkeypatch.setattr(stock_code, "_TRADING_MCP_DIR", tmp_path)
 
         with caplog.at_level(logging.WARNING, logger=stock_code.logger.name):
             assert _is_known_master_code("005930") is True
@@ -301,9 +306,10 @@ class TestIsKnownMasterCode:
         """
         read_calls = []
         original_read_text = Path.read_text
+        expected_path = stock_code._master_stocks_path(stock_code._TRADING_MCP_DIR)
 
         def counting_read_text(self, *args, **kwargs):
-            if self == stock_code._MASTER_STOCKS_PATH:
+            if self == expected_path:
                 read_calls.append(1)
             return original_read_text(self, *args, **kwargs)
 
@@ -342,6 +348,47 @@ def test_master_stocks_path_follows_trading_mcp_dir(tmp_path):
 
     other_dir = tmp_path / "another" / "mcp-trading"
     assert _master_stocks_path(other_dir) == other_dir / "data" / "stocks.json"
+
+
+def test_master_path_wiring_follows_trading_mcp_dir_without_reload(tmp_path, monkeypatch):
+    """_master_stocks_path 자체가 아니라, 그 함수를 *실제로 소비하는* _load_master_codes가
+    하드코딩 경로 대신 _TRADING_MCP_DIR에서 파생한 경로를 읽는지를 고정한다.
+
+    위 test_master_stocks_path_follows_trading_mcp_dir는 순수 함수의 계약만 고정할 뿐,
+    소비자(_load_master_codes)가 실제로 그 함수를 _TRADING_MCP_DIR로 호출하는지는
+    별도로 확인하지 않는다 — 소비자 쪽 배선이 `Path(__file__).resolve().parents[1] /
+    "mcp-trading"`처럼 하드코딩으로 되돌아가도 순수 함수 테스트는 계속 통과한다.
+    개발 환경에서는 두 경로가 우연히 같은 값으로 계산되므로 단순 경로 비교
+    (`_MASTER_STOCKS_PATH == _master_stocks_path(_TRADING_MCP_DIR)`)로도 이 배선
+    풀림을 못 잡는다 — 실제로 마스터를 갈아끼워 다른 내용을 읽는지까지 확인해야 한다.
+
+    reload 없이 stock_code._TRADING_MCP_DIR을 직접 몽키패치하는 것만으로 검증할 수
+    있다 — _load_master_codes가 매 호출 _master_stocks_path(_TRADING_MCP_DIR)를 그
+    자리에서 계산하도록 바뀌었기 때문이다(#151 리뷰 후속). _TRADING_MCP_DIR은 평범한
+    모듈 전역이라 몽키패치가 다음 호출에 곧바로 반영된다.
+
+    뮤테이션: _load_master_codes 안의 `_master_stocks_path(_TRADING_MCP_DIR)`를
+    `_master_stocks_path(Path(__file__).resolve().parents[1] / "mcp-trading")`처럼
+    하드코딩으로 되돌리면, 아래 두 단정 모두 실제 마스터(4,353종)를 읽게 되어 red가
+    된다 — "111111"은 실제 마스터에 없고 "005930"은 실제 마스터에 있으므로.
+    """
+    mcp_dir = tmp_path / "custom-mcp"
+    (mcp_dir / "data").mkdir(parents=True)
+    (mcp_dir / "data" / "stocks.json").write_text(
+        json.dumps(
+            [{"code": "111111", "name": "가짜종목", "market": "KOSPI"}],
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(stock_code, "_TRADING_MCP_DIR", mcp_dir)
+
+    # 커스텀 경로의 마스터에만 있는 코드는 알려진 코드로 판정된다.
+    assert _is_known_master_code("111111") is True
+    # 실제 마스터(mcp-trading/data/stocks.json)에만 있는 코드는 이 커스텀 경로에
+    # 없으므로 알려지지 않은 코드로 판정된다 — 하드코딩 경로로 되돌아가면 이 코드가
+    # 실제 마스터에서 발견돼 True가 되어 버린다.
+    assert _is_known_master_code("005930") is False
 
 
 # ──────────────────────────────────────────────────────────────────────────

--- a/backend/tests/test_stock_code.py
+++ b/backend/tests/test_stock_code.py
@@ -4,16 +4,18 @@ _STOCK_CODE_EXTRACT_RE, _STOCK_CODE_RE / _looks_like_stock_code, _ORDERABLE_STOC
 순수 단위 테스트. 각 호출부 고유 동작(services.py의 빈 문자열 폴백,
 telegram_commands.py의 조기 거절)은 각자의 테스트 파일에 남아 있다.
 """
+import importlib
 import json
 import logging
 from pathlib import Path
 
-from backend import stock_code
+from backend import config, stock_code
 from backend.stock_code import (
     _ORDERABLE_STOCK_CODE_RE,
     _STOCK_CODE_EXTRACT_RE,
     _has_code_digit,
     _is_known_master_code,
+    _is_unresolved_echo,
     _looks_like_stock_code,
 )
 
@@ -241,6 +243,58 @@ class TestIsKnownMasterCode:
         monkeypatch.setattr(stock_code, "_MASTER_STOCKS_PATH", broken_path)
         assert _is_known_master_code("999999") is True
 
+    def test_entry_without_code_does_not_disable_validation(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """code 키가 빠진 항목 하나가 마스터 전체 검증을 꺼뜨리면 안 된다.
+
+        마스터는 외부 KIS 파일에서 생성되므로 형태가 변할 수 있다. 항목 전체를 한
+        try로 묶으면 결손 1건의 KeyError가 4,353건 전부를 fail-open으로 만들고,
+        실패는 캐시되므로 경고조차 프로세스 수명 동안 한 번만 찍힌다.
+        """
+        master = tmp_path / "stocks.json"
+        master.write_text(
+            json.dumps(
+                [
+                    {"code": "005930", "name": "삼성전자", "market": "KOSPI"},
+                    {"name": "코드 없는 항목", "market": "KOSPI"},
+                    {"code": "", "name": "빈 코드", "market": "KOSPI"},
+                    "리스트가 아닌 항목",
+                ],
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(stock_code, "_MASTER_STOCKS_PATH", master)
+
+        with caplog.at_level(logging.WARNING, logger=stock_code.logger.name):
+            # 읽어낸 항목은 정상 대조되고, 못 읽은 항목 때문에 fail-open되지 않는다.
+            assert _is_known_master_code("005930") is True
+            assert _is_known_master_code("999999") is False
+
+        assert "종목마스터 로드 실패" not in caplog.text
+        assert "일부 항목에서 코드를 읽지 못했습니다" in caplog.text
+        assert "1/4건" in caplog.text
+
+    def test_fail_open_when_no_code_could_be_read(self, tmp_path, monkeypatch, caplog):
+        """코드를 하나도 못 읽으면(마스터 형태가 통째로 바뀜) 로드 실패로 취급한다.
+
+        빈 집합을 성공으로 캐시하면 _is_known_master_code가 *모든* 코드를 조용히
+        거부한다 — 실재하는 종목까지 저장이 막히므로 fail-open보다 나쁘다.
+        뮤테이션: `if not codes: raise`를 지우면 아래 True 단정이 red가 된다.
+        """
+        master = tmp_path / "stocks.json"
+        master.write_text(
+            json.dumps({"stocks": [{"code": "005930"}]}, ensure_ascii=False),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(stock_code, "_MASTER_STOCKS_PATH", master)
+
+        with caplog.at_level(logging.WARNING, logger=stock_code.logger.name):
+            assert _is_known_master_code("005930") is True
+
+        assert "종목마스터 로드 실패" in caplog.text
+
     def test_master_codes_loaded_from_disk_at_most_once(self, monkeypatch):
         """지름길 경로가 요청마다 stocks.json(489K)을 다시 파싱하면 지름길을 둔
         이유(MCP 왕복 생략)가 무색해진다 — 첫 호출 이후로는 캐시만 써야 한다.
@@ -260,6 +314,67 @@ class TestIsKnownMasterCode:
         assert _is_known_master_code("F70100026") is True
 
         assert len(read_calls) == 1
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _MASTER_STOCKS_PATH — 백엔드가 읽는 마스터가 MCP가 보는 마스터와 같은가
+# ──────────────────────────────────────────────────────────────────────────
+
+def test_master_stocks_path_follows_trading_mcp_dir(tmp_path, monkeypatch):
+    """마스터 경로는 백엔드가 MCP를 띄우는 디렉터리(TRADING_MCP_DIR)에서 파생돼야 한다.
+
+    stock_code.py 위치에 고정하면 개발 환경에서는 두 경로가 우연히 같아 문제가
+    드러나지 않지만, backend/Dockerfile은 백엔드 소스(/app bind mount)와 MCP
+    디렉터리(/opt/mcp-trading 이미지 스냅샷)를 실제로 갈라놓는다. TRADING_MCP_DIR이
+    레포 바깥을 가리키면 backend 쪽 경로에 파일이 없어 fail-open으로 #151 검증이
+    조용히 꺼진다.
+
+    뮤테이션: `Path(__file__).resolve().parents[1] / "mcp-trading" / ...`로 되돌리면
+    이 테스트가 red가 된다.
+    """
+    mcp_dir = tmp_path / "opt" / "mcp-trading"
+    monkeypatch.setenv("TRADING_MCP_DIR", str(mcp_dir))
+    try:
+        importlib.reload(config)
+        reloaded = importlib.reload(stock_code)
+        assert reloaded._MASTER_STOCKS_PATH == mcp_dir.resolve() / "data" / "stocks.json"
+    finally:
+        # 다른 테스트가 실제 마스터를 대조하므로 환경변수와 모듈 상태를 되돌린다.
+        monkeypatch.undo()
+        importlib.reload(config)
+        importlib.reload(stock_code)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _is_unresolved_echo — stock-master.js Step 3 미해석 에코 판정 (#151)
+# ──────────────────────────────────────────────────────────────────────────
+
+class TestIsUnresolvedEcho:
+    """리포트 저장(services)과 주문 준비(telegram_commands)가 공유하는 판정."""
+
+    def test_detects_numeric_echo(self):
+        assert _is_unresolved_echo("999999 (999999, UNKNOWN)") is True
+
+    def test_detects_alphanumeric_echo(self):
+        assert _is_unresolved_echo("ZZZZ99 (ZZZZ99, UNKNOWN)") is True
+        assert _is_unresolved_echo("Q999999 (Q999999, UNKNOWN)") is True
+
+    def test_rejects_resolved_master_entry(self):
+        assert _is_unresolved_echo("삼성전자 (005930, KOSPI)") is False
+        assert _is_unresolved_echo("한투글로벌넥스트웨이브1(A) (F70100026, KOSPI)") is False
+
+    def test_detects_echo_with_trailing_text(self):
+        """문자열 끝이 아니라 _STOCK_CODE_EXTRACT_RE와 같은 지점에 앵커한다.
+
+        endswith(", UNKNOWN)")로 앵커하면 index.js:559가 응답 뒤에 무언가를 덧붙이는
+        순간 코드 추출은 계속 성공하는데 에코 감지만 조용히 멈춰 #151이 되돌아온다.
+        뮤테이션: 판정을 endswith로 되돌리면 이 케이스가 red가 된다.
+        """
+        assert _is_unresolved_echo("999999 (999999, UNKNOWN)\n(조회 시각: 10:00)") is True
+
+    def test_rejects_unknown_without_code_shape(self):
+        """"UNKNOWN"이 코드 자리 없이 등장하는 문장은 에코가 아니다."""
+        assert _is_unresolved_echo("시장 정보를 알 수 없습니다 (UNKNOWN)") is False
 
 
 # ──────────────────────────────────────────────────────────────────────────

--- a/backend/tests/test_stock_code.py
+++ b/backend/tests/test_stock_code.py
@@ -4,12 +4,11 @@ _STOCK_CODE_EXTRACT_RE, _STOCK_CODE_RE / _looks_like_stock_code, _ORDERABLE_STOC
 순수 단위 테스트. 각 호출부 고유 동작(services.py의 빈 문자열 폴백,
 telegram_commands.py의 조기 거절)은 각자의 테스트 파일에 남아 있다.
 """
-import importlib
 import json
 import logging
 from pathlib import Path
 
-from backend import config, stock_code
+from backend import stock_code
 from backend.stock_code import (
     _ORDERABLE_STOCK_CODE_RE,
     _STOCK_CODE_EXTRACT_RE,
@@ -17,6 +16,7 @@ from backend.stock_code import (
     _is_known_master_code,
     _is_unresolved_echo,
     _looks_like_stock_code,
+    _master_stocks_path,
 )
 
 # 종목마스터 실제 데이터(4,353종 전수) — 판정 함수가 이름·별칭을 코드로 오인하지
@@ -320,7 +320,7 @@ class TestIsKnownMasterCode:
 # _MASTER_STOCKS_PATH — 백엔드가 읽는 마스터가 MCP가 보는 마스터와 같은가
 # ──────────────────────────────────────────────────────────────────────────
 
-def test_master_stocks_path_follows_trading_mcp_dir(tmp_path, monkeypatch):
+def test_master_stocks_path_follows_trading_mcp_dir(tmp_path):
     """마스터 경로는 백엔드가 MCP를 띄우는 디렉터리(TRADING_MCP_DIR)에서 파생돼야 한다.
 
     stock_code.py 위치에 고정하면 개발 환경에서는 두 경로가 우연히 같아 문제가
@@ -329,20 +329,19 @@ def test_master_stocks_path_follows_trading_mcp_dir(tmp_path, monkeypatch):
     레포 바깥을 가리키면 backend 쪽 경로에 파일이 없어 fail-open으로 #151 검증이
     조용히 꺼진다.
 
-    뮤테이션: `Path(__file__).resolve().parents[1] / "mcp-trading" / ...`로 되돌리면
-    이 테스트가 red가 된다.
+    파생 규칙은 _master_stocks_path 순수 함수로 뽑혀 있어(#151 리뷰), 모듈을
+    importlib.reload하지 않고도 서로 다른 mcp_dir 입력에 대해 같은 계약을 고정할 수
+    있다 — reload는 다른 테스트가 붙잡은 config/stock_code 바인딩까지 영향권이라
+    다음 사람이 테스트를 추가할 때 밟기 쉬운 지뢰였다.
+
+    뮤테이션: _master_stocks_path가 mcp_dir 인자를 무시하고 하드코딩 경로를
+    반환하면 이 테스트가 red가 된다.
     """
     mcp_dir = tmp_path / "opt" / "mcp-trading"
-    monkeypatch.setenv("TRADING_MCP_DIR", str(mcp_dir))
-    try:
-        importlib.reload(config)
-        reloaded = importlib.reload(stock_code)
-        assert reloaded._MASTER_STOCKS_PATH == mcp_dir.resolve() / "data" / "stocks.json"
-    finally:
-        # 다른 테스트가 실제 마스터를 대조하므로 환경변수와 모듈 상태를 되돌린다.
-        monkeypatch.undo()
-        importlib.reload(config)
-        importlib.reload(stock_code)
+    assert _master_stocks_path(mcp_dir) == mcp_dir / "data" / "stocks.json"
+
+    other_dir = tmp_path / "another" / "mcp-trading"
+    assert _master_stocks_path(other_dir) == other_dir / "data" / "stocks.json"
 
 
 # ──────────────────────────────────────────────────────────────────────────

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -1360,18 +1360,28 @@ async def test_buy_with_stock_code_resolves_name_and_shows_no_warning():
     assert UNRESOLVED_STOCK_WARNING not in notifier.messages[-1]
 
 
+@pytest.mark.parametrize("code", ["999999", "ZZZZ99", "Q999999"])
 @pytest.mark.asyncio
-async def test_buy_with_unregistered_code_shows_unresolved_warning():
-    """미등록 코드는 이름=코드로 echo되므로 미해석 경고가 붙는다."""
+async def test_buy_with_unresolved_echo_is_rejected(code):
+    """마스터에 없는 코드 형태 입력은 주문 준비 단계에서 끊는다 (#151).
+
+    stock-master.js Step 3는 이런 입력을 market="UNKNOWN"으로 그대로 에코하므로
+    코드 추출은 성공하고 숫자 6~7자 검사(999999)도 통과한다. 백엔드에 이 가드가
+    없으면 실재 확인이 KIS 왕복(get_stock_quote)이나 /confirm 시점 브로커 거절로
+    미뤄진다 — 리포트 저장 경로는 이미 같은 판정으로 막고 있는데 위험도가 더 높은
+    주문 경로만 통과하던 비대칭을 없앤다.
+
+    뮤테이션: _is_unresolved_echo 가드를 지우면 999999가 대기 주문으로 등록돼 red가
+    된다(ZZZZ99·Q999999는 영숫자라 _ORDERABLE_STOCK_CODE_RE가 뒤에서 잡지만, 거절
+    사유가 "ETN·펀드"로 바뀌므로 메시지 단정에서 red가 된다).
+    """
 
     async def mcp_runner(server_params, tool_name, arguments):
         if tool_name == "resolve_stock_code":
-            return "123456 (123456, UNKNOWN)"
-        if tool_name == "get_stock_quote":
-            return "현재가: 0원"
-        if tool_name == "get_balance":
-            return "주문가능금액: 1,000,000원"
-        raise AssertionError(f"unexpected tool: {tool_name}")
+            return f"{code} ({code}, UNKNOWN)"
+        raise AssertionError(
+            f"미해석 에코는 시세·잔고 조회 전에 끊어야 한다: {tool_name}"
+        )
 
     notifier = FakeNotifier()
     handler = TelegramCommandHandler(
@@ -1381,12 +1391,12 @@ async def test_buy_with_unregistered_code_shows_unresolved_warning():
     )
 
     await handler.handle_update(
-        {"message": {"chat": {"id": 123}, "text": "/buy 123456 10"}}
+        {"message": {"chat": {"id": 123}, "text": f"/buy {code} 10"}}
     )
 
-    assert handler.pending_orders["123"].stock_name == "123456"
-    assert handler.pending_orders["123"].stock_code == "123456"
-    assert UNRESOLVED_STOCK_WARNING in notifier.messages[-1]
+    assert handler.pending_orders == {}
+    assert "종목마스터에 없는 종목입니다" in notifier.messages[-1]
+    assert code in notifier.messages[-1]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -1399,6 +1399,34 @@ async def test_buy_with_unresolved_echo_is_rejected(code):
     assert code in notifier.messages[-1]
 
 
+def test_format_order_prompt_warns_when_name_equals_code():
+    """UNRESOLVED_STOCK_WARNING 방어선이 실제로 동작하는지 포맷터 단위로 고정한다.
+
+    주문 준비 단계(_is_unresolved_echo)가 먼저 끊으므로 현재 마스터로는 이 분기에
+    도달하지 않는다(#151) — 그래도 마스터에 name == code인 항목이 생기는 경우를 대비한
+    방어선이라면 실제로 경고를 붙이는지 확인할 수 있어야 한다.
+
+    뮤테이션: telegram_commands._format_order_prompt의
+    `if order.stock_name == order.stock_code:` 분기를 제거하면 이 단정이 red가 된다.
+    """
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(notifier=notifier)
+    order = PendingOrder(
+        chat_id="123",
+        stock_name="999999",
+        stock_code="999999",
+        side="BUY",
+        quantity=10,
+        price=0,
+        created_at=datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+        order_type="MARKET",
+    )
+
+    prompt = handler._format_order_prompt(order, "현재가: 74,500원", "주문가능금액: 1,000,000원")
+
+    assert UNRESOLVED_STOCK_WARNING in prompt
+
+
 @pytest.mark.asyncio
 async def test_confirm_executes_gateway_and_records_trade():
     async def mcp_runner(server_params, tool_name, arguments):

--- a/mcp-trading/stock-master.js
+++ b/mcp-trading/stock-master.js
@@ -98,6 +98,6 @@ export function resolveStock(stockName, stocks) {
 
   throw new Error(
     `'${input}'의 종목 코드를 찾을 수 없습니다. ` +
-      "6~7자리 종목코드로 직접 입력하거나 mcp-trading/data/stocks.json을 갱신하세요.",
+      "6·7·9자리 종목코드로 직접 입력하거나 mcp-trading/data/stocks.json을 갱신하세요.",
   );
 }

--- a/mcp-trading/stock-master.js
+++ b/mcp-trading/stock-master.js
@@ -75,7 +75,7 @@ export function resolveStock(stockName, stocks) {
     const candidates = matches
       .map((stock) => `${stock.name}(${stock.code}, ${stock.market})`)
       .join(", ");
-    throw new Error(`'${input}'의 종목 매칭이 모호합니다: ${candidates}. 6~7자리 종목코드를 직접 입력하세요.`);
+    throw new Error(`'${input}'의 종목 매칭이 모호합니다: ${candidates}. 6·7·9자리 종목코드를 직접 입력하세요.`);
   }
 
   if (matches.length === 1) {

--- a/mcp-trading/tests/stock-master.test.js
+++ b/mcp-trading/tests/stock-master.test.js
@@ -44,10 +44,10 @@ test("resolveStock keeps alphanumeric KIS stock codes available without master e
   });
 });
 
-test("resolveStock guides users to 6~7 digit stock codes when a name is missing", () => {
+test("resolveStock guides users to 6/7/9 digit stock codes when a name is missing", () => {
   assert.throws(
     () => resolveStock("없는종목"),
-    /6~7자리 종목코드로 직접 입력/,
+    /6·7·9자리 종목코드로 직접 입력/,
   );
 });
 

--- a/mcp-trading/tests/stock-master.test.js
+++ b/mcp-trading/tests/stock-master.test.js
@@ -51,6 +51,21 @@ test("resolveStock guides users to 6/7/9 digit stock codes when a name is missin
   );
 });
 
+// The ambiguity message is a sibling of the not-found message above and drifted
+// apart from it: it still said "6~7자리" after the master gained 9-char fund
+// codes. Pin both so the next length change cannot update only one of them.
+test("resolveStock guides users to 6/7/9 digit stock codes when the match is ambiguous", () => {
+  const duplicated = [
+    { code: "111111", name: "중복종목", market: "KOSPI", aliases: [] },
+    { code: "222222", name: "중복종목", market: "KOSDAQ", aliases: [] },
+  ];
+
+  assert.throws(
+    () => resolveStock("중복종목", duplicated),
+    /6·7·9자리 종목코드를 직접 입력/,
+  );
+});
+
 test("resolveStock reads the default stock master once per process cache", () => {
   clearStocksCache();
   const originalReadFileSync = fs.readFileSync;


### PR DESCRIPTION
## 배경

`_resolve_stock_code`의 지름길 분기가 존재 확인 없이 코드를 확정했습니다.

```python
if _looks_like_stock_code(stock):
    return stock.upper()      # 검증 없음, MCP 호출 없음
```

`GET /api/v1/analyze?stock=999999`로 실재하지 않는 종목 리포트가 `AgentReport.stock_code="999999"`로 저장됩니다. 이 엔드포인트에는 인증이 없습니다.

이슈는 A(항상 MCP 경유) / B(로컬 코드 집합 검증) / C(현 동작 수용 + 명시) 세 안을 제시했고, **B로 결정했습니다.**

## 왜 B인가 — 갱신 주기 동기화 문제가 없습니다

B의 주된 우려는 "백엔드가 `stocks.json`을 따로 읽으면 MCP와 어긋난다"였습니다. 확인해 보니 **어긋날 수 없습니다**:

| 확인 대상 | 경로 |
| --- | --- |
| `mcp-trading/stock-master.js:8` | `DEFAULT_STOCKS_PATH = path.join(__dirname, "data", "stocks.json")` |
| `mcp-trading/scripts/update_stock_master.py:12` | `ROOT_DIR / "data" / "stocks.json"` |
| 이 PR의 백엔드 | 같은 파일 |

**같은 파일**이라 두 계층이 항상 같은 마스터를 봅니다. 이 근거를 `stock_code.py` 상단 주석에 남겼습니다.

A(항상 MCP 경유)는 코드 직접 입력마다 stdio 서브프로세스가 뜨므로 지름길을 둔 이유가 사라집니다. C는 아래 수용 기준 1번을 충족하지 못합니다.

## 구현

`backend/stock_code.py`에 지연 로딩 + 프로세스 캐시로 코드 집합을 둡니다.

```python
if _looks_like_stock_code(stock):
    shortcut_code = stock.upper()
    if _is_known_master_code(shortcut_code):
        return shortcut_code
    # 마스터에 없으면 지름길을 포기하고 MCP 경로로 흘려보낸다
```

**fail-open입니다.** 마스터를 읽지 못하면 예외를 던지지 않고 검증을 생략(`True` 반환)한 뒤 경고 로그를 남깁니다. 이 경로는 리포트 저장 판정이지 주문이 아니고, 마스터 하나 때문에 분석 기능 전체가 죽으면 안 됩니다. "로드 실패"와 "성공했지만 빈 집합"을 구분하려고 센티널을 씁니다 — 후자를 전자로 오인하면 모든 코드가 조용히 거부됩니다.

## 수용 기준 — 둘 다 충족

이슈가 명시한 기준입니다. MCP를 `stock-master.js`와 같은 동작으로 스텁해 실측했습니다.

| 입력 | 설명 | 지름길 | 마스터 존재 | `_resolve_stock_code` |
| --- | --- | --- | --- | --- |
| `999999` | 없는 6자 | True | False | **`''`** ✅ |
| `ZZZZ99` | 없는 영숫자 | True | False | **`''`** ✅ |
| `F70100026` | 실재 9자 펀드 | True | True | `'F70100026'` ✅ |
| `005930` | 실재 6자 | True | True | `'005930'` ✅ |
| `삼성전자` | 종목명 | False | — | `'005930'` ✅ |

## 구현 중 발견한 결함 — Step 3 에코가 새로 도달합니다

**이 PR이 만든 경로입니다.** 코드 형태 입력을 MCP로 흘려보내게 되면서, `stock-master.js:92`의 Step 3 에코가 처음으로 `_resolve_stock_code`에 도달할 수 있게 됐습니다.

```js
return { code: upperInput, name: upperInput, market: "UNKNOWN", aliases: [] };
```

`999999`를 보내면 `999999 (999999, UNKNOWN)`이 돌아옵니다. **존재 검증이 아니라 그저 되돌려주는 것인데**, 숫자를 포함하므로 기존 `_has_code_digit` 가드로는 걸러지지 않습니다. 그대로 두면 이 PR의 목적이 무너집니다.

`", UNKNOWN)"` 접미사로 감지해 실패로 취급합니다. 이 신호가 신뢰 가능한지 전제를 실측했습니다:

| 전제 | 확인 결과 |
| --- | --- |
| 마스터에 `UNKNOWN` market이 없는가 | `market` 분포 = KOSPI 2,529 / KOSDAQ 1,824, **UNKNOWN 0건** ✅ |
| 응답이 항상 그 형태로 끝나는가 | `index.js:559` = `` `${stock.name} (${stock.code}, ${stock.market})` `` ✅ |

기존 주석이 "여기 도달할 수 있는 에코는 숫자 없는 코드뿐"이라고 적고 있었는데, 이 PR이 그 전제를 깨뜨렸으므로 주석도 함께 고쳤습니다.

## 성능 — 지름길을 둔 이유를 해치지 않습니다

489K / 4,353종을 요청마다 파싱하면 의미가 없으므로 실측했습니다.

| 측정 | 결과 |
| --- | --- |
| 첫 호출(파일 로드 포함) | **5.3 ms** (프로세스당 1회) |
| 이후 10,000회 합계 | **0.8 ms** (회당 0.0001 ms) |
| 전체 테스트 스위트 중 실제 파싱 횟수 | **11회** (410건 실행) |

테스트 간 캐시 격리를 위해 `conftest.py`에 autouse 리셋 픽스처를 넣었는데, 지연 로딩이라 캐시를 비워도 실제로 마스터를 쓰는 테스트에서만 다시 읽습니다. 전체 실행 시간은 그대로입니다(4.93s).

리셋이 필요한 이유는 한 테스트가 로드 실패(fail-open)를 캐시하면 몽키패치를 되돌린 뒤에도 다음 테스트가 그 상태를 물려받아 대조를 건너뛰기 때문입니다.

## 함께 정리한 것

`mcp-trading/stock-master.js:99`의 오류 메시지가 낡아 있었습니다 — #140에서 9자 펀드 코드까지 지원하게 됐는데 "6~7자리"로 안내하고 있었습니다. **"6·7·9자리"** 로 고치고 해당 테스트의 정규식도 함께 갱신했습니다.

## 검증 (직접 실행)

`pytest backend/` — **398 → 408 passed, 2 skipped** (실패 0건)
`mcp-trading` `npm test` — **137 passed, 0 failed**

뮤테이션 5건 전부 red, 되돌린 뒤 408 복구:

| 뮤턴트 | 결과 |
| --- | --- |
| 마스터 대조 무력화(항상 True) | **5 failed** ✅ |
| 마스터 집합을 빈 집합으로 | **6 failed** ✅ |
| fail-open을 예외 전파로 | **2 failed** ✅ |
| `UNKNOWN` 에코 감지 제거 | **1 failed** ✅ |
| 8자 재허용 (#140 회귀) | **1 failed** ✅ |

## 남는 한계 — 정직하게 적습니다

**마스터를 읽지 못하면 `999999`가 다시 저장됩니다.** fail-open의 대가입니다. 대안(fail-closed)은 마스터가 없을 때 모든 코드 입력을 MCP로 보내는데, MCP도 같은 파일을 읽으므로 결국 실패합니다 — 분석 기능만 죽고 얻는 게 없습니다. 그래서 fail-open을 택했고, 그 경우 `logger.warning`으로 흔적을 남깁니다.

또한 이 검증은 **마스터가 최신이라는 전제**에 의존합니다. 신규 상장 종목이 `stocks.json`에 아직 없으면 정상 코드가 거부되어 MCP 경로로 넘어가는데, MCP도 같은 파일을 보므로 결국 이름 매칭에 실패합니다. 이는 #151 이전에도 같았던 제약이며(마스터 갱신 주기 문제), 이 PR이 새로 만든 것은 아닙니다.

Closes #151
