### PR TITLE
fix: Telegram 폴러 poison update 무한 재처리를 횟수 제한 재시도로 전환 (#241)

### DIFF
--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -2,7 +2,9 @@ import asyncio
 import logging
 import re
 import secrets
+import time
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, Callable
 from urllib.parse import quote as _url_quote
@@ -72,9 +74,33 @@ MARKET_STALE_CALLBACK_TEXT = "이전 조회 버튼입니다. 최신 조회 메�
 MARKET_CALLBACK_LIMIT = 100
 # 실패한 update는 offset을 유지해 재시도한다(일시 장애 때 명령을 버리지 않기 위함).
 # 다만 결정론적으로 실패하는 update는 영원히 재시도되며 뒤의 명령까지 막으므로
-# 이 횟수를 넘기면 건너뛴다 (#241).
-MAX_UPDATE_RETRIES = 3
+# 예산을 넘기면 건너뛴다 (#241).
+#
+# 예산은 "횟수"가 아니라 "시간"이다. 고정 5초 × 3회는 실질 10초여서 redis 재시작·컨테이너
+# 재기동·배포 어느 것도 버티지 못한다 — 일시 장애에 명령을 버리지 않겠다는 원래 목적을
+# 달성하지 못한다 (PR #242 리뷰).
+UPDATE_RETRY_WINDOW_SECONDS = 60.0
+# 전송 실패는 그 update의 문제가 아니라 전역 장애(429 rate limit·5xx)다. 같은 예산을 쓰면
+# 429 몇 초 때문에 대기 중인 명령이 전부 폐기되는데, 폐기 통지도 같은 이유로 실패해
+# 사용자는 아무것도 못 받는다. 기존 동작(막히더라도 복구되면 전부 실행) 대비 회귀이므로
+# 전송 실패에는 훨씬 긴 창을 준다 (PR #242 리뷰).
+SEND_FAILURE_RETRY_WINDOW_SECONDS = 300.0
+# 재시도 간격. 실패가 이어지면 폴링을 늦춰 텔레그램 rate limit을 자극하지 않는다.
+# 폴러는 단일 인스턴스라 동시 기상이 겹칠 일이 없어 jitter는 두지 않았다.
+UPDATE_RETRY_BACKOFF_SECONDS = (5.0, 15.0, 45.0)
 UPDATE_SKIPPED_NOTICE = "요청 처리에 실패했어요. 다시 시도해주세요."
+# 통지에 붙일 실패 명령 요약의 최대 길이. 명령을 연달아 보낸 사용자가 무엇을 다시
+# 보내야 하는지 알 수 있어야 한다 (PR #242 리뷰).
+UPDATE_LABEL_LIMIT = 40
+
+
+class TelegramSendError(RuntimeError):
+    """텔레그램 전송 실패. handle_update가 던지는 예외 중 유일하게 update와 무관하다.
+
+    MCP·redis·저장소 오류는 전부 사용자 메시지로 변환되므로, handle_update가 실제로
+    던지는 지배적 경로는 전송 실패다. 이걸 update별 poison으로 세면 429 한 번에
+    대기 중인 명령이 전부 폐기되므로 폴러가 별도 예산으로 다뤄야 한다 (PR #242 리뷰).
+    """
 ALERT_MODE_EMOJIS = {
     "urgent": "🚨",
     "all": "📣",
@@ -331,7 +357,7 @@ class TelegramCommandHandler:
     ) -> None:
         sent = await self.notifier.send_text(text, reply_markup=reply_markup)
         if sent is False:
-            raise RuntimeError("telegram send failed")
+            raise TelegramSendError("telegram send failed")
 
     async def _handle_callback_query(self, callback_query: dict[str, Any]) -> None:
         message = callback_query.get("message") or {}
@@ -1315,13 +1341,52 @@ class TelegramCommandHandler:
 def _update_sort_key(update: dict[str, Any]) -> tuple[int, int]:
     """update_id 오름차순 정렬 키. update_id가 없는 update는 맨 앞으로 보낸다 (#241).
 
-    update_id가 없으면 재시도 추적도 offset 전진도 불가능해 로그만 남기고 즉시 소화되므로,
-    앞에 두어도 뒤에 오는 update의 재시도 판정에 영향을 주지 않는다.
+    update_id가 없는 update는 재시도 예산도 offset도 추적할 수 없어 실패해도 그 자리에서
+    끝난다(= blocked를 만들지 않는다). 그래서 앞에 두어도 뒤에 오는 update의 재시도 판정에
+    영향을 주지 않는다. 다만 offset이 그걸 지나갈 수 없어 재배달될 때마다 다시 실행되고,
+    blocked가 아니라 sleep도 없으므로 getUpdates busy loop가 된다. 실제 Telegram은 항상
+    update_id를 주므로 이론적 경로다 (PR #242 리뷰).
     """
     update_id = update.get("update_id")
     if isinstance(update_id, int):
         return (1, update_id)
     return (0, 0)
+
+
+# _handle_one_update의 결과. offset을 전진시켜도 되는지(DONE/SKIPPED)와 스킵 통지가
+# 필요한지(SKIPPED)를 한 값으로 구분한다 (#241).
+_UPDATE_DONE = "done"
+_UPDATE_RETRY = "retry"
+_UPDATE_SKIPPED = "skipped"
+
+
+def _update_chat_id(update: dict[str, Any]) -> str:
+    callback_query = update.get("callback_query") or {}
+    message = update.get("message") or callback_query.get("message") or {}
+    return str((message.get("chat") or {}).get("id", "")).strip()
+
+
+def _update_label(update: dict[str, Any]) -> str:
+    """실패 통지에 붙일 요약. 사용자가 무엇을 다시 보내야 하는지 알 수 있게 한다 (#241)."""
+    callback_query = update.get("callback_query") or {}
+    message = update.get("message") or callback_query.get("message") or {}
+    text = (message.get("text") or "").strip()
+    if not text:
+        text = str(callback_query.get("data") or "").strip()
+    if not text:
+        return f"update {update.get('update_id')}"
+    if len(text) > UPDATE_LABEL_LIMIT:
+        return text[:UPDATE_LABEL_LIMIT] + "…"
+    return text
+
+
+@dataclass
+class _UpdateFailure:
+    """update별 재시도 예산. 기준은 횟수가 아니라 첫 실패 이후 흐른 시간이다 (#241)."""
+
+    first_at: float
+    attempts: int
+    send_failure: bool
 
 
 class TelegramCommandPoller:
@@ -1341,12 +1406,18 @@ class TelegramCommandPoller:
             )
         self.handler = handler
         self.offset: int | None = None
-        # update_id -> 연속 실패 횟수. 폴러는 단일 인스턴스로만 돌기 때문에
-        # 인메모리 dict로 충분하다 (#241).
-        self._failure_counts: dict[int, int] = {}
+        # update_id -> 재시도 예산. 폴러는 단일 인스턴스로만 돌기 때문에 인메모리로 충분하다 (#241).
+        self._failures: dict[int, _UpdateFailure] = {}
         # 재시도 대기 중인 update보다 뒤에 있어서 먼저 처리해버린 update_id.
         # offset은 실패 지점에서 멈추므로 이 update들은 다음 폴링에 다시 배달되는데,
         # 그대로 재실행하면 주문 같은 부수효과가 중복된다 (#241).
+        #
+        # 주의: offset과 이 집합이 둘 다 인메모리라, blocked 구간에 프로세스가 죽으면
+        # 여기 기록된 update들은 "실행됐지만 서버에 미확정" 상태로 남아 재시작 후 재실행된다.
+        # origin/main은 poison에서 배치를 통째로 중단해 이 창이 없었으므로 이 PR이 새로
+        # 들이는 리스크다. 금전 경로는 별도로 막혀 있지만(/confirm은 GETDEL claim,
+        # /buy는 set_if_absent) LLM 재호출·중복 메시지는 발생한다. 근본 해결은 offset을
+        # redis에 영속화하는 것이고 별도 이슈로 다룬다 (PR #242 리뷰).
         self._handled_ahead: set[int] = set()
 
     async def run(self) -> None:
@@ -1362,7 +1433,7 @@ class TelegramCommandPoller:
             except Exception as exc:
                 # getUpdates 자체의 네트워크 오류는 기존대로 5초 후 재시도한다.
                 logger.error("Telegram command polling failed: %s", exc)
-                await asyncio.sleep(5)
+                await self._sleep(UPDATE_RETRY_BACKOFF_SECONDS[0])
                 continue
 
             # 재시도 대기 중인 update가 앞에 있으면 offset을 더 전진시킬 수 없다.
@@ -1373,91 +1444,142 @@ class TelegramCommandPoller:
             # 여기서 직접 정렬해 전제를 없앤다 (#241).
             updates = sorted(updates, key=_update_sort_key)
             blocked = False
+            skipped: list[dict[str, Any]] = []
             for update in updates:
                 update_id = update.get("update_id")
                 if isinstance(update_id, int) and update_id in self._handled_ahead:
                     # 이미 처리한 update의 재배달이다. 다시 실행하면 부수효과가 중복되므로
                     # 건너뛰되, offset은 전진시켜야 여기서 다시 막히지 않는다 (#241).
-                    settled = True
+                    outcome = _UPDATE_DONE
                 else:
-                    settled = await self._handle_one_update(update, update_id)
-                if not settled:
+                    outcome = await self._handle_one_update(update, update_id)
+                if outcome is _UPDATE_RETRY:
                     blocked = True
                     continue
+                if outcome is _UPDATE_SKIPPED:
+                    skipped.append(update)
                 if not isinstance(update_id, int):
                     continue
 
-                self._failure_counts.pop(update_id, None)
+                self._failures.pop(update_id, None)
                 if blocked:
                     self._handled_ahead.add(update_id)
                 else:
                     self.offset = update_id + 1
                     self._forget_passed_updates(self.offset)
 
+            if skipped:
+                # 배치 통지는 한 건으로 합친다. poison N건에 N번 발송하면 채팅당 초당 ~1건
+                # 제한에 걸려 429를 만들고, 429는 다시 전송 실패 = 새 poison이 된다 (PR #242 리뷰).
+                await self._notify_updates_skipped(skipped)
             if blocked:
-                # 실패한 update를 곧바로 다시 받아 재시도 횟수를 순식간에 소진하지 않도록
-                # 기존 폴링 실패와 같은 간격으로 쉬어 간다 (#241).
-                await asyncio.sleep(5)
+                # 실패한 update를 곧바로 다시 받아 예산을 순식간에 소진하지 않도록 쉬어 간다.
+                # 실패가 이어지면 간격을 늘려 복구 창을 벌고 rate limit도 덜 자극한다 (#241).
+                await self._sleep(self._retry_delay())
 
-    async def _handle_one_update(
-        self,
-        update: dict[str, Any],
-        update_id: Any,
-    ) -> bool:
-        """update 처리를 끝냈는지(= offset을 전진시켜도 되는지) 반환한다 (#241)."""
+    async def _handle_one_update(self, update: dict[str, Any], update_id: Any) -> str:
+        """update 처리 결과를 반환한다: 완료 / 재시도 대기 / 예산 소진 후 스킵 (#241).
+
+        주의: 재시도는 handle_update가 멱등하다는 전제 위에 있다. 부수효과가 확정된 뒤
+        전송에서 실패하는 경로(/buy의 set_if_absent 후 프롬프트 전송, /confirm의 체결 후
+        결과 전송)는 재시도해도 원래 의도를 달성하지 못하고 다른 메시지로 끝난다.
+        이 PR 범위 밖이라 별도 이슈로 다룬다 (PR #242 리뷰).
+        """
         try:
             await self.handler.handle_update(update)
-            return True
+            return _UPDATE_DONE
         except asyncio.CancelledError:
             raise
         except Exception as exc:
             if not isinstance(update_id, int):
-                # update_id가 없으면 재시도 횟수도 offset도 추적할 수 없다.
-                # 재시도해도 같은 자리에 멈출 뿐이라 로그만 남기고 넘어간다.
+                # update_id가 없으면 예산도 offset도 추적할 수 없다. 붙잡아 둘 방법이
+                # 없으므로 로그만 남기고 넘어간다.
                 logger.error("Telegram update handling failed without update_id: %s", exc)
-                return True
+                return _UPDATE_DONE
 
-            failures = self._failure_counts.get(update_id, 0) + 1
-            self._failure_counts[update_id] = failures
-            if failures < MAX_UPDATE_RETRIES:
+            send_failure = isinstance(exc, TelegramSendError)
+            now = self._now()
+            failure = self._failures.get(update_id)
+            if failure is None:
+                failure = _UpdateFailure(first_at=now, attempts=1, send_failure=send_failure)
+                self._failures[update_id] = failure
+            else:
+                failure.attempts += 1
+                failure.send_failure = send_failure
+
+            elapsed = now - failure.first_at
+            window = (
+                SEND_FAILURE_RETRY_WINDOW_SECONDS
+                if send_failure
+                else UPDATE_RETRY_WINDOW_SECONDS
+            )
+            if elapsed <= window:
                 logger.error(
-                    "Telegram update %s handling failed (%s/%s): %s",
+                    "Telegram update %s handling failed (attempt %s, %.0fs/%.0fs): %s",
                     update_id,
-                    failures,
-                    MAX_UPDATE_RETRIES,
+                    failure.attempts,
+                    elapsed,
+                    window,
                     exc,
                 )
-                return False
+                return _UPDATE_RETRY
 
             logger.error(
-                "Telegram update %s skipped after %s failures: %s",
+                "Telegram update %s skipped after %s attempts over %.0fs: %s",
                 update_id,
-                failures,
+                failure.attempts,
+                elapsed,
                 exc,
             )
-            await self._notify_update_skipped(update)
-            return True
+            return _UPDATE_SKIPPED
 
-    async def _notify_update_skipped(self, update: dict[str, Any]) -> None:
-        callback_query = update.get("callback_query") or {}
-        message = update.get("message") or callback_query.get("message") or {}
-        chat_id = str((message.get("chat") or {}).get("id", "")).strip()
+    def _retry_delay(self) -> float:
+        """미해결 update 중 가장 많이 시도한 것을 기준으로 백오프 간격을 고른다 (#241)."""
+        attempts = max((f.attempts for f in self._failures.values()), default=1)
+        index = min(attempts, len(UPDATE_RETRY_BACKOFF_SECONDS)) - 1
+        return UPDATE_RETRY_BACKOFF_SECONDS[index]
+
+    async def _notify_updates_skipped(self, updates: list[dict[str, Any]]) -> None:
         # notifier는 자기 chat에만 보낼 수 있으므로 다른 chat이면 통지할 방법이 없다.
-        if not chat_id or chat_id != self.notifier.chat_id:
+        mine = [u for u in updates if _update_chat_id(u) == self.notifier.chat_id]
+        if not mine:
             return
+        labels = ", ".join(_update_label(u) for u in mine)
+        text = f"{UPDATE_SKIPPED_NOTICE}\n실패한 요청: {labels}"
         try:
-            await self.notifier.send_text(UPDATE_SKIPPED_NOTICE)
+            sent = await self.notifier.send_text(text)
         except Exception as exc:
-            # 통지 실패가 폴러를 다시 막으면 안 된다 (#241).
+            # 통지 실패가 폴러를 다시 막으면 안 된다. send_text는 예외를 삼키므로 여기
+            # except는 duck-typed notifier 방어용이다 (#241).
             logger.error("Telegram skip notice send failed: %s", exc)
+            return
+        if sent is False:
+            # send_text는 실패해도 예외 대신 False를 돌려준다. 유일한 실패 신호라
+            # 반드시 확인해야 통지 실패가 어디에도 안 남는 일이 없다 (PR #242 리뷰).
+            logger.error("Telegram skip notice not delivered for %s updates", len(mine))
 
     def _forget_passed_updates(self, offset: int) -> None:
-        """offset이 지나간 update_id 기록을 정리해 추적 dict가 무한히 커지지 않게 한다 (#241)."""
-        for update_id in [key for key in self._failure_counts if key < offset]:
-            self._failure_counts.pop(update_id, None)
+        """offset이 지나간 update_id 기록을 정리해 추적 상태가 무한히 커지지 않게 한다 (#241)."""
+        self._failures = {
+            update_id: failure
+            for update_id, failure in self._failures.items()
+            if update_id >= offset
+        }
         self._handled_ahead = {
             update_id for update_id in self._handled_ahead if update_id >= offset
         }
+
+    async def _sleep(self, seconds: float) -> None:
+        """테스트가 전역 asyncio.sleep 대신 이 인스턴스만 대체할 수 있게 하는 간접층 (#241).
+
+        전역 패치는 핸들러 내부의 실제 sleep(_handle_watch의 조회 간격)까지 가로채
+        루프가 엉뚱한 지점에서 끊긴 채 테스트가 통과할 수 있다 (PR #242 리뷰).
+        """
+        await asyncio.sleep(seconds)
+
+    def _now(self) -> float:
+        """재시도 예산용 단조 시계. 테스트에서 대체할 수 있도록 메서드로 둔다 (#241)."""
+        return time.monotonic()
 
     async def _setup_bot_profile(self) -> None:
         load_bot_username = getattr(self.notifier, "load_bot_username", None)

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -1312,6 +1312,18 @@ class TelegramCommandHandler:
             yield state
 
 
