### PR TITLE
feat: /api/v1/db/catalysts에 to_date 구간 조회 추가 (#238)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2,7 +2,7 @@ import os
 import logging
 from contextlib import asynccontextmanager
 from datetime import date
-from fastapi import FastAPI, Query, Depends, WebSocket, WebSocketDisconnect, Body
+from fastapi import FastAPI, HTTPException, Query, Depends, WebSocket, WebSocketDisconnect, Body
 from fastapi.middleware.cors import CORSMiddleware
 from sqlmodel import Session, select
 
@@ -237,13 +237,34 @@ async def get_db_catalysts(
     # 막기 위한 하한(1). 기본값 100은 기존 catalyst_repo.list_upcoming의 기본값(20)보다
     # 넉넉하게 잡아 여러 종목을 한 번에 다루는 전체 조회 용도에 맞춘다.
     limit: int = Query(100, ge=1, le=500, description="결과 상한 (1~500, 기본 100)."),
+    # 이슈 #238: 프론트 시간 링은 "이번 달", "앞으로 3개월" 같은 구간 조회다. to_date가
+    # 없으면 from_date 이후 전부를 요청한 뒤 limit에 걸려 뒷부분이 잘리는데, 잘린 뒷부분을
+    # 다시 가져올 방법이 없었다. 기본 상한(예: from_date+90일)은 두지 않는다 — "전체 조회"
+    # 용도를 막고 기존 호출자의 동작을 조용히 바꾸기 때문이다. 생략 시 상한 없음이 유지된다.
+    to_date: date | None = Query(None, description="이 날짜 이전(포함) 이벤트만 조회. 생략 시 상한 없음."),
     session: Session = Depends(get_session),
 ):
     """저장된 촉매 이벤트(실적/배당/공시/주총 등)를 조회합니다."""
+    # to_date < from_date는 빈 결과로 조용히 응답하지 않고 422로 거부한다. 빈 결과로
+    # 두면 "이 구간에 이벤트가 없다"와 "파라미터를 잘못 보냈다"를 클라이언트가 구분할
+    # 수 없다. 이 엔드포인트가 이미 빈 stock_name을 min_length=1로 422 거부하는 선례가
+    # 있어 일관된다. 두 파라미터 간 관계는 FastAPI Query만으로 검증할 수 없어 핸들러
+    # 본문에서 직접 확인한다.
+    if to_date is not None and to_date < from_date:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "message": "to_date must not be earlier than from_date",
+                "from_date": from_date.isoformat(),
+                "to_date": to_date.isoformat(),
+            },
+        )
     # catalyst_repo.SqliteCatalystEventRepo.list_upcoming은 stock_name이 필수 인자라
     # 전체 종목 조회에 쓸 수 없다. 기존 /api/v1/db/* 4종과 동일하게 이 라우트에서
     # session.exec(select(...))를 직접 실행한다(catalyst_repo.py는 수정하지 않는다).
     query = select(CatalystEvent).where(CatalystEvent.event_date >= from_date)
+    if to_date is not None:
+        query = query.where(CatalystEvent.event_date <= to_date)
     if stock_name is not None:
         query = query.where(CatalystEvent.stock_name == stock_name)
     # event_date만으로는 동일 날짜 이벤트 간 순서가 SQL상 보장되지 않아 limit 절단이

--- a/backend/main.py
+++ b/backend/main.py
@@ -225,7 +225,12 @@ async def get_db_diary(session: Session = Depends(get_session)):
     return {"status": "success", "data": diaries}
 
 
