### PR TITLE
fix: 폴러 offset·handled_ahead를 redis에 영속화 (#248)

### DIFF
--- a/backend/redis_state.py
+++ b/backend/redis_state.py
@@ -26,6 +26,9 @@ TELEGRAM_POLLER_STATE_TTL_SEC = 60 * 60 * 24 * 7
 # RedisTelegramPollerStore._deserialize)의 15배로, 오염된 값만 걸러내고 정상 상태는
 # 절대 버리지 않도록 잡았다. 상한에 걸리면 상태를 버리므로 중복 실행이 생긴다.
 MAX_HANDLED_AHEAD = 100_000
+# offset의 허용 상한. Telegram update_id는 32비트라 정상값이 넘을 수 없다.
+# 왜 위쪽도 닫는지는 RedisTelegramPollerStore._deserialize 참조.
+MAX_OFFSET = 2**31
 
 # pending_order TTL: 10분(600초).
 # 앱 레벨 ORDER_EXPIRES_AFTER(60초)는 별도 존재하며 직접 만료 체크를 수행한다.
@@ -208,13 +211,24 @@ class RedisTelegramPollerStore:
     폴러는 단일 인스턴스이므로 원자적 SET 하나면 둘의 일관성이 보장된다.
 
     호출자(TelegramCommandPoller)가 예외를 삼키는 fail-open이다.
-    RedisPendingOrderStore의 fail-closed와 갈리는 이유는 보호 대상이 다르기 때문이다:
-    금전 경로는 GETDEL claim과 set_if_absent가 이미 별도로 막고 있고, 여기 남는 위험은
-    LLM 재호출과 중복 메시지다. redis 장애에 폴러를 세우면 텔레그램 명령이 전면 중단되는데,
-    이는 영속화 없이 폴링을 계속할 때의 손해(#248 이전 수준의 중복 창)보다 크다.
+    RedisPendingOrderStore의 fail-closed와 갈리는 근거는 "redis가 죽었을 때 무엇이 중복될 수
+    있는가"다. 답은 **아무것도 없다**: /confirm의 claim과 /buy의 set_if_absent가 그 상태에서는
+    보호하는 게 아니라 예외를 던지고, 호출부가 그것을 "주문 저장소 오류"로 사용자에게 돌려주며
+    끝낸다(telegram_commands.py의 _handle_confirm·_handle_buy). 즉 redis 장애 중에는 주문이
+    생성되지도 체결되지도 못하므로 중복될 금전 부수효과 자체가 존재하지 않고, 남는 중복 위험은
+    LLM 재호출과 중복 메시지뿐이다. 반면 여기서 fail-closed를 택하면 redis 장애가 곧 텔레그램
+    명령 전면 중단이 된다.
+
+    주의: "GETDEL이 중복 체결을 막아주니 fail-open이어도 된다"는 정신 모델은 틀렸다 —
+    그 보호는 redis가 살아 있을 때만 존재한다. 이 구분이 무너지면 누군가 같은 논리로
+    pending_order를 fail-open으로 바꿀 수 있고, 그때는 진짜 중복 체결이 생긴다 (PR #251 리뷰).
 
     키: ``finus:telegram:poller_state``
-    TTL: TELEGRAM_POLLER_STATE_TTL_SEC (7일, 쓰기마다 갱신)
+    TTL: TELEGRAM_POLLER_STATE_TTL_SEC (7일)
+        쓰기마다 갱신되지만 쓰기는 update를 처리할 때만 일어난다. 7일 내내 update가 하나도
+        없으면 키가 만료된다 — 그 시점엔 보호할 미확정 update도 없으므로 무해하다.
+        이 TTL을 줄이려면 "유휴 기간 < TTL"이 더는 성립하지 않는다는 점을 먼저 따져야 한다
+        (PR #251 리뷰).
     """
 
     def __init__(
@@ -269,6 +283,13 @@ class RedisTelegramPollerStore:
             # 앞선 미확정 update를 삭제한다 — 사용자의 명령이 흔적 없이 사라진다 (PR #251 리뷰).
             if offset < 0:
                 raise ValueError(f"offset must be non-negative, got {offset}")
+            # 위쪽도 닫는다. 손상으로 거대 양수가 들어가면 getUpdates가 "그보다 작은 update를
+            # 전부 확정"으로 처리해 미확정 update를 모두 삭제하고 빈 배열을 돌려준다. 이후
+            # 새 update_id는 항상 그보다 작으므로 봇이 영구 무응답이 되고, update가 없으니
+            # save()도 안 불려 TTL 7일이 흘러야 복구된다. update_id는 32비트라 이 상한을
+            # 정상값이 넘길 수 없다 (PR #251 리뷰).
+            if offset > MAX_OFFSET:
+                raise ValueError(f"offset too large ({offset} > {MAX_OFFSET})")
         # `or []`로 기본값을 주면 false·0·"" 같은 falsy 비-list 값이 조용히 []로 바뀌어
         # 바로 아래 검사를 건너뛴다. 결과는 fail-safe지만 손상을 감지하지 못해 키가 남고
         # 다음 재시작도 같은 값을 그대로 통과시킨다 (PR #251 리뷰).
@@ -278,10 +299,11 @@ class RedisTelegramPollerStore:
         if not isinstance(handled_ahead, list):
             raise TypeError(f"handled_ahead must be a list, got {handled_ahead!r}")
         # 정상 운영에서 이 집합은 _forget_passed_updates가 묶는다. 상한은 오염된 값이
-        # 들어왔을 때만 의미가 있다 — 원소가 수백만이면 frozenset 생성과 save()의 매 update
-        # sorted()가 CPU·메모리를 먹는다. 한계에 걸리면 상태를 버리고 중복이 생기므로,
-        # 도달 가능한 최댓값에서 넉넉히 떨어뜨렸다: 전송 실패 창 335초 동안 최소 간격 5초로
-        # 폴링하면 67배치 × getUpdates 기본 limit 100 = 6,700이 이론적 상한이다.
+        # 들어왔을 때만 의미가 있다. 검사가 json.loads 뒤라 파싱 시점의 메모리 폭증 자체는
+        # 막지 못한다 — 실제로 막는 것은 그 값을 save()가 매 update마다 재직렬화(sorted +
+        # json.dumps)하는 지속 비용이다 (PR #251 리뷰). 한계에 걸리면 상태를 버리고 중복이
+        # 생기므로 도달 가능한 최댓값에서 넉넉히 떨어뜨렸다: 전송 실패 창 335초 동안 최소
+        # 간격 5초로 폴링하면 67배치 × getUpdates 기본 limit 100 = 6,700이 이론적 상한이다.
         if len(handled_ahead) > MAX_HANDLED_AHEAD:
             raise ValueError(
                 f"handled_ahead too large ({len(handled_ahead)} > {MAX_HANDLED_AHEAD})"
@@ -292,6 +314,17 @@ class RedisTelegramPollerStore:
         return TelegramPollerState(offset=offset, handled_ahead=frozenset(handled_ahead))
 
     async def save(self, state: TelegramPollerState) -> None:
+        # 상한은 load()에만 걸려 있어, 메모리에서 넘어가면 여기서는 그대로 쓰고 다음 재시작의
+        # load()가 조용히 거부한다 — 영속화가 무의미해진 상태를 알릴 신호가 없어진다.
+        # 실패 방향 자체는 수용 가능하므로(상태를 버려도 offset=None 재시작이 받는 집합이
+        # handled_ahead가 덮던 집합과 같다) 거부 대신 경고만 남긴다 (PR #251 리뷰).
+        if len(state.handled_ahead) > MAX_HANDLED_AHEAD // 2:
+            logger.warning(
+                "telegram poller handled_ahead가 상한의 절반을 넘었다 (%s / %s). "
+                "상한을 넘기면 다음 재시작의 load()가 상태를 버려 중복 실행이 생긴다.",
+                len(state.handled_ahead),
+                MAX_HANDLED_AHEAD,
+            )
         payload = json.dumps(
             {"offset": state.offset, "handled_ahead": sorted(state.handled_ahead)}
         )

--- a/backend/redis_state.py
+++ b/backend/redis_state.py
@@ -22,6 +22,10 @@ DEFAULT_TELEGRAM_ALERT_MODE = "urgent"
 # 이미 없다. TTL은 값의 유효기간이 아니라 폴러가 영구히 내려간 뒤 남는 키를 정리하는 장치다.
 # 쓰기마다 갱신되므로 폴러가 살아 있는 한 만료되지 않는다.
 TELEGRAM_POLLER_STATE_TTL_SEC = 60 * 60 * 24 * 7
+# 저장된 handled_ahead의 허용 상한. 도달 가능한 최댓값(약 6,700 — 산출 근거는
+# RedisTelegramPollerStore._deserialize)의 15배로, 오염된 값만 걸러내고 정상 상태는
+# 절대 버리지 않도록 잡았다. 상한에 걸리면 상태를 버리므로 중복 실행이 생긴다.
+MAX_HANDLED_AHEAD = 100_000
 
 # pending_order TTL: 10분(600초).
 # 앱 레벨 ORDER_EXPIRES_AFTER(60초)는 별도 존재하며 직접 만료 체크를 수행한다.
@@ -238,20 +242,50 @@ class RedisTelegramPollerStore:
             return self._deserialize(raw)
         except (ValueError, TypeError, AttributeError) as exc:
             logger.error("telegram poller state 역직렬화 실패, 키 삭제: %s", exc)
-            await self.redis.delete(self._keys.telegram_poller_state())
+            # 삭제 실패를 여기서 새게 두면 호출자의 blanket except가 "상태 복원 실패"로
+            # 뭉뚱그려 로그해 실제 원인(키 삭제 실패)이 가려진다. 손상 키가 TTL까지 남아
+            # 매 재시작이 같은 경로를 반복하므로, 그 사실이 로그에 명시적으로 남아야 한다.
+            try:
+                await self.redis.delete(self._keys.telegram_poller_state())
+            except Exception as delete_exc:
+                logger.error(
+                    "telegram poller state 손상 키 삭제 실패, TTL(%s초)까지 남는다: %s",
+                    self.ttl_sec,
+                    delete_exc,
+                )
             return TelegramPollerState()
 
     @staticmethod
     def _deserialize(raw: str | bytes) -> TelegramPollerState:
         data = json.loads(raw if isinstance(raw, str) else raw.decode())
         offset = data.get("offset")
-        # bool은 int의 하위 타입이라 isinstance만으로는 통과한다. offset에 True가 들어가면
-        # getUpdates가 offset=1로 해석해 24시간치 update를 통째로 재배달한다.
-        if offset is not None and (isinstance(offset, bool) or not isinstance(offset, int)):
-            raise TypeError(f"offset must be int or null, got {offset!r}")
-        handled_ahead = data.get("handled_ahead") or []
+        if offset is not None:
+            # bool은 int의 하위 타입이라 isinstance만으로는 통과한다. offset에 True가 들어가면
+            # getUpdates가 offset=1로 해석해 24시간치 update를 통째로 재배달한다.
+            if isinstance(offset, bool) or not isinstance(offset, int):
+                raise TypeError(f"offset must be int or null, got {offset!r}")
+            # 음수 offset은 Telegram Bot API에서 "마지막 N개만 반환"으로 해석된다. -1이 새면
+            # getUpdates가 일부만 돌려주고, 그 뒤 offset이 정상 전진하는 순간 서버가 그보다
+            # 앞선 미확정 update를 삭제한다 — 사용자의 명령이 흔적 없이 사라진다 (PR #251 리뷰).
+            if offset < 0:
+                raise ValueError(f"offset must be non-negative, got {offset}")
+        # `or []`로 기본값을 주면 false·0·"" 같은 falsy 비-list 값이 조용히 []로 바뀌어
+        # 바로 아래 검사를 건너뛴다. 결과는 fail-safe지만 손상을 감지하지 못해 키가 남고
+        # 다음 재시작도 같은 값을 그대로 통과시킨다 (PR #251 리뷰).
+        handled_ahead = data.get("handled_ahead")
+        if handled_ahead is None:
+            handled_ahead = []
         if not isinstance(handled_ahead, list):
             raise TypeError(f"handled_ahead must be a list, got {handled_ahead!r}")
+        # 정상 운영에서 이 집합은 _forget_passed_updates가 묶는다. 상한은 오염된 값이
+        # 들어왔을 때만 의미가 있다 — 원소가 수백만이면 frozenset 생성과 save()의 매 update
+        # sorted()가 CPU·메모리를 먹는다. 한계에 걸리면 상태를 버리고 중복이 생기므로,
+        # 도달 가능한 최댓값에서 넉넉히 떨어뜨렸다: 전송 실패 창 335초 동안 최소 간격 5초로
+        # 폴링하면 67배치 × getUpdates 기본 limit 100 = 6,700이 이론적 상한이다.
+        if len(handled_ahead) > MAX_HANDLED_AHEAD:
+            raise ValueError(
+                f"handled_ahead too large ({len(handled_ahead)} > {MAX_HANDLED_AHEAD})"
+            )
         for update_id in handled_ahead:
             if isinstance(update_id, bool) or not isinstance(update_id, int):
                 raise TypeError(f"handled_ahead must hold ints, got {update_id!r}")

--- a/backend/redis_state.py
+++ b/backend/redis_state.py
@@ -17,6 +17,12 @@ COOLDOWN_TTL_SEC = 60 * 10
 TELEGRAM_ALERT_MODES = {"urgent", "all", "off"}
 DEFAULT_TELEGRAM_ALERT_MODE = "urgent"
 
+# 폴러 상태(offset·handled_ahead) TTL: 7일.
+# Telegram 서버는 미확정 update를 24시간만 보관하므로, 그보다 오래된 offset은 보호할 대상이
+# 이미 없다. TTL은 값의 유효기간이 아니라 폴러가 영구히 내려간 뒤 남는 키를 정리하는 장치다.
+# 쓰기마다 갱신되므로 폴러가 살아 있는 한 만료되지 않는다.
+TELEGRAM_POLLER_STATE_TTL_SEC = 60 * 60 * 24 * 7
+
 # pending_order TTL: 10분(600초).
 # 앱 레벨 ORDER_EXPIRES_AFTER(60초)는 별도 존재하며 직접 만료 체크를 수행한다.
 # Redis TTL은 프로세스 크래시·재시작 후 stale 키를 자동 정리하는 안전망 역할이다.
@@ -62,6 +68,9 @@ class RedisKeys:
 
     def pending_order(self, chat_id: str) -> str:
         return f"{self.prefix}:pending_order:{chat_id}"
+
+    def telegram_poller_state(self) -> str:
+        return f"{self.prefix}:telegram:poller_state"
 
 
 class RedisSchedulerState:
@@ -152,6 +161,109 @@ class RedisSchedulerState:
             return False
         await self.redis.set(self.keys.telegram_alert_mode(), mode)
         return True
+
+
+@dataclass(frozen=True)
+class TelegramPollerState:
+    """폴러가 재시작을 넘겨 살려야 하는 최소 상태 (#248).
+
+    두 값은 항상 함께 읽고 함께 쓴다. offset만 살아남고 handled_ahead가 사라지면
+    poison 뒤에서 이미 실행한 update가 재배달되어 중복 실행되고, 반대로 handled_ahead만
+    살아남으면 offset이 되감겨 같은 결과가 된다. 한 덩어리로 다뤄야 의미가 있다.
+
+    재시도 예산(_UpdateFailure)은 일부러 담지 않는다. 유실되면 poison의 폐기 시점이
+    미뤄질 뿐 중복 실행으로 이어지지 않으므로, 매 update 쓰기에 얹을 값이 아니다.
+    """
+
+    offset: int | None = None
+    handled_ahead: frozenset[int] = frozenset()
+
+
+class InMemoryTelegramPollerStore:
+    """테스트 전용 인메모리 폴러 상태 저장소.
+
+    재시작 시나리오는 같은 인스턴스를 두 폴러에 공유해 재현한다 —
+    프로세스는 죽어도 redis는 살아남는 상황이 그대로 모형화된다.
+    """
+
+    def __init__(self, state: TelegramPollerState | None = None) -> None:
+        self.state = state or TelegramPollerState()
+
+    async def load(self) -> TelegramPollerState:
+        return self.state
+
+    async def save(self, state: TelegramPollerState) -> None:
+        self.state = state
+
+
+class RedisTelegramPollerStore:
+    """폴러의 offset·handled_ahead를 redis에 영속화한다 (#248).
+
+    두 값을 한 키에 JSON 한 덩어리로 쓴다. 키를 나누면 offset만 전진하고 handled_ahead
+    정리는 유실된 절반 상태가 생기는데, 그게 정확히 이 이슈가 막으려는 중복 실행의 원인이다.
+    폴러는 단일 인스턴스이므로 원자적 SET 하나면 둘의 일관성이 보장된다.
+
+    호출자(TelegramCommandPoller)가 예외를 삼키는 fail-open이다.
+    RedisPendingOrderStore의 fail-closed와 갈리는 이유는 보호 대상이 다르기 때문이다:
+    금전 경로는 GETDEL claim과 set_if_absent가 이미 별도로 막고 있고, 여기 남는 위험은
+    LLM 재호출과 중복 메시지다. redis 장애에 폴러를 세우면 텔레그램 명령이 전면 중단되는데,
+    이는 영속화 없이 폴링을 계속할 때의 손해(#248 이전 수준의 중복 창)보다 크다.
+
+    키: ``finus:telegram:poller_state``
+    TTL: TELEGRAM_POLLER_STATE_TTL_SEC (7일, 쓰기마다 갱신)
+    """
+
+    def __init__(
+        self,
+        redis: Any,
+        *,
+        keys: RedisKeys | None = None,
+        ttl_sec: int = TELEGRAM_POLLER_STATE_TTL_SEC,
+    ) -> None:
+        self.redis = redis
+        self.ttl_sec = ttl_sec
+        self._keys = keys or RedisKeys()
+
+    async def load(self) -> TelegramPollerState:
+        """저장된 상태를 반환하거나, 없으면/손상됐으면 빈 상태를 반환한다.
+
+        손상된 값은 키를 지우고 빈 상태로 떨어진다. 남겨두면 매 재시작마다 같은 값을
+        다시 읽어 실패하고, 그때마다 offset이 처음으로 되감겨 재배달 전체가 재실행된다.
+        offset이 int가 아닌 채 통과하면 getUpdates payload까지 오염되므로 타입도 검증한다.
+        """
+        raw = await self.redis.get(self._keys.telegram_poller_state())
+        if raw is None:
+            return TelegramPollerState()
+        try:
+            return self._deserialize(raw)
+        except (ValueError, TypeError, AttributeError) as exc:
+            logger.error("telegram poller state 역직렬화 실패, 키 삭제: %s", exc)
+            await self.redis.delete(self._keys.telegram_poller_state())
+            return TelegramPollerState()
+
+    @staticmethod
+    def _deserialize(raw: str | bytes) -> TelegramPollerState:
+        data = json.loads(raw if isinstance(raw, str) else raw.decode())
+        offset = data.get("offset")
+        # bool은 int의 하위 타입이라 isinstance만으로는 통과한다. offset에 True가 들어가면
+        # getUpdates가 offset=1로 해석해 24시간치 update를 통째로 재배달한다.
+        if offset is not None and (isinstance(offset, bool) or not isinstance(offset, int)):
+            raise TypeError(f"offset must be int or null, got {offset!r}")
+        handled_ahead = data.get("handled_ahead") or []
+        if not isinstance(handled_ahead, list):
+            raise TypeError(f"handled_ahead must be a list, got {handled_ahead!r}")
+        for update_id in handled_ahead:
+            if isinstance(update_id, bool) or not isinstance(update_id, int):
+                raise TypeError(f"handled_ahead must hold ints, got {update_id!r}")
+        return TelegramPollerState(offset=offset, handled_ahead=frozenset(handled_ahead))
+
+    async def save(self, state: TelegramPollerState) -> None:
+        payload = json.dumps(
+            {"offset": state.offset, "handled_ahead": sorted(state.handled_ahead)}
+        )
+        await self.redis.set(
+            self._keys.telegram_poller_state(), payload, ex=self.ttl_sec
+        )
 
 
 class InMemoryPendingOrderStore:

--- a/backend/redis_state.py
+++ b/backend/redis_state.py
@@ -20,11 +20,13 @@ DEFAULT_TELEGRAM_ALERT_MODE = "urgent"
 # 폴러 상태(offset·handled_ahead) TTL: 7일.
 # Telegram 서버는 미확정 update를 24시간만 보관하므로, 그보다 오래된 offset은 보호할 대상이
 # 이미 없다. TTL은 값의 유효기간이 아니라 폴러가 영구히 내려간 뒤 남는 키를 정리하는 장치다.
-# 쓰기마다 갱신되므로 폴러가 살아 있는 한 만료되지 않는다.
+# 쓰기는 update를 처리할 때만 일어나므로 7일 내내 update가 없으면 만료된다 — 폴러가 살아
+# 있다는 것만으로는 갱신되지 않는다. 이 값을 줄이려면 RedisTelegramPollerStore 독스트링의
+# "유휴 기간 < TTL" 조건을 먼저 따져야 한다 (PR #251 리뷰).
 TELEGRAM_POLLER_STATE_TTL_SEC = 60 * 60 * 24 * 7
-# 저장된 handled_ahead의 허용 상한. 도달 가능한 최댓값(약 6,700 — 산출 근거는
-# RedisTelegramPollerStore._deserialize)의 15배로, 오염된 값만 걸러내고 정상 상태는
-# 절대 버리지 않도록 잡았다. 상한에 걸리면 상태를 버리므로 중복 실행이 생긴다.
+# 저장된 handled_ahead의 허용 상한. 도달 가능한 최댓값(산출 근거는
+# RedisTelegramPollerStore._deserialize)에서 넉넉히 떨어뜨렸다 — 오염된 값만 걸러내고
+# 정상 상태는 절대 버리지 않도록 잡았다. 상한에 걸리면 상태를 버리므로 중복 실행이 생긴다.
 MAX_HANDLED_AHEAD = 100_000
 # offset의 허용 상한. Telegram update_id는 32비트라 정상값이 넘을 수 없다.
 # 왜 위쪽도 닫는지는 RedisTelegramPollerStore._deserialize 참조.
@@ -303,7 +305,10 @@ class RedisTelegramPollerStore:
         # 막지 못한다 — 실제로 막는 것은 그 값을 save()가 매 update마다 재직렬화(sorted +
         # json.dumps)하는 지속 비용이다 (PR #251 리뷰). 한계에 걸리면 상태를 버리고 중복이
         # 생기므로 도달 가능한 최댓값에서 넉넉히 떨어뜨렸다: 전송 실패 창 335초 동안 최소
-        # 간격 5초로 폴링하면 67배치 × getUpdates 기본 limit 100 = 6,700이 이론적 상한이다.
+        # 간격 5초로 폴링하면 67배치이고, 배치당 최대치는 _get_updates가 넘기는 limit이다.
+        # 지금은 limit을 지정하지 않아 Telegram 기본값 100이므로 67 × 100 = 6,700이 상한이고,
+        # limit을 명시하면 그만큼 더 작아진다(#253의 GET_UPDATES_LIMIT=10이면 670). 즉 6,700은
+        # 도달 가능한 최댓값의 상계이고, MAX_HANDLED_AHEAD는 그것의 15배 이상이다.
         if len(handled_ahead) > MAX_HANDLED_AHEAD:
             raise ValueError(
                 f"handled_ahead too large ({len(handled_ahead)} > {MAX_HANDLED_AHEAD})"
@@ -325,6 +330,11 @@ class RedisTelegramPollerStore:
                 len(state.handled_ahead),
                 MAX_HANDLED_AHEAD,
             )
+        # 상태가 그대로여도(blocked 재배달 배치처럼) 같은 payload를 다시 쓴다. dirty check를
+        # 두지 않은 이유는 TTL 갱신이 아니라 비용 대비다 — blocked 구간은 재시도 예산으로
+        # 유계(≤335초)이고 TTL은 7일(604,800초)이라 만료까지 3자릿수 배수의 여유가 있고,
+        # 쓰기가 진짜 0인 유휴 구간은 dirty check가 있든 없든 같다. 단일 채팅 규모에서 중복
+        # SET의 비용이 무시 가능해 상태를 하나 더 들일 값어치가 없다고 봤다 (PR #251 리뷰).
         payload = json.dumps(
             {"offset": state.offset, "handled_ahead": sorted(state.handled_ahead)}
         )

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -108,6 +108,20 @@ UPDATE_SKIPPED_NOTICE = "요청 처리에 실패했어요. 다시 시도해주�
 # 통지에 붙일 실패 명령 요약의 최대 길이. 명령을 연달아 보낸 사용자가 무엇을 다시
 # 보내야 하는지 알 수 있어야 한다 (PR #242 리뷰).
 UPDATE_LABEL_LIMIT = 40
+# 폴러 상태 저장소 호출의 상한. create_redis_client()는 socket_timeout을 주지 않고
+# redis-py asyncio 기본값은 None(무한 대기)이라, 이게 없으면 fail-open이 fail-hang으로 무너진다:
+# redis 호스트가 RST 없이 패킷을 drop하면 _persist_state의 await가 돌아오지 않고, 그 await는
+# run()의 배치 루프 안이라 폴러 태스크가 통째로 멈춘다. except Exception은 예외가 나야 도는데
+# hang은 예외를 내지 않으므로 "인메모리로 계속" 로그조차 남지 않는다.
+#
+# 이 PR이 노출을 넓혔다는 점이 근거다: 이전에는 redis를 만지는 명령(/alerts, /buy, /confirm,
+# /cancel)만 이 위험을 졌고 /help·자연어·/watch는 blackhole 중에도 서비스됐지만, 이제 모든
+# update가 루프 안에서 redis를 동기 대기한다 (PR #251 리뷰).
+#
+# 값은 사용자 체감(폴링 지연)과 일시적 지연 흡수 사이의 절충이다. 정상 redis는 1ms 수준이라
+# 이 상한에 닿는 것은 이미 비정상이며, docker-compose에서 가장 흔한 장애(컨테이너 다운)는
+# 즉시 ECONNREFUSED를 내므로 이 경로를 타지 않는다.
+STATE_STORE_TIMEOUT_SECONDS = 3.0
 
 
 class TelegramSendError(RuntimeError):
@@ -1461,6 +1475,13 @@ class TelegramCommandPoller:
         self.offset: int | None = None
         # update_id -> 재시도 예산. 유실돼도 poison 폐기가 미뤄질 뿐 중복 실행으로 이어지지
         # 않으므로 영속화하지 않는다. 매 update 쓰기에 얹을 값이 아니다 (#248).
+        #
+        # 대가는 분명히 해 둔다: _restore_state가 이 값을 건드리지 않으므로 재시작마다
+        # poison에 예산이 새로 지급된다. 배포가 잦으면 폐기가 무기한 미뤄지고 그동안
+        # _handled_ahead도 함께 묶인다. 영속화하는 offset·_handled_ahead가 "자신을 poison에
+        # 붙들어 매는 상태"인 반면 이건 "poison을 포기하게 해주는 유일한 상태"라 방향이
+        # 반대다. 다만 이 PR이 새로 들이는 위험은 아니다 — 이전에도 재시작 후 Telegram이
+        # 같은 지점부터 재배달하며 예산이 리셋됐다 (PR #251 리뷰).
         self._failures: dict[int, _UpdateFailure] = {}
         # 재시도 대기 중인 update보다 뒤에 있어서 먼저 처리해버린 update_id.
         # offset은 실패 지점에서 멈추므로 이 update들은 다음 폴링에 다시 배달되는데,
@@ -1523,6 +1544,17 @@ class TelegramCommandPoller:
                     self._forget_passed_updates(self.offset)
                 # 배치 끝이 아니라 update마다 쓴다. 배치 단위로 미루면 중간에 죽었을 때
                 # 이미 실행한 update의 기록이 통째로 사라져 영속화의 의미가 없다 (#248).
+                #
+                # 남는 창은 handle_update의 실행 시간이다. #253이 _send_text_settled로
+                # "부수효과 확정 뒤의 전송"을 그 자리에서 재시도하게 만들면서 이 시간이
+                # 밀리초에서 십수 초로 늘어난다. 그 구간에 SIGTERM이 오면 체결은 됐는데
+                # persist 전이라, 재시작 후 재배달·재실행에서 claim이 None을 돌려주고
+                # 사용자는 "확정할 대기 주문이 없습니다"를 받는다 — #253이 없애려던 그
+                # 오표시다. 다만 두 PR 중 어느 쪽의 회귀도 아니다: 영속화 이전에는 이 창이
+                # 재시도 예산 전체(최대 335초)였고 #251이 그걸 handle_update 한 번으로
+                # 줄인다. 삼중 우연(체결 + 전송 실패 + 그 사이 배포)을 요구하고 금전 자체는
+                # 안전하지만(체결은 정상이고 trade_recorder에도 남는다), 오표시가 수동
+                # 재주문을 유발할 수 있어 별도 이슈로 추적한다 (PR #251 리뷰).
                 await self._persist_state()
 
             if skipped:
@@ -1644,10 +1676,17 @@ class TelegramCommandPoller:
         실패하면 빈 상태로 시작한다. Telegram이 미확정 update를 전부 재배달하므로 명령이
         유실되지는 않지만, 실행됐던 것이 다시 실행된다 — 영속화 이전과 같은 상태다.
         여기서 예외를 올리면 redis 장애가 폴러 태스크의 죽음이 되므로 삼킨다.
+
+        wait_for가 필요한 이유는 STATE_STORE_TIMEOUT_SECONDS 주석에 있다. 여기서는 hang이
+        폴링 시작 자체를 막아, 봇이 아무 응답도 못 하는 상태로 무한정 머문다.
         """
         try:
-            state = await self.state_store.load()
+            state = await asyncio.wait_for(
+                self.state_store.load(), timeout=STATE_STORE_TIMEOUT_SECONDS
+            )
         except Exception as exc:
+            # asyncio.TimeoutError는 3.11+에서 내장 TimeoutError(OSError 하위)라 여기 걸린다.
+            # CancelledError는 BaseException이라 걸리지 않고 정상 전파된다.
             logger.error("Telegram poller 상태 복원 실패, 빈 상태로 시작: %s", exc)
             return
         self.offset = state.offset
@@ -1665,15 +1704,23 @@ class TelegramCommandPoller:
         쓰기 실패는 삼킨다 — fail-open 근거는 RedisTelegramPollerStore 독스트링에 있다.
         폴링은 인메모리 상태로 계속되고, 다음 update의 쓰기가 성공하면 그 시점 상태가
         통째로 반영되므로 실패가 누적되지 않는다(전체 상태를 매번 덮어쓰는 덕분이다).
+
+        wait_for가 없으면 이 삼킴이 무의미해진다 — 근거는 STATE_STORE_TIMEOUT_SECONDS 주석.
+        여기 남는 로그가 "영속화가 조용히 죽었다"를 알리는 유일한 신호다. 이게 반복되면
+        중복 창이 #248 이전 수준으로 돌아간 것이므로 경보 대상으로 삼을 만하다.
         """
         try:
-            await self.state_store.save(
-                TelegramPollerState(
-                    offset=self.offset,
-                    handled_ahead=frozenset(self._handled_ahead),
-                )
+            await asyncio.wait_for(
+                self.state_store.save(
+                    TelegramPollerState(
+                        offset=self.offset,
+                        handled_ahead=frozenset(self._handled_ahead),
+                    )
+                ),
+                timeout=STATE_STORE_TIMEOUT_SECONDS,
             )
         except Exception as exc:
+            # TimeoutError·CancelledError 취급은 _restore_state 주석 참조.
             logger.error("Telegram poller 상태 저장 실패, 인메모리로 계속: %s", exc)
 
     def _forget_passed_updates(self, offset: int) -> None:

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -28,6 +28,8 @@ from .redis_state import (
     InMemoryPendingOrderStore,
     RedisSchedulerState,
     RedisPendingOrderStore,
+    RedisTelegramPollerStore,
+    TelegramPollerState,
     create_redis_client,
     redis_state,
 )
@@ -224,6 +226,14 @@ def _create_pending_order_store() -> RedisPendingOrderStore:
     핸들러 인스턴스당 한 번만 호출되므로 클라이언트 누적 없음.
     """
     return RedisPendingOrderStore(create_redis_client())
+
+
+def _create_poller_state_store() -> RedisTelegramPollerStore:
+    """프로덕션 폴러 상태 저장소를 생성한다 (#248).
+
+    _create_pending_order_store와 같은 이유로 클라이언트를 하나만 만들어 풀을 재사용한다.
+    """
+    return RedisTelegramPollerStore(create_redis_client())
 
 
 def _default_watchlist_repo() -> SqliteWatchlistRepo:
@@ -1431,6 +1441,7 @@ class TelegramCommandPoller:
         *,
         notifier: TelegramNotifier = telegram_notifier,
         handler: TelegramCommandHandler | None = None,
+        state_store: Any | None = None,
     ):
         self.notifier = notifier
         if handler is None:
@@ -1441,30 +1452,32 @@ class TelegramCommandPoller:
                 pending_order_store=_create_pending_order_store(),
             )
         self.handler = handler
+        # offset과 _handled_ahead는 redis에 함께 영속화된다 (#248). 둘 다 인메모리였을 때는
+        # blocked 구간에 프로세스가 죽으면 여기 기록된 update들이 "실행됐지만 서버에 미확정"
+        # 상태로 남아 재시작 후 전부 재실행됐다. 창의 길이가 재시도 예산과 같아
+        # (일반 실패 65초, 전송 실패 335초) 무시할 수 없었다 — 게다가 429와 재시작은
+        # "배포"라는 원인을 공유해 겹칠 이유가 있다.
+        self.state_store = state_store if state_store is not None else _create_poller_state_store()
         self.offset: int | None = None
-        # update_id -> 재시도 예산. 폴러는 단일 인스턴스로만 돌기 때문에 인메모리로 충분하다 (#241).
+        # update_id -> 재시도 예산. 유실돼도 poison 폐기가 미뤄질 뿐 중복 실행으로 이어지지
+        # 않으므로 영속화하지 않는다. 매 update 쓰기에 얹을 값이 아니다 (#248).
         self._failures: dict[int, _UpdateFailure] = {}
         # 재시도 대기 중인 update보다 뒤에 있어서 먼저 처리해버린 update_id.
         # offset은 실패 지점에서 멈추므로 이 update들은 다음 폴링에 다시 배달되는데,
         # 그대로 재실행하면 주문 같은 부수효과가 중복된다 (#241).
         #
-        # 주의: offset과 이 집합이 둘 다 인메모리라, blocked 구간에 프로세스가 죽으면
-        # 여기 기록된 update들은 "실행됐지만 서버에 미확정" 상태로 남아 재시작 후 재실행된다.
-        # origin/main은 poison에서 배치를 통째로 중단해 이 창이 없었으므로 이 PR이 새로
-        # 들이는 리스크다. 금전 경로는 별도로 막혀 있지만(/confirm은 GETDEL claim,
-        # /buy는 set_if_absent) LLM 재호출·중복 메시지는 발생한다. 근본 해결은 offset을
-        # redis에 영속화하는 것이고 별도 이슈로 다룬다 (PR #242 리뷰).
-        #
-        # 창의 길이는 재시도 예산과 같다: 일반 실패 65초, 전송 실패 335초.
-        # 시간 기반 예산으로 바꾸면서 기존 10초(고정 5초 × 3회)보다 크게 넓어졌고,
-        # 429와 재시작은 "배포"라는 공통 원인으로 상관관계가 있어 동시에 발생할 수 있다.
-        # 영속화 이슈의 우선순위를 매길 때 이 수치가 근거가 된다 (PR #242 리뷰).
+        # 영속화로 창은 "실행 완료 후 redis 쓰기까지"로 좁혀졌지만 0은 아니다. 순서를 뒤집어
+        # 실행 전에 기록하면 중복 대신 유실(기록만 남고 실행 안 됨)이 되는데, 여기서는
+        # at-least-once가 낫다 — 금전 경로는 GETDEL claim·set_if_absent가 이미 막고 있어
+        # 중복의 실질 비용은 LLM 재호출과 중복 메시지인 반면, 유실은 사용자의 명령이 아무
+        # 흔적 없이 사라지는 것이다 (#248).
         self._handled_ahead: set[int] = set()
 
     async def run(self) -> None:
         if not self.notifier.enabled:
             return
         await self._setup_bot_profile()
+        await self._restore_state()
 
         while True:
             try:
@@ -1508,6 +1521,9 @@ class TelegramCommandPoller:
                 else:
                     self.offset = update_id + 1
                     self._forget_passed_updates(self.offset)
+                # 배치 끝이 아니라 update마다 쓴다. 배치 단위로 미루면 중간에 죽었을 때
+                # 이미 실행한 update의 기록이 통째로 사라져 영속화의 의미가 없다 (#248).
+                await self._persist_state()
 
             if skipped:
                 # 배치 통지는 한 건으로 합친다. poison N건에 N번 발송하면 채팅당 초당 ~1건
@@ -1621,6 +1637,44 @@ class TelegramCommandPoller:
             # send_text는 실패해도 예외 대신 False를 돌려준다. 유일한 실패 신호라
             # 반드시 확인해야 통지 실패가 어디에도 안 남는 일이 없다 (PR #242 리뷰).
             logger.error("Telegram skip notice not delivered for %s updates", len(mine))
+
+    async def _restore_state(self) -> None:
+        """재시작 전 offset·_handled_ahead를 복원한다 (#248).
+
+        실패하면 빈 상태로 시작한다. Telegram이 미확정 update를 전부 재배달하므로 명령이
+        유실되지는 않지만, 실행됐던 것이 다시 실행된다 — 영속화 이전과 같은 상태다.
+        여기서 예외를 올리면 redis 장애가 폴러 태스크의 죽음이 되므로 삼킨다.
+        """
+        try:
+            state = await self.state_store.load()
+        except Exception as exc:
+            logger.error("Telegram poller 상태 복원 실패, 빈 상태로 시작: %s", exc)
+            return
+        self.offset = state.offset
+        self._handled_ahead = set(state.handled_ahead)
+        if state.offset is not None or state.handled_ahead:
+            logger.info(
+                "Telegram poller 상태 복원: offset=%s, 처리 완료 대기 %s건",
+                state.offset,
+                len(state.handled_ahead),
+            )
+
+    async def _persist_state(self) -> None:
+        """offset과 _handled_ahead를 한 번에 저장한다 (#248).
+
+        쓰기 실패는 삼킨다 — fail-open 근거는 RedisTelegramPollerStore 독스트링에 있다.
+        폴링은 인메모리 상태로 계속되고, 다음 update의 쓰기가 성공하면 그 시점 상태가
+        통째로 반영되므로 실패가 누적되지 않는다(전체 상태를 매번 덮어쓰는 덕분이다).
+        """
+        try:
+            await self.state_store.save(
+                TelegramPollerState(
+                    offset=self.offset,
+                    handled_ahead=frozenset(self._handled_ahead),
+                )
+            )
+        except Exception as exc:
+            logger.error("Telegram poller 상태 저장 실패, 인메모리로 계속: %s", exc)
 
     def _forget_passed_updates(self, offset: int) -> None:
         """offset이 지나간 update_id 기록을 정리해 추적 상태가 무한히 커지지 않게 한다 (#241)."""

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -121,6 +121,10 @@ UPDATE_LABEL_LIMIT = 40
 # 값은 사용자 체감(폴링 지연)과 일시적 지연 흡수 사이의 절충이다. 정상 redis는 1ms 수준이라
 # 이 상한에 닿는 것은 이미 비정상이며, docker-compose에서 가장 흔한 장애(컨테이너 다운)는
 # 즉시 ECONNREFUSED를 내므로 이 경로를 타지 않는다.
+#
+# 값을 조정할 때 알아둘 성질: 타임아웃은 update마다 걸리므로 hang 중 배치 하나가 멈추는
+# 시간은 "배치 크기 × 이 값"으로 선형이다(응답 자체는 handle_update가 먼저 끝내 나간 뒤,
+# 그 뒤에 죽은 시간이 붙는다). getUpdates limit이 100이면 최악 약 300초다 (PR #251 리뷰).
 STATE_STORE_TIMEOUT_SECONDS = 3.0
 
 
@@ -1469,8 +1473,16 @@ class TelegramCommandPoller:
         # offset과 _handled_ahead는 redis에 함께 영속화된다 (#248). 둘 다 인메모리였을 때는
         # blocked 구간에 프로세스가 죽으면 여기 기록된 update들이 "실행됐지만 서버에 미확정"
         # 상태로 남아 재시작 후 전부 재실행됐다. 창의 길이가 재시도 예산과 같아
-        # (일반 실패 65초, 전송 실패 335초) 무시할 수 없었다 — 게다가 429와 재시작은
-        # "배포"라는 원인을 공유해 겹칠 이유가 있다.
+        # (일반 실패 65초, 전송 실패 335초) 무시할 수 없었다.
+        #
+        # "429와 재시작이 배포라는 원인을 공유한다"는 근거는 폐기했다 — 배포는 자기가 죽이는
+        # 프로세스의 poison을 만들 수 없고(_handled_ahead는 blocked가 이미 True일 때만 차므로
+        # poison이 사망보다 먼저, 같은 프로세스 안에서 일어나야 한다), 애초에 이 레포엔 CD도
+        # restart: 정책도 없다. 실제 재시작 계기는 Dockerfile의 uvicorn --reload + .:/app
+        # bind mount이며, 그 재시작은 SIGTERM → lifespan → stop_telegram_commands()의 취소
+        # 경로를 탄다. 근거는 확률이 아니라 비용 대비다: _handled_ahead는 Telegram이 원리적으로
+        # 보호해줄 수 없는 유일한 상태인데(서버는 미확정 update만 알 뿐 무엇을 이미 실행했는지
+        # 모른다) 영속화 비용은 이미 쓰는 키에 필드 하나다 (PR #251 리뷰).
         self.state_store = state_store if state_store is not None else _create_poller_state_store()
         self.offset: int | None = None
         # update_id -> 재시도 예산. 유실돼도 poison 폐기가 미뤄질 뿐 중복 실행으로 이어지지

--- a/backend/tests/test_redis_integration.py
+++ b/backend/tests/test_redis_integration.py
@@ -4,7 +4,13 @@ from uuid import uuid4
 
 import pytest
 
-from backend.redis_state import RedisKeys, RedisSchedulerState, signal_hash
+from backend.redis_state import (
+    RedisKeys,
+    RedisSchedulerState,
+    RedisTelegramPollerStore,
+    TelegramPollerState,
+    signal_hash,
+)
 
 
 pytestmark = pytest.mark.asyncio
@@ -76,4 +82,31 @@ async def test_real_redis_allows_only_one_concurrent_analysis_lock_holder():
         keys = await redis.keys(f"{prefix}:*")
         if keys:
             await redis.delete(*keys)
+        await redis.aclose()
+
+
+async def test_real_redis_poller_state_survives_a_new_store_instance():
+    """폴러 상태가 실제 redis를 통해 새 인스턴스로 넘어간다 (#248).
+
+    인스턴스 교체 = 프로세스 재시작. FakeRedis는 JSON 왕복과 TTL 적용을 흉내만 내므로
+    실제 서버에서 한 번 확인한다.
+    """
+    redis = await _redis_client()
+    prefix = f"finus:test:{uuid4().hex}"
+    keys = RedisKeys(prefix=prefix)
+
+    try:
+        writer = RedisTelegramPollerStore(redis, keys=keys)
+        await writer.save(TelegramPollerState(offset=44, handled_ahead=frozenset({42, 43})))
+
+        reader = RedisTelegramPollerStore(redis, keys=keys)
+        loaded = await reader.load()
+
+        assert loaded.offset == 44
+        assert loaded.handled_ahead == frozenset({42, 43})
+        assert await redis.ttl(keys.telegram_poller_state()) > 0
+    finally:
+        stale = await redis.keys(f"{prefix}:*")
+        if stale:
+            await redis.delete(*stale)
         await redis.aclose()

--- a/backend/tests/test_redis_state.py
+++ b/backend/tests/test_redis_state.py
@@ -211,8 +211,14 @@ async def test_poller_state_load_drops_corrupted_value():
         # 음수 offset은 Telegram이 "마지막 N개만"으로 해석한다. 통과하면 앞선 미확정
         # update가 조용히 삭제된다 (PR #251 리뷰).
         '{"offset": -1}',
+        # 위쪽도 닫혀 있어야 한다. 거대 양수가 새면 Telegram이 미확정 update를 전부 삭제하고
+        # 봇이 영구 무응답이 된다 (PR #251 리뷰).
+        '{"offset": 99999999999}',
         '{"offset": 42, "handled_ahead": "42"}',
         '{"offset": 42, "handled_ahead": ["42"]}',
+        # 원소의 bool 가드. 구현은 있었는데 케이스가 없어 뮤테이션이 살아 있었다
+        # (PR #251 리뷰). `1 in frozenset({True})`가 True라 update_id 1이 건너뛰어진다.
+        '{"offset": 42, "handled_ahead": [true]}',
         # falsy 비-list 값. `or []`로 기본값을 주면 조용히 []가 되어 검사를 건너뛴다
         # (PR #251 리뷰).
         '{"handled_ahead": false}',
@@ -299,3 +305,26 @@ async def test_poller_state_load_logs_when_corrupted_key_delete_fails(caplog):
         assert await store.load() == TelegramPollerState()
 
     assert "손상 키 삭제 실패" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_poller_state_save_warns_when_handled_ahead_nears_limit(caplog):
+    """상한은 load에만 걸려 있어, 넘어가는 순간을 save가 알리지 않으면 신호가 없다 (PR #251 리뷰)."""
+    store = RedisTelegramPollerStore(FakeRedis())
+    near_limit = frozenset(range(MAX_HANDLED_AHEAD // 2 + 1))
+
+    with caplog.at_level("WARNING"):
+        await store.save(TelegramPollerState(offset=1, handled_ahead=near_limit))
+
+    assert "상한의 절반을 넘었다" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_poller_state_save_is_quiet_below_warning_threshold(caplog):
+    """도달 가능한 크기(약 6,700)에서 경고가 울리면 로그가 무의미해진다 (PR #251 리뷰)."""
+    store = RedisTelegramPollerStore(FakeRedis())
+
+    with caplog.at_level("WARNING"):
+        await store.save(TelegramPollerState(offset=1, handled_ahead=frozenset(range(6_700))))
+
+    assert caplog.text == ""

--- a/backend/tests/test_redis_state.py
+++ b/backend/tests/test_redis_state.py
@@ -1,6 +1,9 @@
+import json
+
 import pytest
 
 from backend.redis_state import (
+    MAX_HANDLED_AHEAD,
     SIGNAL_HASH_TTL_SEC,
     TELEGRAM_POLLER_STATE_TTL_SEC,
     RedisSchedulerState,
@@ -30,6 +33,9 @@ class FakeRedis:
 
     async def exists(self, key):
         return 1 if key in self.store else 0
+
+    async def delete(self, key):
+        self.store.pop(key, None)
 
     async def eval(self, script, numkeys, key, token):
         _ = script, numkeys
@@ -166,16 +172,9 @@ async def test_telegram_alert_mode_ignores_invalid_values():
 # ---------------------------------------------------------------------------
 
 
-class PollerFakeRedis(FakeRedis):
-    """delete를 더한 FakeRedis. 손상된 상태 키를 지우는 경로를 태우기 위함이다."""
-
-    async def delete(self, key):
-        self.store.pop(key, None)
-
-
 @pytest.mark.asyncio
 async def test_poller_state_round_trips_offset_and_handled_ahead():
-    redis = PollerFakeRedis()
+    redis = FakeRedis()
     store = RedisTelegramPollerStore(redis)
 
     assert await store.load() == TelegramPollerState()
@@ -193,7 +192,7 @@ async def test_poller_state_round_trips_offset_and_handled_ahead():
 @pytest.mark.asyncio
 async def test_poller_state_load_drops_corrupted_value():
     """손상된 값을 남겨두면 매 재시작마다 같은 실패를 반복한다 (#248)."""
-    redis = PollerFakeRedis()
+    redis = FakeRedis()
     redis.store["finus:telegram:poller_state"] = "not json"
     store = RedisTelegramPollerStore(redis)
 
@@ -209,12 +208,20 @@ async def test_poller_state_load_drops_corrupted_value():
         # bool은 int의 하위 타입이라 타입 검사를 그냥 통과한다. offset=True가 통과하면
         # getUpdates가 offset=1로 해석해 24시간치 update를 통째로 재배달한다.
         '{"offset": true}',
+        # 음수 offset은 Telegram이 "마지막 N개만"으로 해석한다. 통과하면 앞선 미확정
+        # update가 조용히 삭제된다 (PR #251 리뷰).
+        '{"offset": -1}',
         '{"offset": 42, "handled_ahead": "42"}',
         '{"offset": 42, "handled_ahead": ["42"]}',
+        # falsy 비-list 값. `or []`로 기본값을 주면 조용히 []가 되어 검사를 건너뛴다
+        # (PR #251 리뷰).
+        '{"handled_ahead": false}',
+        '{"handled_ahead": 0}',
+        '{"handled_ahead": ""}',
     ],
 )
 async def test_poller_state_load_rejects_wrong_types(payload):
-    redis = PollerFakeRedis()
+    redis = FakeRedis()
     redis.store["finus:telegram:poller_state"] = payload
     store = RedisTelegramPollerStore(redis)
 
@@ -225,10 +232,70 @@ async def test_poller_state_load_rejects_wrong_types(payload):
 @pytest.mark.asyncio
 async def test_poller_state_save_overwrites_whole_state():
     """전체 상태를 매번 덮어쓰므로 이전 쓰기가 실패해도 다음 쓰기가 따라잡는다 (#248)."""
-    redis = PollerFakeRedis()
+    redis = FakeRedis()
     store = RedisTelegramPollerStore(redis)
 
     await store.save(TelegramPollerState(offset=None, handled_ahead=frozenset({42, 43})))
     await store.save(TelegramPollerState(offset=44, handled_ahead=frozenset()))
 
     assert await store.load() == TelegramPollerState(offset=44, handled_ahead=frozenset())
+
+
+@pytest.mark.asyncio
+async def test_poller_state_load_accepts_zero_offset_and_empty_handled_ahead():
+    """0과 빈 리스트는 정상값이다 — falsy라고 손상으로 몰면 안 된다 (PR #251 리뷰)."""
+    redis = FakeRedis()
+    redis.store["finus:telegram:poller_state"] = '{"offset": 0, "handled_ahead": []}'
+    store = RedisTelegramPollerStore(redis)
+
+    assert await store.load() == TelegramPollerState(offset=0, handled_ahead=frozenset())
+    # 정상값이므로 키가 남아 있어야 한다.
+    assert "finus:telegram:poller_state" in redis.store
+
+
+@pytest.mark.asyncio
+async def test_poller_state_load_rejects_oversized_handled_ahead():
+    """오염된 거대 집합은 버린다. frozenset 생성과 매 update sorted()가 CPU를 먹는다 (PR #251 리뷰)."""
+    redis = FakeRedis()
+    oversized = list(range(MAX_HANDLED_AHEAD + 1))
+    redis.store["finus:telegram:poller_state"] = json.dumps({"offset": 1, "handled_ahead": oversized})
+    store = RedisTelegramPollerStore(redis)
+
+    assert await store.load() == TelegramPollerState()
+    assert redis.store == {}
+
+
+@pytest.mark.asyncio
+async def test_poller_state_load_keeps_realistic_handled_ahead_size():
+    """도달 가능한 최댓값(약 6,700)은 상한에 걸리지 않아야 한다 (PR #251 리뷰).
+
+    상한에 걸리면 상태를 버려 중복 실행이 생긴다 — 정상 상태를 버리는 상한은 이 PR이
+    고치려는 버그를 되살린다. 전송 실패 창 335초 / 최소 간격 5초 = 67배치 × limit 100.
+    """
+    redis = FakeRedis()
+    reachable = list(range(6_700))
+    redis.store["finus:telegram:poller_state"] = json.dumps({"offset": 1, "handled_ahead": reachable})
+    store = RedisTelegramPollerStore(redis)
+
+    assert len((await store.load()).handled_ahead) == 6_700
+
+
+@pytest.mark.asyncio
+async def test_poller_state_load_logs_when_corrupted_key_delete_fails(caplog):
+    """삭제 실패를 삼키되 원인이 로그에 남아야 한다 (PR #251 리뷰).
+
+    호출자의 blanket except가 "상태 복원 실패"로 뭉뚱그리면 실제 원인이 가려지고,
+    손상 키는 TTL까지 남아 매 재시작이 같은 경로를 반복한다.
+    """
+    class DeleteFailingRedis(FakeRedis):
+        async def delete(self, key):
+            raise RuntimeError("redis unavailable")
+
+    redis = DeleteFailingRedis()
+    redis.store["finus:telegram:poller_state"] = "not json"
+    store = RedisTelegramPollerStore(redis)
+
+    with caplog.at_level("ERROR"):
+        assert await store.load() == TelegramPollerState()
+
+    assert "손상 키 삭제 실패" in caplog.text

--- a/backend/tests/test_redis_state.py
+++ b/backend/tests/test_redis_state.py
@@ -2,7 +2,10 @@ import pytest
 
 from backend.redis_state import (
     SIGNAL_HASH_TTL_SEC,
+    TELEGRAM_POLLER_STATE_TTL_SEC,
     RedisSchedulerState,
+    RedisTelegramPollerStore,
+    TelegramPollerState,
     signal_hash,
     normalize_signal_text,
 )
@@ -156,3 +159,76 @@ async def test_telegram_alert_mode_ignores_invalid_values():
     assert await state.get_telegram_alert_mode() == "all"
 
 
+
+
+# ---------------------------------------------------------------------------
+# RedisTelegramPollerStore (#248)
+# ---------------------------------------------------------------------------
+
+
+class PollerFakeRedis(FakeRedis):
+    """delete를 더한 FakeRedis. 손상된 상태 키를 지우는 경로를 태우기 위함이다."""
+
+    async def delete(self, key):
+        self.store.pop(key, None)
+
+
+@pytest.mark.asyncio
+async def test_poller_state_round_trips_offset_and_handled_ahead():
+    redis = PollerFakeRedis()
+    store = RedisTelegramPollerStore(redis)
+
+    assert await store.load() == TelegramPollerState()
+
+    await store.save(TelegramPollerState(offset=44, handled_ahead=frozenset({42, 43})))
+    loaded = await store.load()
+
+    assert loaded.offset == 44
+    assert loaded.handled_ahead == frozenset({42, 43})
+    # 두 값이 한 키에 함께 저장되어야 절반만 반영된 상태가 생기지 않는다.
+    assert list(redis.store) == ["finus:telegram:poller_state"]
+    assert redis.calls[-1][2] == TELEGRAM_POLLER_STATE_TTL_SEC
+
+
+@pytest.mark.asyncio
+async def test_poller_state_load_drops_corrupted_value():
+    """손상된 값을 남겨두면 매 재시작마다 같은 실패를 반복한다 (#248)."""
+    redis = PollerFakeRedis()
+    redis.store["finus:telegram:poller_state"] = "not json"
+    store = RedisTelegramPollerStore(redis)
+
+    assert await store.load() == TelegramPollerState()
+    assert redis.store == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '{"offset": "42"}',
+        # bool은 int의 하위 타입이라 타입 검사를 그냥 통과한다. offset=True가 통과하면
+        # getUpdates가 offset=1로 해석해 24시간치 update를 통째로 재배달한다.
+        '{"offset": true}',
+        '{"offset": 42, "handled_ahead": "42"}',
+        '{"offset": 42, "handled_ahead": ["42"]}',
+    ],
+)
+async def test_poller_state_load_rejects_wrong_types(payload):
+    redis = PollerFakeRedis()
+    redis.store["finus:telegram:poller_state"] = payload
+    store = RedisTelegramPollerStore(redis)
+
+    assert await store.load() == TelegramPollerState()
+    assert redis.store == {}
+
+
+@pytest.mark.asyncio
+async def test_poller_state_save_overwrites_whole_state():
+    """전체 상태를 매번 덮어쓰므로 이전 쓰기가 실패해도 다음 쓰기가 따라잡는다 (#248)."""
+    redis = PollerFakeRedis()
+    store = RedisTelegramPollerStore(redis)
+
+    await store.save(TelegramPollerState(offset=None, handled_ahead=frozenset({42, 43})))
+    await store.save(TelegramPollerState(offset=44, handled_ahead=frozenset()))
+
+    assert await store.load() == TelegramPollerState(offset=44, handled_ahead=frozenset())

--- a/backend/tests/test_redis_state.py
+++ b/backend/tests/test_redis_state.py
@@ -273,10 +273,12 @@ async def test_poller_state_load_rejects_oversized_handled_ahead():
 
 @pytest.mark.asyncio
 async def test_poller_state_load_keeps_realistic_handled_ahead_size():
-    """도달 가능한 최댓값(약 6,700)은 상한에 걸리지 않아야 한다 (PR #251 리뷰).
+    """도달 가능한 최댓값의 상계(6,700)는 상한에 걸리지 않아야 한다 (PR #251 리뷰).
 
     상한에 걸리면 상태를 버려 중복 실행이 생긴다 — 정상 상태를 버리는 상한은 이 PR이
-    고치려는 버그를 되살린다. 전송 실패 창 335초 / 최소 간격 5초 = 67배치 × limit 100.
+    고치려는 버그를 되살린다. 전송 실패 창 335초 / 최소 간격 5초 = 67배치이고, 배치당
+    최대치는 getUpdates의 limit이다(미지정 = 기본값 100 → 6,700). limit을 명시하면 그만큼
+    작아지므로 6,700은 상계이고, 이 단언은 그 아래 모든 값에 대해서도 성립한다.
     """
     redis = FakeRedis()
     reachable = list(range(6_700))
@@ -321,10 +323,14 @@ async def test_poller_state_save_warns_when_handled_ahead_nears_limit(caplog):
 
 @pytest.mark.asyncio
 async def test_poller_state_save_is_quiet_below_warning_threshold(caplog):
-    """도달 가능한 크기(약 6,700)에서 경고가 울리면 로그가 무의미해진다 (PR #251 리뷰)."""
+    """도달 가능한 크기의 상계(6,700)에서 경고가 울리면 로그가 무의미해진다 (PR #251 리뷰).
+
+    단언을 caplog.text == ""로 두면 무관한 라이브러리 경고 하나에 깨지고, 원인이 이 PR과
+    무관해 보여 추적이 어렵다. 뮤테이션 감지력은 이 문구 검사와 동일하다 (PR #251 리뷰).
+    """
     store = RedisTelegramPollerStore(FakeRedis())
 
     with caplog.at_level("WARNING"):
         await store.save(TelegramPollerState(offset=1, handled_ahead=frozenset(range(6_700))))
 
-    assert caplog.text == ""
+    assert "상한의 절반을 넘었다" not in caplog.text

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -3100,3 +3100,49 @@ async def test_help_and_bot_menu_include_catalysts_command(monkeypatch):
 
     assert "/catalysts <종목명> - 예정 촉매 이벤트 조회" in notifier.messages[-1]
     assert "catalysts" in [command["command"] for command in telegram_commands.TELEGRAM_BOT_COMMANDS]
+
+
+@pytest.mark.asyncio
+async def test_poller_keeps_polling_when_state_store_hangs(monkeypatch, caplog):
+    """저장소가 예외 대신 hang하면 fail-open이 fail-hang으로 무너진다 (PR #251 리뷰).
+
+    create_redis_client()가 socket_timeout을 주지 않아 redis 호스트가 RST 없이 패킷을
+    drop하면 set()이 무한 블록되고, 그 await는 run()의 배치 루프 안이라 폴러 태스크가
+    통째로 멈춘다. except Exception은 예외가 나야 도는 방어라 여기서는 발화하지 않는다.
+    BrokenStore(즉시 raise)는 이 경로를 재현하지 못한다.
+    """
+    notifier = FakeNotifier()
+    notifier.enabled = True
+    notifier.bot_token = "token"
+    handled = []
+
+    class NoopHandler:
+        async def handle_update(self, update):
+            handled.append(update["update_id"])
+
+    class HangingStore:
+        async def load(self):
+            await asyncio.Event().wait()  # 영원히 깨어나지 않는다
+
+        async def save(self, state):
+            await asyncio.Event().wait()
+
+    monkeypatch.setattr(telegram_commands, "STATE_STORE_TIMEOUT_SECONDS", 0.01)
+    poller = _make_poller(notifier, handler=NoopHandler(), state_store=HangingStore())
+
+    async def fake_get_updates():
+        if poller.offset is not None:
+            raise asyncio.CancelledError
+        return [{"update_id": 41, "message": {"chat": {"id": 123}, "text": "/help"}}]
+
+    monkeypatch.setattr(poller, "_get_updates", fake_get_updates)
+
+    with caplog.at_level("ERROR"):
+        with pytest.raises(asyncio.CancelledError):
+            await poller.run()
+
+    # hang에 갇히지 않고 폴링이 진행됐다.
+    assert handled == [41]
+    assert poller.offset == 42
+    assert "상태 복원 실패" in caplog.text
+    assert "상태 저장 실패" in caplog.text

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -23,9 +23,23 @@ from backend.telegram_commands import (
     TelegramCommandHandler,
     TelegramCommandPoller,
 )
+from backend.redis_state import InMemoryTelegramPollerStore, TelegramPollerState
 from backend.trading_orders import OrderExecutionResult, PendingOrder
 
 KST = ZoneInfo("Asia/Seoul")
+
+
+def _make_poller(notifier, handler, *, state_store=None):
+    """폴러 테스트용 생성기 — 상태 저장소를 인메모리로 고정한다 (#248).
+
+    state_store 기본값은 redis 클라이언트라, 주입하지 않으면 테스트가 실제 연결을 시도한다.
+    재시작 시나리오는 같은 state_store를 두 폴러에 넘겨 재현한다.
+    """
+    return TelegramCommandPoller(
+        notifier=notifier,
+        handler=handler,
+        state_store=state_store if state_store is not None else InMemoryTelegramPollerStore(),
+    )
 
 
 class FakeState:
@@ -1844,7 +1858,7 @@ def test_poller_explicit_handler_does_not_call_dependency_factories(monkeypatch)
     monkeypatch.setattr(telegram_commands, "_create_order_gateway", fail_factory)
     monkeypatch.setattr(telegram_commands, "_create_trade_recorder", fail_factory)
 
-    poller = TelegramCommandPoller(notifier=notifier, handler=handler)
+    poller = _make_poller(notifier, handler=handler)
 
     assert poller.handler is handler
 
@@ -1881,7 +1895,7 @@ async def test_poller_keeps_offset_when_update_handling_fails(monkeypatch):
         async def handle_update(self, update):
             raise RuntimeError("redis unavailable")
 
-    poller = TelegramCommandPoller(notifier=notifier, handler=FailingHandler())
+    poller = _make_poller(notifier, handler=FailingHandler())
 
     async def fake_get_updates():
         return [{"update_id": 41, "message": {"chat": {"id": 123}, "text": "/alerts off"}}]
@@ -1908,7 +1922,7 @@ async def test_poller_loads_bot_username_before_updates(monkeypatch):
         async def handle_update(self, update):
             return None
 
-    poller = TelegramCommandPoller(notifier=notifier, handler=NoopHandler())
+    poller = _make_poller(notifier, handler=NoopHandler())
 
     async def fake_get_updates():
         assert notifier.loaded_bot_username is True
@@ -1936,7 +1950,7 @@ async def test_poller_sets_bot_command_menu_before_updates(monkeypatch):
         async def handle_update(self, update):
             return None
 
-    poller = TelegramCommandPoller(notifier=notifier, handler=NoopHandler())
+    poller = _make_poller(notifier, handler=NoopHandler())
 
     async def fake_get_updates():
         assert notifier.bot_commands == telegram_commands.TELEGRAM_BOT_COMMANDS
@@ -1966,7 +1980,7 @@ async def test_poller_keeps_offset_when_nat_response_send_fails(monkeypatch):
         return "NAT 응답"
 
     handler = TelegramCommandHandler(notifier=notifier, llm_runner=fake_llm_runner)
-    poller = TelegramCommandPoller(notifier=notifier, handler=handler)
+    poller = _make_poller(notifier, handler=handler)
     polls = 0
 
     async def fake_get_updates():
@@ -2032,7 +2046,7 @@ async def test_poller_skips_update_after_retry_window(monkeypatch):
             attempts.append(update["update_id"])
             raise RuntimeError("poison update")
 
-    poller = TelegramCommandPoller(notifier=notifier, handler=FailingHandler())
+    poller = _make_poller(notifier, handler=FailingHandler())
     clock = FakePollerClock()
     clock.install(monkeypatch, poller)
 
@@ -2069,7 +2083,7 @@ async def test_poller_does_not_spend_poison_budget_on_send_failures(monkeypatch)
         async def handle_update(self, update):
             raise telegram_commands.TelegramSendError("telegram send failed")
 
-    poller = TelegramCommandPoller(notifier=notifier, handler=SendFailingHandler())
+    poller = _make_poller(notifier, handler=SendFailingHandler())
     clock = FakePollerClock(stop_after=5)
     clock.install(monkeypatch, poller)
 
@@ -2099,7 +2113,7 @@ async def test_poller_retries_when_elapsed_equals_window(monkeypatch):
         async def handle_update(self, update):
             raise RuntimeError("poison update")
 
-    poller = TelegramCommandPoller(notifier=notifier, handler=FailingHandler())
+    poller = _make_poller(notifier, handler=FailingHandler())
     clock = FakePollerClock(stop_after=2)
     clock.install(monkeypatch, poller)
     # 기본 백오프(5/15/45)로는 경과가 창에 정확히 걸리지 않아 경계를 지나친다.
@@ -2146,7 +2160,7 @@ async def test_poller_keeps_send_failure_window_after_other_error(monkeypatch):
             raise RuntimeError("redis timeout")
 
     handler = FlippingHandler()
-    poller = TelegramCommandPoller(notifier=notifier, handler=handler)
+    poller = _make_poller(notifier, handler=handler)
     clock = FakePollerClock(stop_after=4)
     clock.install(monkeypatch, poller)
 
@@ -2186,7 +2200,7 @@ async def test_poller_extends_window_when_send_failure_appears_later(monkeypatch
             raise telegram_commands.TelegramSendError("telegram send failed")
 
     handler = FlippingHandler()
-    poller = TelegramCommandPoller(notifier=notifier, handler=handler)
+    poller = _make_poller(notifier, handler=handler)
     clock = FakePollerClock(stop_after=4)
     clock.install(monkeypatch, poller)
 
@@ -2218,7 +2232,7 @@ async def test_poller_retry_delay_follows_the_newest_failure(monkeypatch):
         async def handle_update(self, update):
             raise RuntimeError("poison update")
 
-    poller = TelegramCommandPoller(notifier=notifier, handler=FailingHandler())
+    poller = _make_poller(notifier, handler=FailingHandler())
     clock = FakePollerClock(stop_after=1)
     clock.install(monkeypatch, poller)
     # 41은 이미 오래 재시도 중(45초 간격), 42는 이제 막 실패한다.
@@ -2253,7 +2267,7 @@ async def test_poller_eventually_skips_persistent_send_failures(monkeypatch):
         async def handle_update(self, update):
             raise telegram_commands.TelegramSendError("telegram send failed")
 
-    poller = TelegramCommandPoller(notifier=notifier, handler=SendFailingHandler())
+    poller = _make_poller(notifier, handler=SendFailingHandler())
     # stop_after는 안전망이다. 창에 상한이 없으면 여기서 끊겨 아래 offset 단언이 실패한다.
     clock = FakePollerClock(stop_after=20)
     clock.install(monkeypatch, poller)
@@ -2288,7 +2302,7 @@ async def test_poller_handles_later_update_when_earlier_update_is_poison(monkeyp
                 raise RuntimeError("poison update")
             handled.append(update["update_id"])
 
-    poller = TelegramCommandPoller(notifier=notifier, handler=PartialHandler())
+    poller = _make_poller(notifier, handler=PartialHandler())
     clock = FakePollerClock()
     clock.install(monkeypatch, poller)
     batch = _poison_batch()
@@ -2331,7 +2345,7 @@ async def test_poller_offset_stays_behind_poison_until_retries_exhausted(monkeyp
                 raise RuntimeError("poison update")
             handled.append(update["update_id"])
 
-    poller = TelegramCommandPoller(notifier=notifier, handler=PartialHandler())
+    poller = _make_poller(notifier, handler=PartialHandler())
     batch = _poison_batch()
 
     async def fake_get_updates():
@@ -2376,7 +2390,7 @@ async def test_poller_offset_stays_behind_poison_in_out_of_order_batch(monkeypat
                 raise RuntimeError("poison update")
             handled.append(update.get("update_id"))
 
-    poller = TelegramCommandPoller(notifier=notifier, handler=PartialHandler())
+    poller = _make_poller(notifier, handler=PartialHandler())
     clock = FakePollerClock(stop_after=1)
     clock.install(monkeypatch, poller)
 
@@ -2412,7 +2426,7 @@ async def test_poller_batches_skip_notice_for_multiple_poison_updates(monkeypatc
         async def handle_update(self, update):
             raise RuntimeError("poison update")
 
-    poller = TelegramCommandPoller(notifier=notifier, handler=FailingHandler())
+    poller = _make_poller(notifier, handler=FailingHandler())
     clock = FakePollerClock()
     clock.install(monkeypatch, poller)
     batch = _poison_batch()
@@ -2445,7 +2459,7 @@ async def test_poller_logs_when_skip_notice_is_not_delivered(monkeypatch, caplog
         async def handle_update(self, update):
             raise RuntimeError("poison update")
 
-    poller = TelegramCommandPoller(notifier=notifier, handler=FailingHandler())
+    poller = _make_poller(notifier, handler=FailingHandler())
     clock = FakePollerClock()
     clock.install(monkeypatch, poller)
 
@@ -2475,7 +2489,7 @@ async def test_poller_skip_notice_skipped_for_other_chat(monkeypatch):
         async def handle_update(self, update):
             raise RuntimeError("poison update")
 
-    poller = TelegramCommandPoller(notifier=notifier, handler=FailingHandler())
+    poller = _make_poller(notifier, handler=FailingHandler())
     clock = FakePollerClock()
     clock.install(monkeypatch, poller)
 
@@ -2510,7 +2524,7 @@ async def test_poller_clears_failure_state_after_success(monkeypatch):
                 raise RuntimeError("redis unavailable")
 
     handler = FlakyHandler()
-    poller = TelegramCommandPoller(notifier=notifier, handler=handler)
+    poller = _make_poller(notifier, handler=handler)
 
     class AssertingClock(FakePollerClock):
         async def _sleep(self, delay):
@@ -2535,6 +2549,186 @@ async def test_poller_clears_failure_state_after_success(monkeypatch):
     assert poller._failures == {}
     assert clock.sleeps == [5.0]
     assert notifier.messages == []
+
+
+# ---------------------------------------------------------------------------
+# 폴러 상태 영속화 (#248)
+# ---------------------------------------------------------------------------
+
+
+def test_poller_defaults_to_redis_state_store(monkeypatch):
+    """상태 저장소를 주입하지 않는 프로덕션 경로는 redis를 쓴다 (#248).
+
+    기본값이 인메모리로 되돌아가면 이 이슈의 중복 창이 조용히 재발한다.
+    """
+    notifier = FakeNotifier()
+    client = object()
+    monkeypatch.setattr(telegram_commands, "create_redis_client", lambda: client)
+
+    poller = TelegramCommandPoller(notifier=notifier, handler=TelegramCommandHandler(notifier=notifier))
+
+    assert isinstance(poller.state_store, telegram_commands.RedisTelegramPollerStore)
+    assert poller.state_store.redis is client
+
+
+@pytest.mark.asyncio
+async def test_poller_restart_does_not_reexecute_updates_handled_ahead_of_poison(monkeypatch):
+    """poison 뒤에서 먼저 실행한 update는 재시작 후에도 다시 실행되지 않는다 (#248).
+
+    이 이슈의 본체다. 영속화 이전에는 blocked 구간(일반 실패 65초, 전송 실패 335초)에
+    프로세스가 죽으면 offset과 _handled_ahead가 함께 사라져 42, 43이 재실행됐다.
+    """
+    notifier = FakeNotifier()
+    notifier.enabled = True
+    notifier.bot_token = "token"
+    handled = []
+    store = InMemoryTelegramPollerStore()
+    batch = [
+        {"update_id": 41, "message": {"chat": {"id": 123}, "text": "/alerts off"}},
+        {"update_id": 42, "message": {"chat": {"id": 123}, "text": "/help"}},
+        {"update_id": 43, "message": {"chat": {"id": 123}, "text": "/trade"}},
+    ]
+
+    class PartialHandler:
+        async def handle_update(self, update):
+            if update["update_id"] == 41:
+                raise RuntimeError("poison update")
+            handled.append(update["update_id"])
+
+    def run_process():
+        """새 폴러 = 새 프로세스. 인메모리 상태는 버리고 store만 넘겨준다."""
+        poller = _make_poller(notifier, handler=PartialHandler(), state_store=store)
+        clock = FakePollerClock(stop_after=1)
+        clock.install(monkeypatch, poller)
+
+        async def fake_get_updates():
+            # 실제 Telegram처럼 offset 이후의 update만 배달한다.
+            offset = poller.offset
+            return [u for u in batch if offset is None or u["update_id"] >= offset]
+
+        monkeypatch.setattr(poller, "_get_updates", fake_get_updates)
+        return poller
+
+    first = run_process()
+    with pytest.raises(asyncio.CancelledError):
+        await first.run()
+
+    # 41은 아직 창 안이라 offset이 멈춰 있고, 42·43은 이미 실행됐다.
+    assert handled == [42, 43]
+    assert first.offset is None
+    assert first._handled_ahead == {42, 43}
+
+    # 프로세스 교체. 41은 여전히 미확정이라 텔레그램이 42·43까지 다시 배달한다.
+    second = run_process()
+    with pytest.raises(asyncio.CancelledError):
+        await second.run()
+
+    assert handled == [42, 43]  # 재실행 없음
+    assert second.offset is None
+    assert second._handled_ahead == {42, 43}
+
+
+@pytest.mark.asyncio
+async def test_poller_restores_offset_across_restart(monkeypatch):
+    """확정된 offset은 재시작 후에도 유지되어 지나간 update를 다시 받지 않는다 (#248)."""
+    notifier = FakeNotifier()
+    notifier.enabled = True
+    notifier.bot_token = "token"
+    store = InMemoryTelegramPollerStore(TelegramPollerState(offset=42, handled_ahead=frozenset()))
+    requested_offsets = []
+
+    class NoopHandler:
+        async def handle_update(self, update):
+            return None
+
+    poller = _make_poller(notifier, handler=NoopHandler(), state_store=store)
+
+    async def fake_get_updates():
+        requested_offsets.append(poller.offset)
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(poller, "_get_updates", fake_get_updates)
+
+    with pytest.raises(asyncio.CancelledError):
+        await poller.run()
+
+    assert requested_offsets == [42]
+
+
+@pytest.mark.asyncio
+async def test_poller_persists_state_after_each_update(monkeypatch):
+    """배치 끝이 아니라 update마다 저장한다 — 배치 중간에 죽어도 기록이 남아야 한다 (#248)."""
+    notifier = FakeNotifier()
+    notifier.enabled = True
+    notifier.bot_token = "token"
+    saved = []
+
+    class NoopHandler:
+        async def handle_update(self, update):
+            return None
+
+    class RecordingStore(InMemoryTelegramPollerStore):
+        async def save(self, state):
+            saved.append(state.offset)
+            await super().save(state)
+
+    poller = _make_poller(notifier, handler=NoopHandler(), state_store=RecordingStore())
+
+    async def fake_get_updates():
+        if poller.offset is not None:
+            raise asyncio.CancelledError
+        return [
+            {"update_id": 41, "message": {"chat": {"id": 123}, "text": "/help"}},
+            {"update_id": 42, "message": {"chat": {"id": 123}, "text": "/help"}},
+        ]
+
+    monkeypatch.setattr(poller, "_get_updates", fake_get_updates)
+
+    with pytest.raises(asyncio.CancelledError):
+        await poller.run()
+
+    assert saved == [42, 43]
+
+
+@pytest.mark.asyncio
+async def test_poller_keeps_polling_when_state_store_fails(monkeypatch, caplog):
+    """redis 장애로 load·save가 실패해도 폴링은 인메모리 상태로 계속된다 (#248).
+
+    fail-closed로 두면 redis 장애가 곧 텔레그램 명령 전면 중단이 된다.
+    """
+    notifier = FakeNotifier()
+    notifier.enabled = True
+    notifier.bot_token = "token"
+    handled = []
+
+    class NoopHandler:
+        async def handle_update(self, update):
+            handled.append(update["update_id"])
+
+    class BrokenStore:
+        async def load(self):
+            raise RuntimeError("redis unavailable")
+
+        async def save(self, state):
+            raise RuntimeError("redis unavailable")
+
+    poller = _make_poller(notifier, handler=NoopHandler(), state_store=BrokenStore())
+
+    async def fake_get_updates():
+        if poller.offset is not None:
+            raise asyncio.CancelledError
+        return [{"update_id": 41, "message": {"chat": {"id": 123}, "text": "/help"}}]
+
+    monkeypatch.setattr(poller, "_get_updates", fake_get_updates)
+
+    with caplog.at_level("ERROR"):
+        with pytest.raises(asyncio.CancelledError):
+            await poller.run()
+
+    assert handled == [41]
+    assert poller.offset == 42
+    assert "상태 복원 실패" in caplog.text
+    assert "상태 저장 실패" in caplog.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 📝 개요

#241(PR #242)이 head-of-line blocking을 없애면서 poison 뒤의 update를 선행 실행하게 됐다.
중복은 `_handled_ahead`가 막지만, `offset`과 `_handled_ahead`가 **둘 다 인메모리**라 이 구간에
프로세스가 죽으면 이미 실행한 update들이 "서버에는 미확정" 상태로 남아 전부 재배달·재실행된다.

```
재시작 전: executed={42: 1, 43: 1}  offset=None  handled_ahead={42, 43}
재시작 후: executed={42: 2, 43: 2}  offset=44
→ 42, 43 중복 실행
```

창의 길이는 재시도 예산과 같아 **일반 poison 65초 / 전송 실패 335초**다. 시간 기반 예산으로
바꾸면서 기존 10초(고정 5초 × 3회)보다 크게 넓어졌다.

**이 창이 실제로 열리는 조건은 좁다.** `_handled_ahead`는 `blocked`가 이미 True일 때만 채워지므로
poison이 프로세스 사망보다 **먼저, 같은 프로세스 안에서** 일어나야 한다. 따라서 "배포가 429와
재시작을 동시에 유발한다"(이슈 #248의 서술)는 성립하지 않는다 — 배포가 자극하는 rate limit은
재시작 **이후** 새 프로세스에서 일어나고, 배포는 자기가 죽이는 프로세스의 poison을 만들 수 없다.

**애초에 이 레포에는 배포가 없다.** CD도(`ci.yml`은 테스트·린트만 한다), `restart:` 정책도,
프로덕션 compose도 없다. 실제 재시작 계기는 `backend/Dockerfile`의 **`uvicorn --reload`** 와
`.:/app` bind mount다 — 마운트된 트리의 파일이 바뀌면(저장, `git checkout` 등) 프로세스가
재시작하고 `lifespan`이 `stop_telegram_commands()` → 태스크 cancel을 거친다. 이 PR이 다루는
바로 그 취소 지점이다.

그래서 창이 열리는 조건은 **봇을 실제로 쓰는 구간과 마운트 트리가 변경되는 구간이 겹칠 때**다.
드물지만, 겹치는 순간에는 세 조건이 한꺼번에 쉬워진다 — 코드를 만지는 중이면 핸들러 예외
(= poison)도 흔하고 재시작은 파일 하나 저장으로 일어난다. 반대로 `restart:` 정책이 없다는 것은
크래시 루프가 성립하지 않는다는 뜻이기도 하다.

**그래서 이 PR의 근거는 확률이 아니라 비용 대비다.** `_handled_ahead`는 Telegram이 원리적으로
보호해줄 수 없는 유일한 상태다 — 서버는 "확정하지 않은 update"만 알 뿐, 그중 무엇을 이미 실행했는지
알 방법이 없다. 반면 영속화 비용은 이미 쓰는 키에 필드 하나이고, long-polling이라 유휴 시 쓰기는
0이다. 확률이 낮아도 방어하지 않을 이유가 없다.

정확히 하면 **영속화의 내용물은 `_handled_ahead`다.** offset은 `_get_updates`가 실어 보내는 순간
서버가 `< offset`을 삭제하므로 redis와 서버가 갈라지는 구간이 배치 하나뿐이다. offset을 함께 쓰는
것은 두 값의 일관성 때문이고, 단일 키 결정이 그래서 더 옳다.

두 값을 redis에 함께 영속화해 창을 "실행 완료 → redis 쓰기" 사이로 좁혔다.

## 🚀 변경 사항

- **`RedisTelegramPollerStore` 신설** (`backend/redis_state.py`).
  `offset`과 `handled_ahead`를 `finus:telegram:poller_state` **한 키에 JSON 한 덩어리**로 쓴다.
  키를 나누면 offset만 전진하고 handled_ahead 정리는 유실된 절반 상태가 생기는데, 그게 정확히
  이 이슈가 막으려는 중복 실행의 원인이다. 폴러는 단일 인스턴스라 원자적 SET 하나로 둘의
  일관성이 보장된다. TTL 7일 — 텔레그램이 미확정 update를 24시간만 보관하므로 값의 유효기간이
  아니라 폴러가 영구히 내려간 뒤 남는 키를 정리하는 장치다. 쓰기는 update를 처리할 때만
  일어나므로 7일 유휴면 만료되는데, 그 시점엔 보호할 미확정 update도 없어 무해하다.
- **`load()`의 방어**: 손상된 값은 키를 지우고 빈 상태로 떨어진다. 남겨두면 매 재시작마다 같은
  실패를 반복하며 그때마다 offset이 처음으로 되감긴다. 타입도 검증한다 — 특히 `bool`은 `int`의
  하위 타입이라 `isinstance`만으로는 통과하는데, `offset=true`가 새면 getUpdates가 `offset=1`로
  해석해 24시간치 update를 통째로 재배달한다. (리뷰 반영으로 음수 offset·falsy 비-list·길이
  상한·삭제 실패까지 확장됐다 — 상세는 리뷰 답변 코멘트 참조.)
- **`run()`에 복원·저장 배선** (`backend/telegram_commands.py`).
  시작 시 `_restore_state()`, 상태가 바뀌는 **update마다** `_persist_state()`.
  배치 끝으로 미루면 중간에 죽었을 때 이미 실행한 update의 기록이 통째로 사라져 영속화의 의미가
  없다. 쓰기는 전체 상태를 매번 덮어쓰므로 한 번 실패해도 다음 쓰기가 따라잡는다.
- **fail-open**: load/save 실패는 삼키고 인메모리 상태로 폴링을 계속한다. 호출은
  `asyncio.wait_for`(3초)로 감싼다 — `create_redis_client()`에 소켓 타임아웃이 없어, 없으면
  redis hang이 폴러 태스크를 통째로 멈춰 fail-open이 **fail-hang**으로 무너진다.
  `RedisPendingOrderStore`의 fail-closed와 갈리는 근거는 "redis가 죽었을 때 무엇이 중복될 수
  있는가"다. 답은 **아무것도 없다** — 그 상태에서 `claim`과 `set_if_absent`는 보호하는 게 아니라
  예외를 던지고, 호출부가 "주문 저장소 오류"로 끝낸다. 즉 주문이 생성·체결될 수 없으므로
  중복될 금전 부수효과가 아예 없고 남는 위험은 LLM 재호출뿐인 반면, fail-closed로 두면
  redis 장애가 곧 **텔레그램 명령 전면 중단**이 된다.
- **`state_store` 기본값은 redis**. 프로덕션 경로(`TelegramCommandPoller()`)가 주입 없이도 옳도록
  했고, 기본값이 인메모리로 되돌아가면 이 창이 조용히 재발하므로 테스트로 고정했다.
- **변경하지 않은 것**: 재시도 예산(`_UpdateFailure`)은 영속화하지 않는다. 유실돼도 poison 폐기가
  미뤄질 뿐 중복 실행으로 이어지지 않아 매 update 쓰기에 얹을 값이 아니다.

### `_handled_ahead`를 없앨 것인가 (이슈에서 제기된 질문)

**유지하기로 했다.** poison이 offset을 잡아두는 한 그보다 뒤의 update는 **반드시 재배달**되므로,
재실행을 막는 층은 이것뿐이다. 없애려면 poison을 로컬 큐에 담고 offset을 먼저 전진시켜야 하는데,
그러면 poison이 프로세스와 함께 사라진다.

여기서 "poison 유실"이 결정적 반박은 아니라는 점은 짚어둔다 — 시스템은 이미 poison을 버리는 정책을
갖고 있다. 예산이 소진되면 `SKIPPED`로 폐기하고 `UPDATE_SKIPPED_NOTICE`를 보낸다. 즉 유실은 설계가
이미 ≤335초 뒤에 수용하는 결과이고, **차이는 시점이 아니라 통지 유무**다. 금융 명령에서 "통지 없이
조용히 사라짐"과 "통지와 함께 폐기됨"은 다르므로 유지 쪽을 택했다. 영속화 비용이 이미 쓰는 키에
필드 하나라 사실상 0인 것도 같은 방향이다.

대안으로 **#241 이전으로 되돌려 poison에서 배치를 중단하는 것**(창이 아예 없음)이 있다. 단일 채팅·단일
프로세스라 #241이 사는 것은 "내 다음 명령이 최대 335초 늦어지는 것"을 피하는 정도이므로, 3단 상태
기계의 유지 비용이 계속 누적되면 재검토 후보다. 이 PR에서 되돌리자는 뜻은 아니다.

정렬(`sorted`)도 그대로 둔다. 물막이가 "미해결 update를 먼저 만난다"는 전제 위에 성립하는 한
전제를 코드로 제거해 둔 상태를 되돌릴 이유가 없다.

### 남은 창

0이 아니라 **"실행 완료 → redis 쓰기" 사이**로 좁혀졌다. 순서를 뒤집어 실행 전에 기록하면 중복
대신 유실(기록만 남고 실행 안 됨)이 되는데, 여기서는 at-least-once가 낫다 — 중복의 실질 비용은
LLM 재호출과 중복 메시지인 반면, 유실은 사용자의 명령이 아무 흔적 없이 사라지는 것이다.

### 테스트

이슈가 **미커버로 지목한 재시작 중복 시나리오**를, 같은 `state_store`를 두 폴러 인스턴스에
공유하는 방식으로 재현했다(인스턴스 교체 = 프로세스 재시작, redis는 생존).

| 테스트 | 검증 |
| --- | --- |
| `test_poller_restart_does_not_reexecute_updates_handled_ahead_of_poison` | **이 이슈의 본체.** poison 뒤에서 먼저 실행한 42·43이 재시작 후 재배달돼도 다시 실행되지 않음 |
| `test_poller_restores_offset_across_restart` | 확정된 offset이 재시작 후 getUpdates에 그대로 실림 |
| `test_poller_persists_state_after_each_update` | 배치 끝이 아니라 update마다 저장 |
| `test_poller_keeps_polling_when_state_store_fails` | load·save가 모두 터져도 폴링 지속 + 양쪽 로그 |
| `test_poller_defaults_to_redis_state_store` | 주입 없는 프로덕션 경로가 redis를 씀 (기본값 회귀 가드) |
| `test_poller_state_round_trips_offset_and_handled_ahead` | 왕복 + **단일 키** + TTL |
| `test_poller_state_load_drops_corrupted_value` | 손상값을 지우고 빈 상태로 |
| `test_poller_state_load_rejects_wrong_types` (10 params) | `offset` 의 `"42"`/`true`/`-1`/거대 양수, `handled_ahead` 의 `"42"`/`["42"]`/`[true]`/`false`/`0`/`""` |
| `test_poller_keeps_polling_when_state_store_hangs` | 저장소가 예외 대신 **hang**해도 폴링 지속 (fail-hang 가드) |
| `test_poller_state_save_warns_when_handled_ahead_nears_limit` | 상한 50% 초과 시 경고 — 상한은 load에만 걸려 있어 신호가 필요하다 |
| `test_poller_state_load_keeps_realistic_handled_ahead_size` | 도달 가능한 6,700은 통과 (상한이 정상 상태를 버리지 않음) |
| `test_poller_state_save_overwrites_whole_state` | 전체 덮어쓰기 — 이전 쓰기 실패를 따라잡음 |
| `test_real_redis_poller_state_survives_a_new_store_instance` | 실제 redis 왕복·TTL (통합, `REDIS_INTEGRATION_URL` 필요) |

기존 폴러 테스트 19개는 `_make_poller` 헬퍼로 인메모리 저장소를 주입하도록 바꿨다 —
`state_store` 기본값이 redis 클라이언트라 주입하지 않으면 테스트가 실제 연결을 시도한다.
**단언은 한 줄도 바꾸지 않았다.**

```
backend/tests/test_telegram_commands.py  →  122 passed
backend/tests/                           →  479 passed, 3 skipped, 6 subtests passed
```

> skip 3건은 `REDIS_INTEGRATION_URL` 미설정으로 인한 redis 통합 테스트다(신규 1건 포함).

### 뮤테이션 검증

새 테스트가 실제로 회귀를 잡는지 코드를 일부러 깨뜨려 확인했다 (검증용이며 커밋에 포함되지 않음).

| 뮤테이션 | 결과 |
| --- | --- |
| `await self._persist_state()` 제거 | `test_poller_restart_does_not_reexecute_updates_handled_ahead_of_poison`, `test_poller_persists_state_after_each_update` **FAILED** |
| `_restore_state`가 `handled_ahead`를 복원하지 않음 | `test_poller_restart_does_not_reexecute_updates_handled_ahead_of_poison` **FAILED** — 재시작 후 42·43이 실제로 재실행됨 |
| `save()`가 `handled_ahead`를 버리고 offset만 저장 | `test_poller_state_round_trips_offset_and_handled_ahead` **FAILED** |
| `offset`의 `bool` 검사 제거 | `test_poller_state_load_rejects_wrong_types[{"offset": true}]` **FAILED** |
| `asyncio.wait_for` 제거 | `test_poller_keeps_polling_when_state_store_hangs` **20초 타임아웃 (hang)** |

## 🔗 관련 이슈
- Related to #248
- Closes #248
- PR #242 리뷰 4번, 후속 리뷰 🟡-2에서 파생

## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [ ] 변경 사항에 대한 문서(README 등)를 업데이트했나요? — redis 키를 나열한 문서가 없어 영향 없음. 근거는 코드 주석에 인라인으로 남겼다

## 📸 스크린샷 (선택 사항)

없음 — 백엔드 내부 동작 변경.