+def _update_sort_key(update: dict[str, Any]) -> tuple[int, int]:
+    """update_id 오름차순 정렬 키. update_id가 없는 update는 맨 앞으로 보낸다 (#241).
+
+    update_id가 없으면 재시도 추적도 offset 전진도 불가능해 로그만 남기고 즉시 소화되므로,
+    앞에 두어도 뒤에 오는 update의 재시도 판정에 영향을 주지 않는다.
+    """
+    update_id = update.get("update_id")
+    if isinstance(update_id, int):
+        return (1, update_id)
+    return (0, 0)
+
+
 class TelegramCommandPoller:
     def __init__(
         self,
@@ -1356,9 +1368,10 @@ class TelegramCommandPoller:
             # 재시도 대기 중인 update가 앞에 있으면 offset을 더 전진시킬 수 없다.
             # 그래도 배치의 나머지 update는 계속 처리해서, poison 1건이 뒤의 명령을
             # 통째로 막지 않게 한다 (#241).
-            # getUpdates는 update_id 오름차순으로 돌려주므로, 재시도 대기 중인 update는
-            # 매 배치에서 뒤의 update보다 먼저 나온다. 즉 이 플래그는 항상 제때 켜지고
-            # offset이 미해결 update를 넘어가는 일은 없다 (#241).
+            # blocked는 미해결 update를 먼저 만난다는 전제 위에서만 offset을 지켜준다.
+            # getUpdates가 오름차순을 보장한다는 외부 전제에 정확성을 걸지 않도록
+            # 여기서 직접 정렬해 전제를 없앤다 (#241).
+            updates = sorted(updates, key=_update_sort_key)
             blocked = False
             for update in updates:
                 update_id = update.get("update_id")

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -70,6 +70,11 @@ MARKET_QUOTE_CALLBACK = "market:quote"
 MARKET_TREND_CALLBACK = "market:trend"
 MARKET_STALE_CALLBACK_TEXT = "이전 조회 버튼입니다. 최신 조회 메시지에서 다시 선택하세요."
 MARKET_CALLBACK_LIMIT = 100
+# 실패한 update는 offset을 유지해 재시도한다(일시 장애 때 명령을 버리지 않기 위함).
+# 다만 결정론적으로 실패하는 update는 영원히 재시도되며 뒤의 명령까지 막으므로
+# 이 횟수를 넘기면 건너뛴다 (#241).
+MAX_UPDATE_RETRIES = 3
+UPDATE_SKIPPED_NOTICE = "요청 처리에 실패했어요. 다시 시도해주세요."
 ALERT_MODE_EMOJIS = {
     "urgent": "🚨",
     "all": "📣",
@@ -1324,6 +1329,13 @@ class TelegramCommandPoller:
             )
         self.handler = handler
         self.offset: int | None = None
+        # update_id -> 연속 실패 횟수. 폴러는 단일 인스턴스로만 돌기 때문에
+        # 인메모리 dict로 충분하다 (#241).
+        self._failure_counts: dict[int, int] = {}
+        # 재시도 대기 중인 update보다 뒤에 있어서 먼저 처리해버린 update_id.
+        # offset은 실패 지점에서 멈추므로 이 update들은 다음 폴링에 다시 배달되는데,
+        # 그대로 재실행하면 주문 같은 부수효과가 중복된다 (#241).
+        self._handled_ahead: set[int] = set()
 
     async def run(self) -> None:
         if not self.notifier.enabled:
@@ -1333,16 +1345,103 @@ class TelegramCommandPoller:
         while True:
             try:
                 updates = await self._get_updates()
-                for update in updates:
-                    update_id = update.get("update_id")
-                    await self.handler.handle_update(update)
-                    if isinstance(update_id, int):
-                        self.offset = update_id + 1
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
+                # getUpdates 자체의 네트워크 오류는 기존대로 5초 후 재시도한다.
                 logger.error("Telegram command polling failed: %s", exc)
                 await asyncio.sleep(5)
+                continue
+
+            # 재시도 대기 중인 update가 앞에 있으면 offset을 더 전진시킬 수 없다.
+            # 그래도 배치의 나머지 update는 계속 처리해서, poison 1건이 뒤의 명령을
+            # 통째로 막지 않게 한다 (#241).
+            blocked = False
+            for update in updates:
+                update_id = update.get("update_id")
+                if isinstance(update_id, int) and update_id in self._handled_ahead:
+                    # 이미 처리한 update의 재배달이다. 다시 실행하면 부수효과가 중복되므로
+                    # 건너뛰되, offset은 전진시켜야 여기서 다시 막히지 않는다 (#241).
+                    settled = True
+                else:
+                    settled = await self._handle_one_update(update, update_id)
+                if not settled:
+                    blocked = True
+                    continue
+                if not isinstance(update_id, int):
+                    continue
+
+                self._failure_counts.pop(update_id, None)
+                if blocked:
+                    self._handled_ahead.add(update_id)
+                else:
+                    self.offset = update_id + 1
+                    self._forget_passed_updates(self.offset)
+
+            if blocked:
+                # 실패한 update를 곧바로 다시 받아 재시도 횟수를 순식간에 소진하지 않도록
+                # 기존 폴링 실패와 같은 간격으로 쉬어 간다 (#241).
+                await asyncio.sleep(5)
+
+    async def _handle_one_update(
+        self,
+        update: dict[str, Any],
+        update_id: Any,
+    ) -> bool:
+        """update 처리를 끝냈는지(= offset을 전진시켜도 되는지) 반환한다 (#241)."""
+        try:
+            await self.handler.handle_update(update)
+            return True
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            if not isinstance(update_id, int):
+                # update_id가 없으면 재시도 횟수도 offset도 추적할 수 없다.
+                # 재시도해도 같은 자리에 멈출 뿐이라 로그만 남기고 넘어간다.
+                logger.error("Telegram update handling failed without update_id: %s", exc)
+                return True
+
+            failures = self._failure_counts.get(update_id, 0) + 1
+            self._failure_counts[update_id] = failures
+            if failures < MAX_UPDATE_RETRIES:
+                logger.error(
+                    "Telegram update %s handling failed (%s/%s): %s",
+                    update_id,
+                    failures,
+                    MAX_UPDATE_RETRIES,
+                    exc,
+                )
+                return False
+
+            logger.error(
+                "Telegram update %s skipped after %s failures: %s",
+                update_id,
+                failures,
+                exc,
+            )
+            await self._notify_update_skipped(update)
+            return True
+
+    async def _notify_update_skipped(self, update: dict[str, Any]) -> None:
+        callback_query = update.get("callback_query") or {}
+        message = update.get("message") or callback_query.get("message") or {}
+        chat_id = str((message.get("chat") or {}).get("id", "")).strip()
+        # notifier는 자기 chat에만 보낼 수 있으므로 다른 chat이면 통지할 방법이 없다.
+        if not chat_id or chat_id != self.notifier.chat_id:
+            return
+        try:
+            await self.notifier.send_text(UPDATE_SKIPPED_NOTICE)
+        except Exception as exc:
+            # 통지 실패가 폴러를 다시 막으면 안 된다 (#241).
+            logger.error("Telegram skip notice send failed: %s", exc)
+
+    def _forget_passed_updates(self, offset: int) -> None:
+        """offset이 지나간 update_id 기록을 정리해 추적 dict가 무한히 커지지 않게 한다 (#241)."""
+        for update_id in [key for key in self._failure_counts if key < offset]:
+            self._failure_counts.pop(update_id, None)
+        self._handled_ahead = {
+            update_id for update_id in self._handled_ahead if update_id >= offset
+        }
 
     async def _setup_bot_profile(self) -> None:
         load_bot_username = getattr(self.notifier, "load_bot_username", None)

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -5,6 +5,7 @@ import secrets
 import time
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from enum import Enum
 from datetime import datetime, timedelta
 from typing import Any, Callable
 from urllib.parse import quote as _url_quote
@@ -1364,11 +1365,16 @@ def _update_sort_key(update: dict[str, Any]) -> tuple[int, int]:
     return (0, 0)
 
 
-# _handle_one_update의 결과. offset을 전진시켜도 되는지(DONE/SKIPPED)와 스킵 통지가
-# 필요한지(SKIPPED)를 한 값으로 구분한다 (#241).
-_UPDATE_DONE = "done"
-_UPDATE_RETRY = "retry"
-_UPDATE_SKIPPED = "skipped"
+class _UpdateOutcome(Enum):
+    """_handle_one_update의 결과 (#241).
+
+    offset을 전진시켜도 되는지(DONE/SKIPPED)와 스킵 통지가 필요한지(SKIPPED)를 한 값으로
+    구분한다. 평문 str이면 오타가 조용히 통과하므로 Enum으로 강제한다 (PR #242 리뷰).
+    """
+
+    DONE = "done"
+    RETRY = "retry"
+    SKIPPED = "skipped"
 
 
 def _update_chat_id(update: dict[str, Any]) -> str:
@@ -1466,13 +1472,13 @@ class TelegramCommandPoller:
                 if isinstance(update_id, int) and update_id in self._handled_ahead:
                     # 이미 처리한 update의 재배달이다. 다시 실행하면 부수효과가 중복되므로
                     # 건너뛰되, offset은 전진시켜야 여기서 다시 막히지 않는다 (#241).
-                    outcome = _UPDATE_DONE
+                    outcome = _UpdateOutcome.DONE
                 else:
                     outcome = await self._handle_one_update(update, update_id)
-                if outcome is _UPDATE_RETRY:
+                if outcome is _UpdateOutcome.RETRY:
                     blocked = True
                     continue
-                if outcome is _UPDATE_SKIPPED:
+                if outcome is _UpdateOutcome.SKIPPED:
                     skipped.append(update)
                 if not isinstance(update_id, int):
                     continue
@@ -1493,7 +1499,11 @@ class TelegramCommandPoller:
                 # 실패가 이어지면 간격을 늘려 복구 창을 벌고 rate limit도 덜 자극한다 (#241).
                 await self._sleep(self._retry_delay())
 
-    async def _handle_one_update(self, update: dict[str, Any], update_id: Any) -> str:
+    async def _handle_one_update(
+        self,
+        update: dict[str, Any],
+        update_id: Any,
+    ) -> _UpdateOutcome:
         """update 처리 결과를 반환한다: 완료 / 재시도 대기 / 예산 소진 후 스킵 (#241).
 
         주의: 재시도는 handle_update가 멱등하다는 전제 위에 있다. 부수효과가 확정된 뒤
@@ -1508,7 +1518,7 @@ class TelegramCommandPoller:
         """
         try:
             await self.handler.handle_update(update)
-            return _UPDATE_DONE
+            return _UpdateOutcome.DONE
         except asyncio.CancelledError:
             raise
         except Exception as exc:
@@ -1516,7 +1526,7 @@ class TelegramCommandPoller:
                 # update_id가 없으면 예산도 offset도 추적할 수 없다. 붙잡아 둘 방법이
                 # 없으므로 로그만 남기고 넘어간다.
                 logger.error("Telegram update handling failed without update_id: %s", exc)
-                return _UPDATE_DONE
+                return _UpdateOutcome.DONE
 
             send_failure = isinstance(exc, TelegramSendError)
             now = self._now()
@@ -1526,12 +1536,18 @@ class TelegramCommandPoller:
                 self._failures[update_id] = failure
             else:
                 failure.attempts += 1
-                failure.send_failure = send_failure
+                # 한 번이라도 전송 실패가 있었으면 긴 창을 유지한다. first_at은 첫 실패에
+                # 고정인데 창을 마지막 예외 종류로 매번 다시 고르면 두 값의 기준이 어긋난다:
+                # 429가 290초 이어지다 마지막에 redis 오류가 한 번 나면 창이 60초로 줄어
+                # 그 오류에 재시도가 0회 주어진 채 즉시 폐기된다. 종류가 바뀔 때마다
+                # first_at을 리셋하면 종류를 번갈아 던지는 update가 영원히 살아남으므로,
+                # 상한이 유계인 이 방식을 택했다 (PR #242 리뷰).
+                failure.send_failure = failure.send_failure or send_failure
 
             elapsed = now - failure.first_at
             window = (
                 SEND_FAILURE_RETRY_WINDOW_SECONDS
-                if send_failure
+                if failure.send_failure
                 else UPDATE_RETRY_WINDOW_SECONDS
             )
             if elapsed <= window:
@@ -1543,7 +1559,7 @@ class TelegramCommandPoller:
                     window,
                     exc,
                 )
-                return _UPDATE_RETRY
+                return _UpdateOutcome.RETRY
 
             logger.error(
                 "Telegram update %s skipped after %s attempts over %.0fs: %s",
@@ -1552,23 +1568,31 @@ class TelegramCommandPoller:
                 elapsed,
                 exc,
             )
-            return _UPDATE_SKIPPED
+            return _UpdateOutcome.SKIPPED
 
     def _retry_delay(self) -> float:
-        """미해결 update 중 가장 많이 시도한 것을 기준으로 백오프 간격을 고른다 (#241)."""
-        attempts = max((f.attempts for f in self._failures.values()), default=1)
+        """미해결 update 중 가장 적게 시도한 것을 기준으로 백오프 간격을 고른다 (#241).
+
+        간격은 배치 전체에 하나뿐이라 가장 급한 쪽에 맞춰야 한다. 최대 시도 수를 쓰면
+        갓 실패한 update가 오래된 poison의 45초 간격을 물려받아 자기 창(60초) 안에
+        시도 횟수를 손해 본다 (PR #242 리뷰).
+        """
+        attempts = min((f.attempts for f in self._failures.values()), default=1)
         index = min(attempts, len(UPDATE_RETRY_BACKOFF_SECONDS)) - 1
         return UPDATE_RETRY_BACKOFF_SECONDS[index]
 
     async def _notify_updates_skipped(self, updates: list[dict[str, Any]]) -> None:
-        # notifier는 자기 chat에만 보낼 수 있으므로 다른 chat이면 통지할 방법이 없다.
-        mine = [u for u in updates if _update_chat_id(u) == self.notifier.chat_id]
-        if not mine:
-            return
-        labels = ", ".join(_update_label(u) for u in mine)
-        text = f"{UPDATE_SKIPPED_NOTICE}\n실패한 요청: {labels}"
+        # run()의 배치 루프는 try 밖이라 여기서 새는 예외는 폴러 태스크를 죽인다.
+        # 통지문 조립(임의의 update dict를 파싱한다)까지 try 안에 둔다 (PR #242 리뷰).
         try:
-            sent = await self.notifier.send_text(text)
+            # notifier는 자기 chat에만 보낼 수 있으므로 다른 chat이면 통지할 방법이 없다.
+            mine = [u for u in updates if _update_chat_id(u) == self.notifier.chat_id]
+            if not mine:
+                return
+            labels = ", ".join(_update_label(u) for u in mine)
+            sent = await self.notifier.send_text(
+                f"{UPDATE_SKIPPED_NOTICE}\n실패한 요청: {labels}"
+            )
         except Exception as exc:
             # 통지 실패가 폴러를 다시 막으면 안 된다. send_text는 예외를 삼키므로 여기
             # except는 duck-typed notifier 방어용이다 (#241).

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -84,9 +84,18 @@ UPDATE_RETRY_WINDOW_SECONDS = 60.0
 # 429 몇 초 때문에 대기 중인 명령이 전부 폐기되는데, 폐기 통지도 같은 이유로 실패해
 # 사용자는 아무것도 못 받는다. 기존 동작(막히더라도 복구되면 전부 실행) 대비 회귀이므로
 # 전송 실패에는 훨씬 긴 창을 준다 (PR #242 리뷰).
+#
+# 이 값은 무한정 키우면 안 된다. handle_update가 던지는 지배적 경로가 전송 실패라서,
+# 영구적 전송 실패(특정 메시지의 Markdown 파싱 400)가 하나 들어오면 offset이 이 시간만큼
+# 얼어붙어 #241이 그대로 재발한다. 상한이 있다는 사실 자체를 테스트가 고정한다
+# (test_poller_eventually_skips_persistent_send_failures).
 SEND_FAILURE_RETRY_WINDOW_SECONDS = 300.0
 # 재시도 간격. 실패가 이어지면 폴링을 늦춰 텔레그램 rate limit을 자극하지 않는다.
 # 폴러는 단일 인스턴스라 동시 기상이 겹칠 일이 없어 jitter는 두지 않았다.
+#
+# 위 두 창과 맞물려 실제 예산은 이렇게 정해진다 (PR #242 리뷰):
+#   일반 실패   t=0, 5, 20, 65  → 4시도 / 65초 후 폐기
+#   전송 실패   t=0, 5, 20, 65, 110 … 335 → 10시도 / 335초 후 폐기 (마지막 간격 45초 반복)
 UPDATE_RETRY_BACKOFF_SECONDS = (5.0, 15.0, 45.0)
 UPDATE_SKIPPED_NOTICE = "요청 처리에 실패했어요. 다시 시도해주세요."
 # 통지에 붙일 실패 명령 요약의 최대 길이. 명령을 연달아 보낸 사용자가 무엇을 다시