-@app.get("/api/v1/db/catalysts", response_model=CommonResponse, tags=["Database"])
+@app.get(
+    "/api/v1/db/catalysts",
+    response_model=CommonResponse,
+    tags=["Database"],
+    responses={422: {"description": "to_date < from_date 이거나 쿼리 파라미터 검증 실패"}},
+)
 async def get_db_catalysts(
     # Request는 쿼리 파라미터가 아니라 타입으로 판별돼 주입된다. 기본값이 없는 인자라
     # 기본값 있는 인자들보다 앞에 와야 한다(파이썬 문법). from_date가 기본값으로
@@ -235,7 +240,7 @@ async def get_db_catalysts(
     # default_factory에 today_kst를 직접 넘기면 라우트 등록 시점의 함수 객체가
     # 고정돼 테스트에서 backend.main.today_kst를 monkeypatch해도 반영되지 않는다.
     # 람다로 감싸 요청마다 모듈 전역의 today_kst를 다시 조회하도록 한다.
-    from_date: date = Query(default_factory=lambda: today_kst(), description="이 날짜 이후(포함) 이벤트만 조회. 생략 시 KST 기준 오늘."),
+    from_date: date = Query(default_factory=lambda: today_kst(), description="이 날짜부터(당일 포함) 이벤트만 조회. 생략 시 KST 기준 오늘."),
     # 이슈 #228: 프론트 시간 링(캘린더 시각화)이 한 번에 그릴 이벤트 수를 과도하게
     # 받아 렌더링이 느려지는 것을 막기 위한 상한(500). 1건도 없이 호출되는 것을
     # 막기 위한 하한(1). 기본값 100은 기존 catalyst_repo.list_upcoming의 기본값(20)보다
@@ -245,7 +250,20 @@ async def get_db_catalysts(
     # 없으면 from_date 이후 전부를 요청한 뒤 limit에 걸려 뒷부분이 잘리는데, 잘린 뒷부분을
     # 다시 가져올 방법이 없었다. 기본 상한(예: from_date+90일)은 두지 않는다 — "전체 조회"
     # 용도를 막고 기존 호출자의 동작을 조용히 바꾸기 때문이다. 생략 시 상한 없음이 유지된다.
-    to_date: date | None = Query(None, description="이 날짜 이전(포함) 이벤트만 조회. 생략 시 상한 없음."),
+    #
+    # 남은 간극: to_date는 절단 문제를 완화할 뿐 없애지 못한다. 구간을 하루까지 좁혀도
+    # (from_date == to_date) 그 하루에 limit을 넘는 이벤트가 몰리면 message == "truncated"인
+    # 채로 더 좁힐 수 없어 뒷부분을 회수할 방법이 없다. 실적 시즌처럼 특정일에 공시가
+    # 집중되는 도메인이라 가정적 시나리오가 아니다. 이 잔여 간극은 offset/cursor
+    # 페이지네이션으로만 닫히며, 별도 이슈로 다룬다.
+    to_date: date | None = Query(
+        None,
+        description=(
+            "이 날짜까지(당일 포함) 이벤트만 조회. 생략 시 상한 없음. "
+            "과거 구간을 조회하려면 from_date도 함께 보내야 한다 "
+            "(생략 시 KST 기준 오늘이 적용되어 to_date < from_date로 422가 난다)."
+        ),
+    ),
     session: Session = Depends(get_session),
 ):
     """저장된 촉매 이벤트(실적/배당/공시/주총 등)를 조회합니다."""

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,7 +2,7 @@ import os
 import logging
 from contextlib import asynccontextmanager
 from datetime import date
-from fastapi import FastAPI, HTTPException, Query, Depends, WebSocket, WebSocketDisconnect, Body
+from fastapi import FastAPI, HTTPException, Query, Depends, Request, WebSocket, WebSocketDisconnect, Body
 from fastapi.middleware.cors import CORSMiddleware
 from sqlmodel import Session, select
 
@@ -227,6 +227,10 @@ async def get_db_diary(session: Session = Depends(get_session)):
 
 @app.get("/api/v1/db/catalysts", response_model=CommonResponse, tags=["Database"])
 async def get_db_catalysts(
+    # Request는 쿼리 파라미터가 아니라 타입으로 판별돼 주입된다. 기본값이 없는 인자라
+    # 기본값 있는 인자들보다 앞에 와야 한다(파이썬 문법). from_date가 기본값으로
+    # 채워졌는지 판별하는 데만 쓴다 — 아래 422 분기 참고.
+    request: Request,
     stock_name: str | None = Query(None, min_length=1, description="종목명 정확 일치 필터. 생략 시 전체 종목 조회."),
     # default_factory에 today_kst를 직접 넘기면 라우트 등록 시점의 함수 객체가
     # 고정돼 테스트에서 backend.main.today_kst를 monkeypatch해도 반영되지 않는다.
@@ -250,14 +254,42 @@ async def get_db_catalysts(
     # 수 없다. 이 엔드포인트가 이미 빈 stock_name을 min_length=1로 422 거부하는 선례가
     # 있어 일관된다. 두 파라미터 간 관계는 FastAPI Query만으로 검증할 수 없어 핸들러
     # 본문에서 직접 확인한다.
+    #
+    # detail은 FastAPI 자체 검증(min_length=1, ge/le 등)과 동일한 list[{loc,msg,type}]
+    # 형태로 낸다. 같은 엔드포인트가 같은 422를 dict와 list 두 형태로 내면
+    # `for err in resp.json()["detail"]: err["loc"]` 같은 표준 파싱이 dict를 순회해
+    # 키 문자열에서 TypeError로 죽는다. 상태 코드만 선례를 따르고 body 계약은 따르지
+    # 않은 셈이었다.
+    #
+    # 교차 필드 의미 오류를 400으로 분리하는 안도 검토했다("422 = 스키마 검증" 불변식이
+    # 유지된다). 채택하지 않은 이유: 이미 422로 문서화·테스트된 계약을 바꾸는 것이라
+    # 팀 합의가 필요한데, 소비자가 붙기 전인 지금은 형태 통일만으로 문제가 해소되므로
+    # 계약 변경 비용을 지불할 이유가 없다.
+    #
+    # from_date는 생략 시 서버가 오늘(KST)로 채운다. 클라이언트가 과거 구간을 의도해
+    # to_date만 보내면 보낸 적 없는 from_date와 비교돼 422가 나므로, 기본값이 적용됐다는
+    # 사실을 detail에 실어 원인을 바로 알 수 있게 한다.
+    from_date_defaulted = "from_date" not in request.query_params
     if to_date is not None and to_date < from_date:
         raise HTTPException(
             status_code=422,
-            detail={
-                "message": "to_date must not be earlier than from_date",
-                "from_date": from_date.isoformat(),
-                "to_date": to_date.isoformat(),
-            },
+            detail=[
+                {
+                    "loc": ["query", "to_date"],
+                    "msg": (
+                        "to_date must not be earlier than from_date "
+                        "(from_date was not sent and defaulted to today in KST)"
+                        if from_date_defaulted
+                        else "to_date must not be earlier than from_date"
+                    ),
+                    "type": "value_error.date_range",
+                    "ctx": {
+                        "from_date": from_date.isoformat(),
+                        "to_date": to_date.isoformat(),
+                        "from_date_defaulted": from_date_defaulted,
+                    },
+                }
+            ],
         )
     # catalyst_repo.SqliteCatalystEventRepo.list_upcoming은 stock_name이 필수 인자라
     # 전체 종목 조회에 쓸 수 없다. 기존 /api/v1/db/* 4종과 동일하게 이 라우트에서

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -587,25 +587,79 @@ def test_get_catalysts_rejects_to_date_before_from_date(
     )
     assert response.status_code == 422
     detail = response.json()["detail"]
-    assert isinstance(detail, dict)
-    assert detail["from_date"] == today.isoformat()
-    assert detail["to_date"] == to_date.isoformat()
-
-
-def test_get_catalysts_fastapi_native_422_has_different_detail_shape(
-    client: TestClient,
-):
-    # to_date < from_date 검사와 FastAPI 자체 검증(예: stock_name의 min_length=1)이
-    # 둘 다 422를 내지만 detail 형태가 달라야 한다. 위 테스트가 detail 내용만 보고
-    # "우리 검사가 통과했다"고 착각하지 않도록, FastAPI 자체 422는 우리 detail 구조
-    # (from_date/to_date 키를 가진 dict)를 갖지 않음을 실측으로 고정한다.
-    response = client.get("/api/v1/db/catalysts", params={"stock_name": ""})
-    assert response.status_code == 422
-    detail = response.json()["detail"]
-    # FastAPI 자체 검증 오류는 dict가 아니라 list(각 원소가 loc/msg/type을 담은 dict)다.
+    # FastAPI 자체 검증 422와 동일한 list[{loc,msg,type}] 형태다(아래 share_detail_shape 참고).
     assert isinstance(detail, list)
-    for error in detail:
-        assert not ({"from_date", "to_date"} <= set(error.keys()))
+    assert len(detail) == 1
+    error = detail[0]
+    assert error["loc"] == ["query", "to_date"]
+    assert error["type"] == "value_error.date_range"
+    assert error["ctx"]["from_date"] == today.isoformat()
+    assert error["ctx"]["to_date"] == to_date.isoformat()
+    # from_date를 명시해 보냈으므로 기본값 적용이 아니다.
+    assert error["ctx"]["from_date_defaulted"] is False
+
+
+def test_get_catalysts_to_date_only_reports_from_date_defaulted(
+    client: TestClient, session: Session, frozen_today: date
+):
+    # from_date를 생략하면 서버가 KST 오늘로 채운다. 과거 구간을 의도해 to_date만 보낸
+    # 클라이언트는 보낸 적 없는 from_date와 비교돼 422를 받으므로, 원인을 알려면
+    # "기본값이 적용됐다"는 사실이 detail에 실려야 한다. 이게 없으면 메시지가
+    # "to_date must not be earlier than from_date"뿐이라 무엇을 고쳐야 할지 알 수 없다.
+    today = frozen_today
+    response = client.get(
+        "/api/v1/db/catalysts",
+        params={"to_date": (today - timedelta(days=30)).isoformat()},
+    )
+    assert response.status_code == 422
+    error = response.json()["detail"][0]
+    assert error["ctx"]["from_date_defaulted"] is True
+    assert error["ctx"]["from_date"] == today.isoformat()
+    # 메시지 자체에도 기본값 적용 사실이 드러나야 한다(ctx를 안 보는 클라이언트/사람용).
+    assert "defaulted" in error["msg"]
+
+
+def test_get_catalysts_custom_and_native_422_share_detail_shape(
+    client: TestClient, frozen_today: date
+):
+    """두 종류의 422가 같은 detail 형태(list)를 갖는지 고정한다.
+
+    to_date < from_date 검사와 FastAPI 자체 검증(예: stock_name의 min_length=1)은
+    같은 엔드포인트에서 같은 422를 낸다. 형태가 다르면 클라이언트가
+    `for err in resp.json()["detail"]: err["loc"]`처럼 단일 경로로 파싱할 수 없고,
+    dict를 순회해 키 문자열에서 TypeError가 난다. 두 경로가 같은 형태임을 실측으로
+    묶어 클라이언트의 단일 파싱 경로를 보장한다.
+
+    형태가 같아진 대가로 "다른 경로에서 나온 422를 우리 검사가 통과한 것으로 착각"할
+    위험이 생기므로, loc/type으로 두 422를 여전히 구별할 수 있음도 함께 단언한다.
+    """
+    today = frozen_today
+    native = client.get("/api/v1/db/catalysts", params={"stock_name": ""})
+    custom = client.get(
+        "/api/v1/db/catalysts",
+        params={
+            "from_date": today.isoformat(),
+            "to_date": (today - timedelta(days=1)).isoformat(),
+        },
+    )
+    assert native.status_code == 422
+    assert custom.status_code == 422
+
+    native_detail = native.json()["detail"]
+    custom_detail = custom.json()["detail"]
+    # 단일 파싱 경로: 둘 다 list이고, 원소는 loc/msg/type을 갖는 dict다.
+    for detail in (native_detail, custom_detail):
+        assert isinstance(detail, list)
+        assert detail
+        for error in detail:
+            assert isinstance(error, dict)
+            assert {"loc", "msg", "type"} <= set(error.keys())
+
+    # 형태가 같아도 두 422는 구별 가능해야 한다.
+    assert native_detail[0]["loc"] == ["query", "stock_name"]
+    assert custom_detail[0]["loc"] == ["query", "to_date"]
+    assert native_detail[0]["type"] != custom_detail[0]["type"]
+    assert custom_detail[0]["type"] == "value_error.date_range"
 
 
 def test_get_catalysts_truncated_within_to_date_range(

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -513,6 +513,96 @@ def test_get_catalysts_signals_truncation_when_over_limit(
     assert body["message"] == "truncated"
 
 
+def test_get_catalysts_to_date_omitted_keeps_no_upper_bound(
+    client: TestClient, session: Session, frozen_today: date
+):
+    # to_date를 생략하면 기존 동작(상한 없음)이 그대로 유지되는지 확인한다.
+    today = frozen_today
+    session.add(_make_catalyst(stock_name="가까움", event_date=today))
+    session.add(_make_catalyst(stock_name="아주먼미래", event_date=today + timedelta(days=365)))
+    session.commit()
+
+    response = client.get("/api/v1/db/catalysts")
+    assert response.status_code == 200
+    names = [row["stock_name"] for row in response.json()["data"]]
+    assert names == ["가까움", "아주먼미래"]
+
+
+def test_get_catalysts_to_date_includes_boundary_excludes_after(
+    client: TestClient, session: Session, frozen_today: date
+):
+    # to_date는 "이전(포함)"이어야 한다: event_date == to_date는 포함되고, 그 이후는 제외된다.
+    today = frozen_today
+    session.add(_make_catalyst(stock_name="경계이전", event_date=today + timedelta(days=1)))
+    session.add(_make_catalyst(stock_name="경계", event_date=today + timedelta(days=2)))
+    session.add(_make_catalyst(stock_name="경계이후", event_date=today + timedelta(days=3)))
+    session.commit()
+
+    response = client.get(
+        "/api/v1/db/catalysts",
+        params={"from_date": today.isoformat(), "to_date": (today + timedelta(days=2)).isoformat()},
+    )
+    assert response.status_code == 200
+    names = [row["stock_name"] for row in response.json()["data"]]
+    assert names == ["경계이전", "경계"]
+
+
+def test_get_catalysts_from_date_equals_to_date_single_day(
+    client: TestClient, session: Session, frozen_today: date
+):
+    # from_date == to_date는 단일 날짜 조회로 유효해야 한다(422가 아니다).
+    today = frozen_today
+    session.add(_make_catalyst(stock_name="전날", event_date=today - timedelta(days=1)))
+    session.add(_make_catalyst(stock_name="당일", event_date=today))
+    session.add(_make_catalyst(stock_name="다음날", event_date=today + timedelta(days=1)))
+    session.commit()
+
+    response = client.get(
+        "/api/v1/db/catalysts",
+        params={"from_date": today.isoformat(), "to_date": today.isoformat()},
+    )
+    assert response.status_code == 200
+    names = [row["stock_name"] for row in response.json()["data"]]
+    assert names == ["당일"]
+
+
+def test_get_catalysts_rejects_to_date_before_from_date(
+    client: TestClient, session: Session, frozen_today: date
+):
+    today = frozen_today
+    response = client.get(
+        "/api/v1/db/catalysts",
+        params={
+            "from_date": today.isoformat(),
+            "to_date": (today - timedelta(days=1)).isoformat(),
+        },
+    )
+    assert response.status_code == 422
+
+
+def test_get_catalysts_truncated_within_to_date_range(
+    client: TestClient, session: Session, frozen_today: date
+):
+    # to_date가 있어도 구간 안에 limit을 넘는 이벤트가 있으면 여전히 truncated 신호가 떠야 한다.
+    today = frozen_today
+    for i in range(4):
+        session.add(_make_catalyst(stock_name=f"종목{i}", event_date=today + timedelta(days=i)))
+    session.commit()
+
+    response = client.get(
+        "/api/v1/db/catalysts",
+        params={
+            "from_date": today.isoformat(),
+            "to_date": (today + timedelta(days=10)).isoformat(),
+            "limit": 3,
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["data"]) == 3
+    assert body["message"] == "truncated"
+
+
 def test_get_catalysts_not_truncated_at_exact_limit(
     client: TestClient, session: Session, frozen_today: date
 ):

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -569,15 +569,43 @@ def test_get_catalysts_from_date_equals_to_date_single_day(
 def test_get_catalysts_rejects_to_date_before_from_date(
     client: TestClient, session: Session, frozen_today: date
 ):
+    # status_code == 422만 확인하면 부족하다: (1) detail을 평문 문자열로 바꿔도
+    # 여전히 422라 통과하고 — "이벤트 없음"과 "파라미터 오류"를 구분하려는 이 422의
+    # 근거 자체(구조화된 detail)가 무방비가 된다. (2) 같은 엔드포인트에
+    # min_length=1/ge=1/le=500 등 FastAPI 자체 검증도 422를 내므로, 우리 검사를
+    # 지우고 다른 경로로 422가 나도 구분하지 못한다. detail 내용까지 확인해 두 경우
+    # 모두 잡는다.
+    # 뮤테이션: detail을 평문 문자열(예: detail="...")로 바꾸면 이 단언이 red가 된다.
     today = frozen_today
+    to_date = today - timedelta(days=1)
     response = client.get(
         "/api/v1/db/catalysts",
         params={
             "from_date": today.isoformat(),
-            "to_date": (today - timedelta(days=1)).isoformat(),
+            "to_date": to_date.isoformat(),
         },
     )
     assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert isinstance(detail, dict)
+    assert detail["from_date"] == today.isoformat()
+    assert detail["to_date"] == to_date.isoformat()
+
+
+def test_get_catalysts_fastapi_native_422_has_different_detail_shape(
+    client: TestClient,
+):
+    # to_date < from_date 검사와 FastAPI 자체 검증(예: stock_name의 min_length=1)이
+    # 둘 다 422를 내지만 detail 형태가 달라야 한다. 위 테스트가 detail 내용만 보고
+    # "우리 검사가 통과했다"고 착각하지 않도록, FastAPI 자체 422는 우리 detail 구조
+    # (from_date/to_date 키를 가진 dict)를 갖지 않음을 실측으로 고정한다.
+    response = client.get("/api/v1/db/catalysts", params={"stock_name": ""})
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    # FastAPI 자체 검증 오류는 dict가 아니라 list(각 원소가 loc/msg/type을 담은 dict)다.
+    assert isinstance(detail, list)
+    for error in detail:
+        assert not ({"from_date", "to_date"} <= set(error.keys()))
 
 
 def test_get_catalysts_truncated_within_to_date_range(

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -513,6 +513,25 @@ def test_get_catalysts_signals_truncation_when_over_limit(
     assert body["message"] == "truncated"
 
 
+def test_get_catalysts_not_truncated_at_exact_limit(
+    client: TestClient, session: Session, frozen_today: date
+):
+    # 정확히 limit개일 때가 유일하게 애매한 경계다. 위 두 테스트는 각각 경계에서
+    # 2 모자라고 1 넘어서 비켜 가므로, len(rows) > limit을 >= 로 바꾼 오프바이원
+    # 뮤턴트가 둘 다 통과한다. 이 경계가 깨지면 이벤트가 정확히 limit개일 때 프론트가
+    # "더 있음"으로 오해해 없는 다음 페이지를 그린다 — 데이터는 멀쩡한데 UI만 틀린다.
+    today = frozen_today
+    for i in range(3):
+        session.add(_make_catalyst(stock_name=f"종목{i}", event_date=today + timedelta(days=i)))
+    session.commit()
+
+    response = client.get("/api/v1/db/catalysts", params={"limit": 3})
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["data"]) == 3
+    assert body["message"] is None
+
+
 def test_get_catalysts_to_date_omitted_keeps_no_upper_bound(
     client: TestClient, session: Session, frozen_today: date
 ):
@@ -531,7 +550,8 @@ def test_get_catalysts_to_date_omitted_keeps_no_upper_bound(
 def test_get_catalysts_to_date_includes_boundary_excludes_after(
     client: TestClient, session: Session, frozen_today: date
 ):
-    # to_date는 "이전(포함)"이어야 한다: event_date == to_date는 포함되고, 그 이후는 제외된다.
+    # to_date는 "그 날짜까지(당일 포함)"여야 한다: event_date == to_date는 포함되고,
+    # 그 이후는 제외된다.
     today = frozen_today
     session.add(_make_catalyst(stock_name="경계이전", event_date=today + timedelta(days=1)))
     session.add(_make_catalyst(stock_name="경계", event_date=today + timedelta(days=2)))
@@ -564,6 +584,37 @@ def test_get_catalysts_from_date_equals_to_date_single_day(
     assert response.status_code == 200
     names = [row["stock_name"] for row in response.json()["data"]]
     assert names == ["당일"]
+
+
+def test_get_catalysts_valid_but_empty_range_returns_200_not_422(
+    client: TestClient, session: Session, frozen_today: date
+):
+    """유효한 구간에 이벤트가 0건이면 200 + 빈 배열이어야 한다.
+
+    to_date < from_date를 422로 거부하는 근거는 "이 구간에 이벤트가 없다"와
+    "파라미터를 잘못 보냈다"를 클라이언트가 구분할 수 있게 하는 것이다. 그 구분은
+    양쪽이 모두 고정돼야 성립하는데, 다른 테스트들은 422(후자)만 검증한다. 대비되는
+    쪽이 비어 있으면 훗날 누군가 "빈 구간도 에러로 알려주자"고 바꿔도 스위트가
+    red가 되지 않아 422의 존재 이유가 조용히 사라진다. 이 테스트가 그 절반을 고정한다.
+    """
+    today = frozen_today
+    # 조회 구간(내일~모레) 바깥에만 이벤트를 둬, 구간 자체는 유효하지만 결과가 0건이 되게 한다.
+    session.add(_make_catalyst(stock_name="구간이전", event_date=today))
+    session.add(_make_catalyst(stock_name="구간이후", event_date=today + timedelta(days=10)))
+    session.commit()
+
+    response = client.get(
+        "/api/v1/db/catalysts",
+        params={
+            "from_date": (today + timedelta(days=1)).isoformat(),
+            "to_date": (today + timedelta(days=2)).isoformat(),
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "success"
+    assert body["data"] == []
+    assert body["message"] is None
 
 
 def test_get_catalysts_rejects_to_date_before_from_date(
@@ -683,25 +734,6 @@ def test_get_catalysts_truncated_within_to_date_range(
     body = response.json()
     assert len(body["data"]) == 3
     assert body["message"] == "truncated"
-
-
-def test_get_catalysts_not_truncated_at_exact_limit(
-    client: TestClient, session: Session, frozen_today: date
-):
-    # 정확히 limit개일 때가 유일하게 애매한 경계다. 위 두 테스트는 각각 경계에서
-    # 2 모자라고 1 넘어서 비켜 가므로, len(rows) > limit을 >= 로 바꾼 오프바이원
-    # 뮤턴트가 둘 다 통과한다. 이 경계가 깨지면 이벤트가 정확히 limit개일 때 프론트가
-    # "더 있음"으로 오해해 없는 다음 페이지를 그린다 — 데이터는 멀쩡한데 UI만 틀린다.
-    today = frozen_today
-    for i in range(3):
-        session.add(_make_catalyst(stock_name=f"종목{i}", event_date=today + timedelta(days=i)))
-    session.commit()
-
-    response = client.get("/api/v1/db/catalysts", params={"limit": 3})
-    assert response.status_code == 200
-    body = response.json()
-    assert len(body["data"]) == 3
-    assert body["message"] is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 배경

PR #233 리뷰에서 나온 후속입니다. 프론트 시간 링은 본질적으로 **구간** 조회(이번 달, 앞으로 3개월)인데 엔드포인트에 상한 날짜가 없었습니다. 클라이언트가 `from_date` 이후 전부를 요청한 뒤 `limit`에 걸려 뒤쪽이 잘리는 구조였고, #233이 `message="truncated"`로 **잘렸다는 사실은** 알 수 있게 했지만 잘린 뒷부분을 가져올 방법이 없었습니다.

## 이슈가 남긴 결정 3건

이슈 본문의 "검토가 필요한 지점"입니다. 선택과 근거를 코드 주석에도 남겼습니다.

### 1. `to_date < from_date` → 422로 거부

빈 결과로 조용히 응답하면 클라이언트가 **"이 구간에 이벤트가 없다"와 "파라미터를 잘못 보냈다"를 구분할 수 없습니다.** 이 엔드포인트가 이미 빈 `stock_name`을 `min_length=1`로 422 거부하는 선례가 있어 일관됩니다.

두 파라미터 간 관계는 FastAPI `Query`만으로 검증할 수 없어 핸들러 본문에서 처리하고, 어느 값이 문제인지 응답에 담습니다.

```python
detail={
    "message": "to_date must not be earlier than from_date",
    "from_date": from_date.isoformat(),
    "to_date": to_date.isoformat(),
}
```

### 2. 기본 상한은 두지 않습니다 (생략 시 무제한)

`from_date + 90일` 같은 기본값은 **"전체 조회" 용도를 막고 기존 호출자의 동작을 조용히 바꿉니다.** `message="truncated"` 신호가 이미 있어 절단은 감지 가능합니다.

### 3. `message="truncated"` 신호 유지

`to_date`가 있어도 구간 안에 `limit`을 넘는 이벤트가 있을 수 있습니다.

## 경계 동작

| 요청 | 결과 |
| --- | --- |
| `to_date` 생략 | 상한 없음 (기존 동작 그대로) |
| `event_date == to_date` | **포함** |
| `event_date > to_date` | 제외 |
| `from_date == to_date` | 단일 날짜 조회 |
| `to_date < from_date` | **422** |
| 구간 내 이벤트 > `limit` | `message == "truncated"` 유지 |

## 검증 (직접 실행)

`pytest backend/` — **454 → 460 passed, 2 skipped** (실패 0건)

뮤테이션 6건 전부 red, 되돌린 뒤 460 복구:

| 뮤턴트 | 결과 |
| --- | --- |
| `to_date` 경계 `<=` → `<` | **2 failed** ✅ |
| `to_date` 필터 제거 | **2 failed** ✅ |
| `to_date < from_date` 422 검사 제거 | **1 failed** ✅ |
| `truncated` 신호 제거 | **2 failed** ✅ |
| `today_kst` → `date.today` | **9 failed** ✅ |
| 422의 `detail`을 평문 문자열로 | **1 failed** ✅ |

## CI 타임존 회귀 방지 — PR #233의 전례를 밟지 않았습니다

#233에서 픽스처를 `date.today()`(주변 타임존)로 만들고 서버는 `today_kst()`를 쓰는 바람에 **UTC 러너에서 매일 9시간 동안 6건이 red**가 되는 회귀가 있었습니다. 신규 테스트 5건은 모두 `frozen_today` 픽스처를 쓰고 `date.today()` 직접 사용은 0건입니다.

`today_kst()`를 하루 앞뒤로 밀어 UTC 컨테이너 조건을 재현했습니다:

| 시뮬레이션 | 결과 |
| --- | --- |
| KST가 로컬보다 **하루 앞** (UTC 컨테이너) | **19 passed** ✅ |
| KST가 로컬보다 **하루 뒤** | **19 passed** ✅ |

## 422 계약을 테스트로 고정했습니다

`status_code == 422`만 확인하면 부족합니다. 이 엔드포인트는 `min_length=1`·`ge=1`·`le=500`으로 **FastAPI 자체 422도 여러 경로로 납니다.** 우리 검사를 지우고 다른 이유로 422가 나도 통과해 버립니다.

그래서 두 가지를 고정했습니다:
- 우리 422의 `detail` 구조(`from_date`·`to_date`가 요청값과 일치)
- FastAPI 자체 422(`stock_name=""`)는 **이 구조를 갖지 않는다**는 것

`detail`을 평문 문자열로 바꾸는 뮤턴트가 **1 failed**로 red임을 확인했습니다.

Closes #238