@@ -101,6 +110,8 @@ class TelegramSendError(RuntimeError):
     던지는 지배적 경로는 전송 실패다. 이걸 update별 poison으로 세면 429 한 번에
     대기 중인 명령이 전부 폐기되므로 폴러가 별도 예산으로 다뤄야 한다 (PR #242 리뷰).
     """
+
+
 ALERT_MODE_EMOJIS = {
     "urgent": "🚨",
     "all": "📣",
@@ -1418,6 +1429,11 @@ class TelegramCommandPoller:
         # 들이는 리스크다. 금전 경로는 별도로 막혀 있지만(/confirm은 GETDEL claim,
         # /buy는 set_if_absent) LLM 재호출·중복 메시지는 발생한다. 근본 해결은 offset을
         # redis에 영속화하는 것이고 별도 이슈로 다룬다 (PR #242 리뷰).
+        #
+        # 창의 길이는 재시도 예산과 같다: 일반 실패 65초, 전송 실패 335초.
+        # 시간 기반 예산으로 바꾸면서 기존 10초(고정 5초 × 3회)보다 크게 넓어졌고,
+        # 429와 재시작은 "배포"라는 공통 원인으로 상관관계가 있어 동시에 발생할 수 있다.
+        # 영속화 이슈의 우선순위를 매길 때 이 수치가 근거가 된다 (PR #242 리뷰).
         self._handled_ahead: set[int] = set()
 
     async def run(self) -> None:
@@ -1484,6 +1500,11 @@ class TelegramCommandPoller:
         전송에서 실패하는 경로(/buy의 set_if_absent 후 프롬프트 전송, /confirm의 체결 후
         결과 전송)는 재시도해도 원래 의도를 달성하지 못하고 다른 메시지로 끝난다.
         이 PR 범위 밖이라 별도 이슈로 다룬다 (PR #242 리뷰).
+
+        그 경로의 재실행 횟수는 예산과 같다 — 일반 실패 4회, 전송 실패 10회다.
+        예산을 시간 기반으로 넓히면서 기존 3회보다 늘었다. 자연어 메시지처럼 부수효과가
+        LLM 호출인 경로는 429 구간에서 최대 10번 호출·과금된다(주문은 GETDEL·set_if_absent로
+        보호되어 금전 피해는 없다). 멱등성 이슈의 노출량 근거다 (PR #242 리뷰).
         """
         try:
             await self.handler.handle_update(update)

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -1356,6 +1356,9 @@ class TelegramCommandPoller:
             # 재시도 대기 중인 update가 앞에 있으면 offset을 더 전진시킬 수 없다.
             # 그래도 배치의 나머지 update는 계속 처리해서, poison 1건이 뒤의 명령을
             # 통째로 막지 않게 한다 (#241).
+            # getUpdates는 update_id 오름차순으로 돌려주므로, 재시도 대기 중인 update는
+            # 매 배치에서 뒤의 update보다 먼저 나온다. 즉 이 플래그는 항상 제때 켜지고
+            # offset이 미해결 update를 넘어가는 일은 없다 (#241).
             blocked = False
             for update in updates:
                 update_id = update.get("update_id")

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -2039,6 +2039,56 @@ async def test_poller_handles_later_update_when_earlier_update_is_poison(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_poller_offset_stays_behind_poison_until_retries_exhausted(monkeypatch):
+    """poison 뒤의 update를 처리해도 offset은 poison이 해소되기 전엔 넘어가지 않는다 (#241)."""
+    notifier = FakeNotifier()
+    notifier.enabled = True
+    notifier.bot_token = "token"
+    handled = []
+
+    class PartialHandler:
+        async def handle_update(self, update):
+            if update["update_id"] == 41:
+                raise RuntimeError("poison update")
+            handled.append(update["update_id"])
+
+    poller = TelegramCommandPoller(notifier=notifier, handler=PartialHandler())
+    batch = [
+        {"update_id": 41, "message": {"chat": {"id": 123}, "text": "/alerts off"}},
+        {"update_id": 42, "message": {"chat": {"id": 123}, "text": "/help"}},
+    ]
+
+    async def fake_get_updates():
+        offset = poller.offset
+        return [u for u in batch if offset is None or u["update_id"] >= offset]
+
+    sleeps = 0
+
+    async def fake_sleep(delay):
+        # 배치 처리가 끝날 때마다 물막이를 확인한다: 41이 아직 상한에 못 미쳤으므로
+        # offset은 41을 넘어선 안 된다(넘으면 41이 조용히 버려진다).
+        nonlocal sleeps
+        sleeps += 1
+        assert poller.offset is None or poller.offset <= 41
+        assert poller._failure_counts == {41: sleeps}
+        if sleeps >= telegram_commands.MAX_UPDATE_RETRIES - 1:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(poller, "_get_updates", fake_get_updates)
+    monkeypatch.setattr("backend.telegram_commands.asyncio.sleep", fake_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await poller.run()
+
+    # 뒤의 update는 처리됐지만(중복 없이 1회), 41은 아직 재시도 중이라 버려지지 않았다.
+    assert handled == [42]
+    assert poller.offset is None
+    assert poller._handled_ahead == {42}
+    assert poller._failure_counts == {41: telegram_commands.MAX_UPDATE_RETRIES - 1}
+    assert notifier.messages == []
+
+
+@pytest.mark.asyncio
 async def test_poller_clears_failure_count_after_success(monkeypatch):
     """일시 장애로 실패한 update가 성공하면 실패 카운터가 남지 않는다 (#241)."""
     notifier = FakeNotifier()

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -2089,6 +2089,46 @@ async def test_poller_offset_stays_behind_poison_until_retries_exhausted(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_poller_offset_stays_behind_poison_in_out_of_order_batch(monkeypatch):
+    """배치가 update_id 역순으로 와도 offset은 poison을 넘지 않는다 (#241)."""
+    notifier = FakeNotifier()
+    notifier.enabled = True
+    notifier.bot_token = "token"
+    handled = []
+
+    class PartialHandler:
+        async def handle_update(self, update):
+            if update.get("update_id") == 41:
+                raise RuntimeError("poison update")
+            handled.append(update.get("update_id"))
+
+    poller = TelegramCommandPoller(notifier=notifier, handler=PartialHandler())
+
+    async def fake_get_updates():
+        # 정렬 전 순서가 정확성을 좌우하지 않아야 하므로 일부러 뒤집어 준다.
+        # update_id 없는 update도 섞어 정렬 키의 나머지 절반을 함께 태운다.
+        return [
+            {"update_id": 42, "message": {"chat": {"id": 123}, "text": "/help"}},
+            {"message": {"chat": {"id": 123}, "text": "/help"}},
+            {"update_id": 41, "message": {"chat": {"id": 123}, "text": "/alerts off"}},
+        ]
+
+    async def fake_sleep(delay):
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(poller, "_get_updates", fake_get_updates)
+    monkeypatch.setattr("backend.telegram_commands.asyncio.sleep", fake_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await poller.run()
+
+    assert poller.offset is None
+    assert poller._failure_counts == {41: 1}
+    assert poller._handled_ahead == {42}
+    assert handled == [None, 42]
+
+
+@pytest.mark.asyncio
 async def test_poller_clears_failure_count_after_success(monkeypatch):
     """일시 장애로 실패한 update가 성공하면 실패 카운터가 남지 않는다 (#241)."""
     notifier = FakeNotifier()

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -2086,6 +2086,121 @@ async def test_poller_retries_when_elapsed_equals_window(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_poller_keeps_send_failure_window_after_other_error(monkeypatch):
+    """전송 실패가 섞였던 update는 다른 오류로 바뀌어도 긴 창을 유지한다 (PR #242 리뷰).
+
+    first_at은 첫 실패에 고정인데 창만 마지막 예외 종류로 다시 고르면 기준이 어긋난다.
+    429가 이어지다 마지막에 다른 오류가 한 번 나면 창이 60초로 줄어, 그 오류에 재시도가
+    0회 주어진 채 즉시 폐기된다.
+    """
+    notifier = FakeNotifier()
+    notifier.enabled = True
+    notifier.bot_token = "token"
+
+    class FlippingHandler:
+        def __init__(self):
+            self.calls = 0
+
+        async def handle_update(self, update):
+            self.calls += 1
+            if self.calls <= 3:
+                raise telegram_commands.TelegramSendError("telegram send failed")
+            raise RuntimeError("redis timeout")
+
+    handler = FlippingHandler()
+    poller = TelegramCommandPoller(notifier=notifier, handler=handler)
+    clock = FakePollerClock(stop_after=4)
+    clock.install(monkeypatch, poller)
+
+    async def fake_get_updates():
+        if poller.offset is not None:
+            raise asyncio.CancelledError
+        return [{"update_id": 41, "message": {"chat": {"id": 123}, "text": "/buy 005930 10"}}]
+
+    monkeypatch.setattr(poller, "_get_updates", fake_get_updates)
+
+    with pytest.raises(asyncio.CancelledError):
+        await poller.run()
+
+    # 4번째 시도(t=65초)는 비-전송 오류다. 창이 60초로 줄었다면 여기서 폐기됐을 것이다.
+    assert handler.calls == 4
+    assert clock.now > telegram_commands.UPDATE_RETRY_WINDOW_SECONDS
+    assert poller.offset is None
+    assert poller._failures[41].send_failure is True
+    assert notifier.messages == []
+
+
+@pytest.mark.asyncio
+async def test_poller_extends_window_when_send_failure_appears_later(monkeypatch):
+    """반대 방향도 같다 — 도중에 전송 실패가 섞이면 긴 창으로 넘어간다 (PR #242 리뷰)."""
+    notifier = FakeNotifier()
+    notifier.enabled = True
+    notifier.bot_token = "token"
+
+    class FlippingHandler:
+        def __init__(self):
+            self.calls = 0
+
+        async def handle_update(self, update):
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("redis timeout")
+            raise telegram_commands.TelegramSendError("telegram send failed")
+
+    handler = FlippingHandler()
+    poller = TelegramCommandPoller(notifier=notifier, handler=handler)
+    clock = FakePollerClock(stop_after=4)
+    clock.install(monkeypatch, poller)
+
+    async def fake_get_updates():
+        if poller.offset is not None:
+            raise asyncio.CancelledError
+        return [{"update_id": 41, "message": {"chat": {"id": 123}, "text": "/buy 005930 10"}}]
+
+    monkeypatch.setattr(poller, "_get_updates", fake_get_updates)
+
+    with pytest.raises(asyncio.CancelledError):
+        await poller.run()
+
+    # 첫 실패는 일반 오류였지만 이후 전송 실패가 섞였으므로 60초에서 폐기되지 않는다.
+    assert handler.calls == 4
+    assert clock.now > telegram_commands.UPDATE_RETRY_WINDOW_SECONDS
+    assert poller.offset is None
+    assert poller._failures[41].send_failure is True
+
+
+@pytest.mark.asyncio
+async def test_poller_retry_delay_follows_the_newest_failure(monkeypatch):
+    """간격은 배치에 하나뿐이라 가장 급한 update에 맞춘다 (PR #242 리뷰)."""
+    notifier = FakeNotifier()
+    notifier.enabled = True
+    notifier.bot_token = "token"
+
+    class FailingHandler:
+        async def handle_update(self, update):
+            raise RuntimeError("poison update")
+
+    poller = TelegramCommandPoller(notifier=notifier, handler=FailingHandler())
+    clock = FakePollerClock(stop_after=1)
+    clock.install(monkeypatch, poller)
+    # 41은 이미 오래 재시도 중(45초 간격), 42는 이제 막 실패한다.
+    poller._failures[41] = telegram_commands._UpdateFailure(
+        first_at=0.0, attempts=8, send_failure=False
+    )
+
+    async def fake_get_updates():
+        return [{"update_id": 42, "message": {"chat": {"id": 123}, "text": "/help"}}]
+
+    monkeypatch.setattr(poller, "_get_updates", fake_get_updates)
+
+    with pytest.raises(asyncio.CancelledError):
+        await poller.run()
+
+    # 42가 41의 45초 간격을 물려받으면 자기 창(60초) 안에서 시도 횟수를 손해 본다.
+    assert clock.sleeps == [5.0]
+
+
+@pytest.mark.asyncio
 async def test_poller_eventually_skips_persistent_send_failures(monkeypatch):
     """전송 실패 창에도 상한이 있어야 한다 (PR #242 리뷰).
 

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import date, datetime
 from types import SimpleNamespace
 from zoneinfo import ZoneInfo
@@ -1948,6 +1949,132 @@ async def test_poller_keeps_offset_when_nat_response_send_fails(monkeypatch):
 
     assert calls == [("nat", "질문", "telegram:123")]
     assert poller.offset is None
+
+
+@pytest.mark.asyncio
+async def test_poller_skips_update_after_max_retries(monkeypatch):
+    """결정론적으로 실패하는 update는 재시도 상한에서 건너뛴다 (#241)."""
+    notifier = FakeNotifier()
+    notifier.enabled = True
+    notifier.bot_token = "token"
+    attempts = []
+
+    class FailingHandler:
+        async def handle_update(self, update):
+            attempts.append(update["update_id"])
+            raise RuntimeError("poison update")
+
+    poller = TelegramCommandPoller(notifier=notifier, handler=FailingHandler())
+
+    async def fake_get_updates():
+        if poller.offset is not None:
+            raise asyncio.CancelledError
+        return [{"update_id": 41, "message": {"chat": {"id": 123}, "text": "/alerts off"}}]
+
+    sleeps = []
+
+    async def fake_sleep(delay):
+        sleeps.append(delay)
+        if len(sleeps) > telegram_commands.MAX_UPDATE_RETRIES:
+            raise pytest.fail.Exception("poller kept retrying past MAX_UPDATE_RETRIES")
+
+    monkeypatch.setattr(poller, "_get_updates", fake_get_updates)
+    monkeypatch.setattr("backend.telegram_commands.asyncio.sleep", fake_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await poller.run()
+
+    assert attempts == [41] * telegram_commands.MAX_UPDATE_RETRIES
+    assert poller.offset == 42
+    assert notifier.messages == [telegram_commands.UPDATE_SKIPPED_NOTICE]
+    assert poller._failure_counts == {}
+
+
+@pytest.mark.asyncio
+async def test_poller_handles_later_update_when_earlier_update_is_poison(monkeypatch):
+    """배치 안의 poison 1건이 뒤의 정상 update를 막지 않는다 (#241)."""
+    notifier = FakeNotifier()
+    notifier.enabled = True
+    notifier.bot_token = "token"
+    handled = []
+
+    class PartialHandler:
+        async def handle_update(self, update):
+            if update["update_id"] == 41:
+                raise RuntimeError("poison update")
+            handled.append(update["update_id"])
+
+    poller = TelegramCommandPoller(notifier=notifier, handler=PartialHandler())
+    batch = [
+        {"update_id": 41, "message": {"chat": {"id": 123}, "text": "/alerts off"}},
+        {"update_id": 42, "message": {"chat": {"id": 123}, "text": "/help"}},
+    ]
+
+    async def fake_get_updates():
+        # 실제 Telegram처럼 offset 이후의 update만 다시 배달한다.
+        offset = poller.offset
+        if offset is not None and offset > 42:
+            raise asyncio.CancelledError
+        return [u for u in batch if offset is None or u["update_id"] >= offset]
+
+    sleeps = []
+
+    async def fake_sleep(delay):
+        sleeps.append(delay)
+        if len(sleeps) > telegram_commands.MAX_UPDATE_RETRIES:
+            raise pytest.fail.Exception("poller kept retrying past MAX_UPDATE_RETRIES")
+
+    monkeypatch.setattr(poller, "_get_updates", fake_get_updates)
+    monkeypatch.setattr("backend.telegram_commands.asyncio.sleep", fake_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await poller.run()
+
+    # 정상 update는 첫 배치에서 바로 처리되고, 재배달되어도 중복 실행되지 않는다.
+    assert handled == [42]
+    assert poller.offset == 43
+    assert poller._handled_ahead == set()
+    assert poller._failure_counts == {}
+    assert notifier.messages == [telegram_commands.UPDATE_SKIPPED_NOTICE]
+
+
+@pytest.mark.asyncio
+async def test_poller_clears_failure_count_after_success(monkeypatch):
+    """일시 장애로 실패한 update가 성공하면 실패 카운터가 남지 않는다 (#241)."""
+    notifier = FakeNotifier()
+    notifier.enabled = True
+    notifier.bot_token = "token"
+
+    class FlakyHandler:
+        def __init__(self):
+            self.calls = 0
+
+        async def handle_update(self, update):
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("redis unavailable")
+
+    handler = FlakyHandler()
+    poller = TelegramCommandPoller(notifier=notifier, handler=handler)
+
+    async def fake_get_updates():
+        if poller.offset is not None:
+            raise asyncio.CancelledError
+        return [{"update_id": 41, "message": {"chat": {"id": 123}, "text": "/alerts off"}}]
+
+    async def fake_sleep(delay):
+        assert poller._failure_counts == {41: 1}
+
+    monkeypatch.setattr(poller, "_get_updates", fake_get_updates)
+    monkeypatch.setattr("backend.telegram_commands.asyncio.sleep", fake_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await poller.run()
+
+    assert handler.calls == 2
+    assert poller.offset == 42
+    assert poller._failure_counts == {}
+    assert notifier.messages == []
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -1951,9 +1951,39 @@ async def test_poller_keeps_offset_when_nat_response_send_fails(monkeypatch):
     assert poller.offset is None
 
 
+class FakePollerClock:
+    """폴러의 _sleep/_now만 대체해 시간 기반 재시도 예산을 결정론적으로 진행시킨다 (#241).
+
+    전역 asyncio.sleep을 패치하면 핸들러 내부의 실제 sleep(_handle_watch의 조회 간격)까지
+    가로채므로 인스턴스 수준 간접층만 건드린다 (PR #242 리뷰).
+    """
+
+    def __init__(self, *, stop_after=None):
+        self.now = 0.0
+        self.sleeps = []
+        self._stop_after = stop_after
+
+    def install(self, monkeypatch, poller):
+        monkeypatch.setattr(poller, "_sleep", self._sleep)
+        monkeypatch.setattr(poller, "_now", lambda: self.now)
+
+    async def _sleep(self, delay):
+        self.sleeps.append(delay)
+        self.now += delay
+        if self._stop_after is not None and len(self.sleeps) >= self._stop_after:
+            raise asyncio.CancelledError
+
+
+def _poison_batch():
+    return [
+        {"update_id": 41, "message": {"chat": {"id": 123}, "text": "/alerts off"}},
+        {"update_id": 42, "message": {"chat": {"id": 123}, "text": "/help"}},
+    ]
+
+
 @pytest.mark.asyncio
-async def test_poller_skips_update_after_max_retries(monkeypatch):
-    """결정론적으로 실패하는 update는 재시도 상한에서 건너뛴다 (#241)."""
+async def test_poller_skips_update_after_retry_window(monkeypatch):
+    """복구 창을 넘긴 update는 건너뛰고, 통지에 실패한 명령을 함께 알린다 (#241)."""
     notifier = FakeNotifier()
     notifier.enabled = True
     notifier.bot_token = "token"
@@ -1965,29 +1995,58 @@ async def test_poller_skips_update_after_max_retries(monkeypatch):
             raise RuntimeError("poison update")
 
     poller = TelegramCommandPoller(notifier=notifier, handler=FailingHandler())
+    clock = FakePollerClock()
+    clock.install(monkeypatch, poller)
 
     async def fake_get_updates():
         if poller.offset is not None:
             raise asyncio.CancelledError
         return [{"update_id": 41, "message": {"chat": {"id": 123}, "text": "/alerts off"}}]
 
-    sleeps = []
-
-    async def fake_sleep(delay):
-        sleeps.append(delay)
-        if len(sleeps) > telegram_commands.MAX_UPDATE_RETRIES:
-            raise pytest.fail.Exception("poller kept retrying past MAX_UPDATE_RETRIES")
-
     monkeypatch.setattr(poller, "_get_updates", fake_get_updates)
-    monkeypatch.setattr("backend.telegram_commands.asyncio.sleep", fake_sleep)
 
     with pytest.raises(asyncio.CancelledError):
         await poller.run()
 
-    assert attempts == [41] * telegram_commands.MAX_UPDATE_RETRIES
+    # 5 + 15 + 45 = 65초 > 60초 창. 예산이 실질 10초가 아니라는 회귀 가드다.
+    assert clock.sleeps == list(telegram_commands.UPDATE_RETRY_BACKOFF_SECONDS)
+    assert clock.now > telegram_commands.UPDATE_RETRY_WINDOW_SECONDS
+    assert attempts == [41, 41, 41, 41]
     assert poller.offset == 42
-    assert notifier.messages == [telegram_commands.UPDATE_SKIPPED_NOTICE]
-    assert poller._failure_counts == {}
+    assert notifier.messages == [
+        f"{telegram_commands.UPDATE_SKIPPED_NOTICE}\n실패한 요청: /alerts off"
+    ]
+    assert poller._failures == {}
+
+
+@pytest.mark.asyncio
+async def test_poller_does_not_spend_poison_budget_on_send_failures(monkeypatch):
+    """전송 실패는 전역 장애라 update별 예산으로 세지 않는다 (#241, PR #242 리뷰)."""
+    notifier = FakeNotifier()
+    notifier.enabled = True
+    notifier.bot_token = "token"
+
+    class SendFailingHandler:
+        async def handle_update(self, update):
+            raise telegram_commands.TelegramSendError("telegram send failed")
+
+    poller = TelegramCommandPoller(notifier=notifier, handler=SendFailingHandler())
+    clock = FakePollerClock(stop_after=5)
+    clock.install(monkeypatch, poller)
+
+    async def fake_get_updates():
+        return [{"update_id": 41, "message": {"chat": {"id": 123}, "text": "/alerts off"}}]
+
+    monkeypatch.setattr(poller, "_get_updates", fake_get_updates)
+
+    with pytest.raises(asyncio.CancelledError):
+        await poller.run()
+
+    # 일반 창(60초)은 이미 지났지만 전송 실패는 더 긴 창을 쓰므로 아직 폐기되지 않는다.
+    assert clock.now > telegram_commands.UPDATE_RETRY_WINDOW_SECONDS
+    assert poller.offset is None
+    assert poller._failures[41].send_failure is True
+    assert notifier.messages == []
 
 
 @pytest.mark.asyncio
@@ -2005,10 +2064,9 @@ async def test_poller_handles_later_update_when_earlier_update_is_poison(monkeyp
             handled.append(update["update_id"])
 
     poller = TelegramCommandPoller(notifier=notifier, handler=PartialHandler())
-    batch = [
-        {"update_id": 41, "message": {"chat": {"id": 123}, "text": "/alerts off"}},
-        {"update_id": 42, "message": {"chat": {"id": 123}, "text": "/help"}},
-    ]
+    clock = FakePollerClock()
+    clock.install(monkeypatch, poller)
+    batch = _poison_batch()
 
     async def fake_get_updates():
         # 실제 Telegram처럼 offset 이후의 update만 다시 배달한다.
@@ -2017,15 +2075,7 @@ async def test_poller_handles_later_update_when_earlier_update_is_poison(monkeyp
             raise asyncio.CancelledError
         return [u for u in batch if offset is None or u["update_id"] >= offset]
 
-    sleeps = []
-
-    async def fake_sleep(delay):
-        sleeps.append(delay)
-        if len(sleeps) > telegram_commands.MAX_UPDATE_RETRIES:
-            raise pytest.fail.Exception("poller kept retrying past MAX_UPDATE_RETRIES")
-
     monkeypatch.setattr(poller, "_get_updates", fake_get_updates)
-    monkeypatch.setattr("backend.telegram_commands.asyncio.sleep", fake_sleep)
 
     with pytest.raises(asyncio.CancelledError):
         await poller.run()
@@ -2034,8 +2084,11 @@ async def test_poller_handles_later_update_when_earlier_update_is_poison(monkeyp
     assert handled == [42]
     assert poller.offset == 43
     assert poller._handled_ahead == set()
-    assert poller._failure_counts == {}
-    assert notifier.messages == [telegram_commands.UPDATE_SKIPPED_NOTICE]
+    assert poller._failures == {}
+    assert clock.sleeps == list(telegram_commands.UPDATE_RETRY_BACKOFF_SECONDS)
+    assert notifier.messages == [
+        f"{telegram_commands.UPDATE_SKIPPED_NOTICE}\n실패한 요청: /alerts off"
+    ]
 
 
 @pytest.mark.asyncio
@@ -2053,38 +2106,33 @@ async def test_poller_offset_stays_behind_poison_until_retries_exhausted(monkeyp
             handled.append(update["update_id"])
 
     poller = TelegramCommandPoller(notifier=notifier, handler=PartialHandler())
-    batch = [
-        {"update_id": 41, "message": {"chat": {"id": 123}, "text": "/alerts off"}},
-        {"update_id": 42, "message": {"chat": {"id": 123}, "text": "/help"}},
-    ]
+    batch = _poison_batch()
 
     async def fake_get_updates():
         offset = poller.offset
         return [u for u in batch if offset is None or u["update_id"] >= offset]
 
-    sleeps = 0
+    class WatermarkClock(FakePollerClock):
+        async def _sleep(self, delay):
+            # 배치 처리가 끝날 때마다 물막이를 확인한다: 41이 아직 창 안이므로
+            # offset은 41을 넘어선 안 된다(넘으면 41이 조용히 버려진다).
+            assert poller.offset is None or poller.offset <= 41
+            assert poller._failures[41].attempts == len(self.sleeps) + 1
+            await super()._sleep(delay)
 
-    async def fake_sleep(delay):
-        # 배치 처리가 끝날 때마다 물막이를 확인한다: 41이 아직 상한에 못 미쳤으므로
-        # offset은 41을 넘어선 안 된다(넘으면 41이 조용히 버려진다).
-        nonlocal sleeps
-        sleeps += 1
-        assert poller.offset is None or poller.offset <= 41
-        assert poller._failure_counts == {41: sleeps}
-        if sleeps >= telegram_commands.MAX_UPDATE_RETRIES - 1:
-            raise asyncio.CancelledError
-
+    clock = WatermarkClock(stop_after=2)
+    clock.install(monkeypatch, poller)
     monkeypatch.setattr(poller, "_get_updates", fake_get_updates)
-    monkeypatch.setattr("backend.telegram_commands.asyncio.sleep", fake_sleep)
 
     with pytest.raises(asyncio.CancelledError):
         await poller.run()
 
-    # 뒤의 update는 처리됐지만(중복 없이 1회), 41은 아직 재시도 중이라 버려지지 않았다.
+    # 뒤의 update는 처리됐지만(중복 없이 1회), 41은 아직 창 안이라 버려지지 않았다.
     assert handled == [42]
     assert poller.offset is None
     assert poller._handled_ahead == {42}
-    assert poller._failure_counts == {41: telegram_commands.MAX_UPDATE_RETRIES - 1}
+    assert poller._failures[41].attempts == 2
+    assert clock.now < telegram_commands.UPDATE_RETRY_WINDOW_SECONDS
     assert notifier.messages == []
 
 
@@ -2103,6 +2151,8 @@ async def test_poller_offset_stays_behind_poison_in_out_of_order_batch(monkeypat
             handled.append(update.get("update_id"))
 
     poller = TelegramCommandPoller(notifier=notifier, handler=PartialHandler())
+    clock = FakePollerClock(stop_after=1)
+    clock.install(monkeypatch, poller)
 
     async def fake_get_updates():
         # 정렬 전 순서가 정확성을 좌우하지 않아야 하므로 일부러 뒤집어 준다.
@@ -2113,24 +2163,112 @@ async def test_poller_offset_stays_behind_poison_in_out_of_order_batch(monkeypat
             {"update_id": 41, "message": {"chat": {"id": 123}, "text": "/alerts off"}},
         ]
 
-    async def fake_sleep(delay):
-        raise asyncio.CancelledError
-
     monkeypatch.setattr(poller, "_get_updates", fake_get_updates)
-    monkeypatch.setattr("backend.telegram_commands.asyncio.sleep", fake_sleep)
 
     with pytest.raises(asyncio.CancelledError):
         await poller.run()
 
     assert poller.offset is None
-    assert poller._failure_counts == {41: 1}
+    assert set(poller._failures) == {41}
     assert poller._handled_ahead == {42}
     assert handled == [None, 42]
 
 
 @pytest.mark.asyncio
-async def test_poller_clears_failure_count_after_success(monkeypatch):
-    """일시 장애로 실패한 update가 성공하면 실패 카운터가 남지 않는다 (#241)."""
+async def test_poller_batches_skip_notice_for_multiple_poison_updates(monkeypatch):
+    """한 배치에 poison이 여럿이어도 통지는 한 건으로 합친다 (#241, PR #242 리뷰)."""
+    notifier = FakeNotifier()
+    notifier.enabled = True
+    notifier.bot_token = "token"
+
+    class FailingHandler:
+        async def handle_update(self, update):
+            raise RuntimeError("poison update")
+
+    poller = TelegramCommandPoller(notifier=notifier, handler=FailingHandler())
+    clock = FakePollerClock()
+    clock.install(monkeypatch, poller)
+    batch = _poison_batch()
+
+    async def fake_get_updates():
+        offset = poller.offset
+        if offset is not None and offset > 42:
+            raise asyncio.CancelledError
+        return [u for u in batch if offset is None or u["update_id"] >= offset]
+
+    monkeypatch.setattr(poller, "_get_updates", fake_get_updates)
+
+    with pytest.raises(asyncio.CancelledError):
+        await poller.run()
+
+    assert poller.offset == 43
+    assert notifier.messages == [
+        f"{telegram_commands.UPDATE_SKIPPED_NOTICE}\n실패한 요청: /alerts off, /help"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_poller_logs_when_skip_notice_is_not_delivered(monkeypatch, caplog):
+    """send_text는 예외 대신 False를 돌려주므로 반환값을 확인해야 한다 (PR #242 리뷰)."""
+    notifier = FakeNotifier(send_text_result=False)
+    notifier.enabled = True
+    notifier.bot_token = "token"
+
+    class FailingHandler:
+        async def handle_update(self, update):
+            raise RuntimeError("poison update")
+
+    poller = TelegramCommandPoller(notifier=notifier, handler=FailingHandler())
+    clock = FakePollerClock()
+    clock.install(monkeypatch, poller)
+
+    async def fake_get_updates():
+        if poller.offset is not None:
+            raise asyncio.CancelledError
+        return [{"update_id": 41, "message": {"chat": {"id": 123}, "text": "/alerts off"}}]
+
+    monkeypatch.setattr(poller, "_get_updates", fake_get_updates)
+
+    with pytest.raises(asyncio.CancelledError):
+        await poller.run()
+
+    assert "skip notice not delivered" in caplog.text
+    # 통지가 실패해도 폴러는 계속 전진한다.
+    assert poller.offset == 42
+
+
+@pytest.mark.asyncio
+async def test_poller_skip_notice_skipped_for_other_chat(monkeypatch):
+    """notifier는 자기 chat에만 보낼 수 있으므로 다른 chat이면 통지하지 않는다 (#241)."""
+    notifier = FakeNotifier()
+    notifier.enabled = True
+    notifier.bot_token = "token"
+
+    class FailingHandler:
+        async def handle_update(self, update):
+            raise RuntimeError("poison update")
+
+    poller = TelegramCommandPoller(notifier=notifier, handler=FailingHandler())
+    clock = FakePollerClock()
+    clock.install(monkeypatch, poller)
+
+    async def fake_get_updates():
+        if poller.offset is not None:
+            raise asyncio.CancelledError
+        return [{"update_id": 41, "message": {"chat": {"id": 999}, "text": "/alerts off"}}]
+
+    monkeypatch.setattr(poller, "_get_updates", fake_get_updates)
+
+    with pytest.raises(asyncio.CancelledError):
+        await poller.run()
+
+    assert poller.offset == 42
+    assert notifier.messages == []
+
+
+@pytest.mark.asyncio
+async def test_poller_clears_failure_state_after_success(monkeypatch):
+    """일시 장애로 실패한 update가 성공하면 재시도 예산 기록이 남지 않는다 (#241)."""
     notifier = FakeNotifier()
     notifier.enabled = True
     notifier.bot_token = "token"
@@ -2147,23 +2285,28 @@ async def test_poller_clears_failure_count_after_success(monkeypatch):
     handler = FlakyHandler()
     poller = TelegramCommandPoller(notifier=notifier, handler=handler)
 
+    class AssertingClock(FakePollerClock):
+        async def _sleep(self, delay):
+            assert poller._failures[41].attempts == 1
+            await super()._sleep(delay)
+
+    clock = AssertingClock()
+    clock.install(monkeypatch, poller)
+
     async def fake_get_updates():
         if poller.offset is not None:
             raise asyncio.CancelledError
         return [{"update_id": 41, "message": {"chat": {"id": 123}, "text": "/alerts off"}}]
 
-    async def fake_sleep(delay):
-        assert poller._failure_counts == {41: 1}
-
     monkeypatch.setattr(poller, "_get_updates", fake_get_updates)
-    monkeypatch.setattr("backend.telegram_commands.asyncio.sleep", fake_sleep)
 
     with pytest.raises(asyncio.CancelledError):
         await poller.run()
 
     assert handler.calls == 2
     assert poller.offset == 42
-    assert poller._failure_counts == {}
+    assert poller._failures == {}
+    assert clock.sleeps == [telegram_commands.UPDATE_RETRY_BACKOFF_SECONDS[0]]
     assert notifier.messages == []
 
 

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -2009,7 +2009,8 @@ async def test_poller_skips_update_after_retry_window(monkeypatch):
         await poller.run()
 
     # 5 + 15 + 45 = 65초 > 60초 창. 예산이 실질 10초가 아니라는 회귀 가드다.
-    assert clock.sleeps == list(telegram_commands.UPDATE_RETRY_BACKOFF_SECONDS)
+    # 상수를 그대로 비교하면 동어반복이라 값 변경을 못 잡는다. 리터럴로 고정한다 (PR #242 리뷰).
+    assert clock.sleeps == [5.0, 15.0, 45.0]
     assert clock.now > telegram_commands.UPDATE_RETRY_WINDOW_SECONDS
     assert attempts == [41, 41, 41, 41]
     assert poller.offset == 42
@@ -2050,6 +2051,77 @@ async def test_poller_does_not_spend_poison_budget_on_send_failures(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_poller_retries_when_elapsed_equals_window(monkeypatch):
+    """창의 경계는 포함이다 — 경과 == 창이면 아직 폐기하지 않는다 (PR #242 리뷰)."""
+    notifier = FakeNotifier()
+    notifier.enabled = True
+    notifier.bot_token = "token"
+
+    class FailingHandler:
+        async def handle_update(self, update):
+            raise RuntimeError("poison update")
+
+    poller = TelegramCommandPoller(notifier=notifier, handler=FailingHandler())
+    clock = FakePollerClock(stop_after=2)
+    clock.install(monkeypatch, poller)
+    # 기본 백오프(5/15/45)로는 경과가 창에 정확히 걸리지 않아 경계를 지나친다.
+    monkeypatch.setattr(
+        poller, "_retry_delay", lambda: telegram_commands.UPDATE_RETRY_WINDOW_SECONDS
+    )
+
+    async def fake_get_updates():
+        if poller.offset is not None:
+            raise asyncio.CancelledError
+        return [{"update_id": 41, "message": {"chat": {"id": 123}, "text": "/alerts off"}}]
+
+    monkeypatch.setattr(poller, "_get_updates", fake_get_updates)
+
+    with pytest.raises(asyncio.CancelledError):
+        await poller.run()
+
+    assert clock.now == telegram_commands.UPDATE_RETRY_WINDOW_SECONDS * 2
+    assert poller.offset is None
+    assert poller._failures[41].attempts == 2
+    assert notifier.messages == []
+
+
+@pytest.mark.asyncio
+async def test_poller_eventually_skips_persistent_send_failures(monkeypatch):
+    """전송 실패 창에도 상한이 있어야 한다 (PR #242 리뷰).
+
+    이 창이 사실상 무한대가 되면 영구적 전송 실패(특정 메시지의 파싱 400) 하나로 offset이
+    그 시간만큼 얼어붙어 #241이 그대로 재발한다. 창을 늘리는 변경에 신호가 있어야 한다.
+    """
+    notifier = FakeNotifier()
+    notifier.enabled = True
+    notifier.bot_token = "token"
+
+    class SendFailingHandler:
+        async def handle_update(self, update):
+            raise telegram_commands.TelegramSendError("telegram send failed")
+
+    poller = TelegramCommandPoller(notifier=notifier, handler=SendFailingHandler())
+    # stop_after는 안전망이다. 창에 상한이 없으면 여기서 끊겨 아래 offset 단언이 실패한다.
+    clock = FakePollerClock(stop_after=20)
+    clock.install(monkeypatch, poller)
+
+    async def fake_get_updates():
+        if poller.offset is not None:
+            raise asyncio.CancelledError
+        return [{"update_id": 41, "message": {"chat": {"id": 123}, "text": "/alerts off"}}]
+
+    monkeypatch.setattr(poller, "_get_updates", fake_get_updates)
+
+    with pytest.raises(asyncio.CancelledError):
+        await poller.run()
+
+    assert poller.offset == 42
+    assert clock.now > telegram_commands.SEND_FAILURE_RETRY_WINDOW_SECONDS
+    assert clock.now < telegram_commands.SEND_FAILURE_RETRY_WINDOW_SECONDS * 2
+    assert poller._failures == {}
+
+
+@pytest.mark.asyncio
 async def test_poller_handles_later_update_when_earlier_update_is_poison(monkeypatch):
     """배치 안의 poison 1건이 뒤의 정상 update를 막지 않는다 (#241)."""
     notifier = FakeNotifier()
@@ -2085,7 +2157,8 @@ async def test_poller_handles_later_update_when_earlier_update_is_poison(monkeyp
     assert poller.offset == 43
     assert poller._handled_ahead == set()
     assert poller._failures == {}
-    assert clock.sleeps == list(telegram_commands.UPDATE_RETRY_BACKOFF_SECONDS)
+    # 상수를 그대로 비교하면 동어반복이라 값 변경을 못 잡는다. 리터럴로 고정한다 (PR #242 리뷰).
+    assert clock.sleeps == [5.0, 15.0, 45.0]
     assert notifier.messages == [
         f"{telegram_commands.UPDATE_SKIPPED_NOTICE}\n실패한 요청: /alerts off"
     ]
@@ -2170,6 +2243,7 @@ async def test_poller_offset_stays_behind_poison_in_out_of_order_batch(monkeypat
 
     assert poller.offset is None
     assert set(poller._failures) == {41}
+    assert poller._failures[41].attempts == 1
     assert poller._handled_ahead == {42}
     assert handled == [None, 42]
 
@@ -2306,7 +2380,7 @@ async def test_poller_clears_failure_state_after_success(monkeypatch):
     assert handler.calls == 2
     assert poller.offset == 42
     assert poller._failures == {}
-    assert clock.sleeps == [telegram_commands.UPDATE_RETRY_BACKOFF_SECONDS[0]]
+    assert clock.sleeps == [5.0]
     assert notifier.messages == []
 
 


### PR DESCRIPTION
## 📝 개요

`TelegramCommandPoller.run()`은 `handle_update()`가 예외를 던지면 offset을 전진시키지 않는다.
일시 장애(redis 다운 등)에 사용자 명령을 버리지 않으려는 의도된 동작이지만, 결정론적으로 실패하는
update가 하나 들어오면 5초마다 같은 예외를 영원히 반복하며 뒤에 도착한 모든 명령을 막는다
(head-of-line blocking).

무조건 offset을 전진시키는 대신 **횟수 제한 재시도**로 바꿨다. 1~2회 실패 시 offset 유지는 그대로라
일시 장애에 대한 기존 재시도 의미가 보존되고, `MAX_UPDATE_RETRIES`(3)를 넘긴 update만 건너뛴다.
기존 offset 유지 테스트 4개는 **한 줄도 수정하지 않고** 통과한다.

## 🚀 변경 사항

- **횟수 제한 재시도**: `_failure_counts`(update_id → 연속 실패 횟수)를 추적해 3회 실패한 update는
  offset을 전진시켜 건너뛴다. 건너뛸 때 error 로그(update_id, 실패 횟수, 마지막 예외)를 남기고,
  chat이 확인되면 `"요청 처리에 실패했어요. 다시 시도해주세요."`를 통지한다. 통지 실패는 삼킨다 —
  통지가 폴러를 다시 막으면 안 되기 때문.
- **update 단위 try/except**: 배치 안의 poison 1건이 나머지 update 처리를 막지 않는다.
  `_handle_one_update()`가 "이 update를 끝냈는가(= offset을 전진시켜도 되는가)"를 반환한다.
- **offset 물막이(watermark)**: 미해결 update가 앞에 있으면 `blocked` 플래그가 offset 전진을 막는다.
  offset은 실패 지점에 머물러야 하므로 그보다 뒤에서 이미 처리한 update는 다음 폴링에 반드시
  재배달되는데, 그대로 재실행하면 주문 같은 부수효과가 중복된다. 이를 `_handled_ahead`에 기억해
  **재실행 없이 offset만 전진**시킨다. → "명령을 버리지 않는다"와 "중복 실행하지 않는다"를 동시에 만족.
- **순서 전제를 코드로 제거**: 물막이는 미해결 update를 뒤의 update보다 먼저 만난다는 전제 위에서만
  성립한다. 이 전제를 "getUpdates가 update_id 오름차순을 보장한다"는 **외부 계약에 걸어두는 대신**
  `sorted(updates, key=_update_sort_key)`로 배치를 직접 정렬해 없앴다. 주석으로 전제를 설명하는 것보다
  전제 자체를 제거하는 쪽이 안전하다. update_id가 없는 update는 재시도 추적이 불가능해 로그만 남기고
  즉시 소화되므로 정렬 키에서 맨 앞으로 보내도 뒤의 재시도 판정에 영향이 없다.
- **카운터 정리**: 성공 시 해당 update_id의 카운터를 지우고, offset 전진 시 `_forget_passed_updates()`가
  지나간 update_id를 `_failure_counts`·`_handled_ahead` 양쪽에서 제거해 무한 증가를 막는다.
- **변경하지 않은 것**: `_get_updates()` 자체의 네트워크 예외는 기존대로 로그 + 5초 후 재시도.

### 테스트

신규 4개 (기존 4개는 무수정):

| 테스트 | 검증 |
| --- | --- |
| `test_poller_skips_update_after_max_retries` | 3회 실패 후 offset 전진·스킵·통지 |
| `test_poller_handles_later_update_when_earlier_update_is_poison` | poison 뒤 정상 update가 첫 배치에서 처리되고, 재배달돼도 중복 실행되지 않음 |
| `test_poller_offset_stays_behind_poison_until_retries_exhausted` | 3회 미달 구간에서 offset이 poison을 넘지 않음 (물막이 회귀 가드) |
| `test_poller_offset_stays_behind_poison_in_out_of_order_batch` | 배치가 역순으로 와도 물막이 유지 (정렬 줄 커버) |

```
backend/tests/test_telegram_commands.py  →  111 passed
backend/tests/                           →  415 passed, 2 skipped, 6 subtests passed
```

> 리뷰 반영으로 테스트가 추가됐다. 표의 4개 외에 전송 실패 예산 분리·창 상한·창 경계·통지 배치·
> 통지 미전달 로그·타 chat 통지 생략을 각각 고정한다.

### 뮤테이션 검증

새 테스트가 실제로 회귀를 잡는지 코드를 일부러 깨뜨려 확인했다 (검증용이며 커밋에 포함되지 않음).

| 뮤테이션 | 결과 |
| --- | --- |
| `if blocked:` 무력화 (물막이 제거) | `test_poller_offset_stays_behind_poison_until_retries_exhausted`, `test_poller_handles_later_update_when_earlier_update_is_poison` **FAILED** — `assert (43 is None or 43 <= 41)`, 즉 poison 41이 1회 실패만 하고 offset이 43으로 새어 조용히 유실됨 |
| `sorted(...)` 주석 처리 (정렬 제거) | `test_poller_offset_stays_behind_poison_in_out_of_order_batch` **FAILED** — 역순 배치에서 42가 먼저 offset을 43으로 전진시켜 41 유실 |

두 뮤테이션 모두 되돌린 뒤 전체 통과를 재확인했다.

### 재시도 예산 (리뷰 반영 후)

| 실패 종류 | 창 | 시도 | 폐기 시점 |
| --- | --- | --- | --- |
| 일반 (redis 다운 등) | 60초 | 4회 | t=65초 |
| 전송 실패 (429·5xx) | 300초 | 10회 | t=335초 |

간격은 5 / 15 / 45초 백오프(마지막 값 반복). 폴러가 단일 인스턴스라 jitter는 두지 않았다.

### 알려진 한계 (후속 이슈)

- **재시작 시 중복 실행 창.** `offset`·`_handled_ahead`가 인메모리라, blocked 구간에 프로세스가
  죽으면 poison 뒤에서 이미 실행한 update가 재배달·재실행된다. origin/main은 poison에서 배치를
  통째로 중단해 이 창이 없었으므로 **이 PR이 새로 들이는 리스크**다. 창 길이는 위 예산과 같아
  일반 65초 / 전송 실패 335초이며, 시간 기반 예산으로 바꾸면서 기존 10초보다 넓어졌다.
  429와 재시작은 "배포"라는 공통 원인을 공유하므로 동시 발생이 가설적이지 않다.
  금전 경로는 별도로 보호되지만(`/confirm`은 GETDEL claim, `/buy`는 `set_if_absent`)
  LLM 재호출·중복 메시지는 발생한다. 근본 해결은 offset의 redis 영속화.
- **비멱등 경로.** 부수효과가 확정된 뒤 전송에서 실패하는 경로(`/buy`의 프롬프트 전송,
  `/confirm`의 결과 전송)는 재시도해도 원래 의도를 달성하지 못한다. 재실행 횟수도 위 예산과 같아
  전송 실패 경로에서 최대 10회이며, 자연어 메시지는 그만큼 LLM이 호출·과금된다.
- **재시작하면 재시도 예산이 초기화된다.** 재시작이 잦으면 폐기까지 도달하지 못하고 다시 막힐 수 있다.
  단일 인스턴스 기준 #241의 요구(무한 재처리 차단)는 충족한다.

## 🔗 관련 이슈
- Related to #241
- Closes #241

## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [ ] 변경 사항에 대한 문서(README 등)를 업데이트했나요? — 내부 동작 변경이라 문서 영향 없음

## 📸 스크린샷 (선택 사항)
