### PR TITLE
feat: nginx에 /api·/health 리버스 프록시를 추가해 same-origin으로 전환 (#245)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,8 @@ VISUALIZATION_URL=http://100.x.y.z:8080/
 # Security
 # Unity WebGL 대시보드는 docker compose의 frontend(nginx)가 8080으로 서빙합니다.
 # 다른 호스트/포트에서 열어야 하면 쉼표로 구분해 추가하세요.
+# nginx가 /api를 backend로 프록시하지만(#245), 현재 번들은 아직 8000번을 직접 호출하므로
+# 이 목록이 필요합니다. 번들이 상대 경로로 바뀌면(#246) same-origin이 되어 불필요해집니다.
 ALLOW_ORIGINS=http://localhost:8080,http://127.0.0.1:8080
 
 # Mem0 API Key를 발급받아 입력하세요

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ bash scripts/run_stack.sh
 | `finus-nat` | 8001 | 멀티 에이전트 엔진 |
 | `redis` | 6379 | 신호 중복 방지 캐시 |
 
-- `frontend`(nginx)는 `/api/`와 `/health`를 `backend:8000`으로 프록시하므로, 대시보드와 API가 브라우저에서 같은 오리진(8080)입니다. 8000 포트는 API 직접 호출과 `/docs`용으로 계속 열려 있습니다. 자세한 내용은 [`frontend/README.md`](frontend/README.md)를 참고하세요.
+- `frontend`(nginx)는 `/api/`와 `/health`를 `backend:8000`으로 프록시합니다. 이 경로로 부르면 대시보드와 API가 브라우저에서 같은 오리진(8080)이 됩니다. **다만 현재 Unity 번들은 아직 `http://localhost:8000`을 하드코딩해 8000번을 직접 호출하므로, 실제로 same-origin이 되는 것은 번들이 상대 경로를 쓰게 되는 #246 이후입니다.** 그전까지는 `ALLOW_ORIGINS`가 계속 필요합니다. 8000 포트는 API 직접 호출과 `/docs`용으로도 열려 있습니다. 자세한 내용은 [`frontend/README.md`](frontend/README.md)를 참고하세요.
 - `backend`는 `finus-nat`과 `redis`가 정상(healthy)이 된 뒤에 뜹니다. `finus-nat`은 준비되는 대로 healthy가 되며, 처음 90초 동안은 헬스체크가 실패해도 재시도로 세지 않습니다(`docker-compose.yml`의 `start_period`). 90초가 지난 뒤에도 응답이 없으면 15초 간격으로 10번 더 확인한 뒤 unhealthy로 판정하므로, 최악의 경우 약 4분 뒤에 `backend` 기동이 중단됩니다.
 - 로컬에서 `uvicorn --reload`만 쓰고 싶다면 볼륨 마운트된 소스로 호스트에서 실행하면 됩니다.
 

--- a/README.md
+++ b/README.md
@@ -194,11 +194,12 @@ bash scripts/run_stack.sh
 
 | 서비스 | 포트 | 역할 |
 | :--- | :--- | :--- |
-| `frontend` | 8080 | Unity WebGL 대시보드 (nginx 정적 서빙) |
+| `frontend` | 8080 | Unity WebGL 대시보드 (nginx 정적 서빙 + `/api` 프록시) |
 | `backend` | 8000 | API·스케줄러·텔레그램 봇 |
 | `finus-nat` | 8001 | 멀티 에이전트 엔진 |
 | `redis` | 6379 | 신호 중복 방지 캐시 |
 
+- `frontend`(nginx)는 `/api/`와 `/health`를 `backend:8000`으로 프록시하므로, 대시보드와 API가 브라우저에서 같은 오리진(8080)입니다. 8000 포트는 API 직접 호출과 `/docs`용으로 계속 열려 있습니다. 자세한 내용은 [`frontend/README.md`](frontend/README.md)를 참고하세요.
 - `backend`는 `finus-nat`과 `redis`가 정상(healthy)이 된 뒤에 뜹니다. `finus-nat`은 준비되는 대로 healthy가 되며, 처음 90초 동안은 헬스체크가 실패해도 재시도로 세지 않습니다(`docker-compose.yml`의 `start_period`). 90초가 지난 뒤에도 응답이 없으면 15초 간격으로 10번 더 확인한 뒤 unhealthy로 판정하므로, 최악의 경우 약 4분 뒤에 `backend` 기동이 중단됩니다.
 - 로컬에서 `uvicorn --reload`만 쓰고 싶다면 볼륨 마운트된 소스로 호스트에서 실행하면 됩니다.
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -110,6 +110,9 @@ def is_placeholder_secret(value: str | None) -> bool:
 
 # CORS 설정
 # 기본값은 docker-compose의 frontend(nginx)가 Unity WebGL 번들을 서빙하는 8080 오리진이다.
+# #245로 nginx가 /api를 backend로 프록시하므로, 번들이 상대 경로를 쓰기 시작하면(#246,
+# WebGL 재빌드 필요) 브라우저 요청은 same-origin이 되어 CORS 자체가 개입하지 않는다.
+# 현재 번들은 아직 8000번을 직접 호출하므로 이 목록이 계속 필요하다.
 _ALLOW_ORIGINS_RAW = os.getenv("ALLOW_ORIGINS", "http://localhost:8080,http://127.0.0.1:8080")
 ALLOW_ORIGINS = [origin.strip() for origin in _ALLOW_ORIGINS_RAW.split(",") if origin.strip()]
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI, Query, Depends, WebSocket, WebSocketDisconnect, Bod
 from fastapi.middleware.cors import CORSMiddleware
 from sqlmodel import Session, select
 
-from .config import NAT_BASE_URL, NEWS_MCP_PARAMS, TRADING_MCP_PARAMS, DART_MCP_PARAMS, ALLOW_ORIGINS
+from .config import NEWS_MCP_PARAMS, TRADING_MCP_PARAMS, DART_MCP_PARAMS, ALLOW_ORIGINS
 from .ws_manager import manager
 from .scheduler import start_scheduler, stop_scheduler
 from .telegram_commands import start_telegram_commands, stop_telegram_commands
@@ -278,7 +278,10 @@ async def create_db_diary(
 
 @app.get("/health", tags=["System"])
 async def health_check():
-    return {"status": "alive", "nat_base_url": NAT_BASE_URL}
+    # nat_base_url(내부 서비스 주소)은 싣지 않는다. #245로 nginx가 /health를 8080으로도
+    # 중계하면서 내부 토폴로지가 외부에 노출되는 경로가 생겼다. compose 헬스체크는
+    # 상태코드만 보고, 이 필드를 읽는 코드도 없다(PR #252 리뷰).
+    return {"status": "alive"}
 
 
 @app.websocket("/api/v1/ws")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,10 @@
 services:
-  # Unity WebGL 빌드(frontend/Build)를 정적 서빙한다. file://로는 로더가 동작하지 않아
-  # HTTP 서빙이 필수다(frontend/README.md 참고). 정적 파일만 내보내므로 backend에
-  # 의존하지 않는다 — 브라우저가 8000번의 backend를 따로 직접 호출한다.
+  # Unity WebGL 빌드(frontend/Build)를 정적 서빙하고, /api·/health는 같은 네트워크의
+  # backend:8000으로 프록시한다(#245). file://로는 로더가 동작하지 않아 HTTP 서빙이
+  # 필수다(frontend/README.md 참고).
+  # depends_on은 일부러 두지 않는다 — nginx.conf가 proxy_pass에 변수를 써서 backend
+  # 이름을 요청 시점에 해석하므로, backend가 아직 없어도 nginx는 뜨고 정적 화면이 먼저
+  # 보인다. backend를 기다리게 만들면 그 이점이 사라진다.
   frontend:
     image: nginx:alpine
     ports:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -92,12 +92,30 @@ docker compose up frontend
 | 문서 루트 | `./frontend/Build` → `/usr/share/nginx/html` (읽기 전용 `:ro`) |
 | nginx 설정 | `./frontend/nginx.conf` → `/etc/nginx/conf.d/default.conf` (읽기 전용) |
 | `.wasm` MIME | `application/wasm` (`nginx.conf`에서 명시) |
-| backend 의존 | 없음 — 정적 파일만 내보내고, 브라우저가 8000번 backend를 직접 호출합니다 |
+| API 프록시 | `/api/`·`/health` → `http://backend:8000` (이슈 #245) |
+| backend 의존 | `depends_on` 없음 — backend가 아직 없어도 nginx는 뜨고 정적 화면이 먼저 보입니다 |
 
-브라우저가 8080에서 8000번 backend를 호출하므로 backend의 CORS 허용 오리진에
-`http://localhost:8080`이 포함돼야 합니다 (`backend/config.py`의 `ALLOW_ORIGINS` 기본값,
-`.env.example` 참고). 다른 호스트(예: Tailscale 주소)로 시연할 때는 해당 오리진을
-`ALLOW_ORIGINS`에 추가하세요.
+### `/api` 리버스 프록시 (#245)
+
+`nginx.conf`가 `/api/`와 `/health`를 같은 compose 네트워크의 `backend:8000`으로
+프록시합니다. 브라우저 입장에서는 대시보드와 API가 **같은 오리진(8080)**이므로 CORS가
+개입하지 않고, 어떤 주소로 열든(로컬·Tailscale·리버스 프록시 뒤) 그대로 동작합니다.
+
+`proxy_pass`에는 상수 대신 변수(`set $backend_upstream backend:8000;`)를 씁니다. 상수
+호스트명이면 nginx가 **기동 시점에** 이름을 해석하고 실패 시 아예 뜨지 않아 `depends_on`이
+필요해지는데, 변수를 쓰면 Docker 내장 DNS(`resolver 127.0.0.11`)로 **요청 시점에** 해석하므로
+backend를 기다리지 않아도 됩니다. backend가 없는 동안 `/api` 호출만 502가 납니다.
+
+`/api/v1/ws`(WebSocket)는 `map $http_upgrade $connection_upgrade`로 업그레이드 헤더를
+조건부 중계합니다. `/api/v1/analyze`는 LLM 호출로 오래 걸려 `proxy_read_timeout`을 300s로
+올려 뒀습니다.
+
+> **CORS 설정은 아직 남겨 둡니다.** 현재 Unity 번들은 `http://localhost:8000`을 하드코딩해
+> 여전히 8000번을 직접 호출합니다. 번들이 상대 경로를 쓰도록 바뀌는 시점(이슈 #246,
+> WebGL 재빌드 필요)부터 프록시 경로만 타게 되며, 그때 `ALLOW_ORIGINS` 수동 관리가
+> 실제로 사라집니다. 그전까지는 backend의 CORS 허용 오리진에 `http://localhost:8080`이
+> 포함돼야 하고(`backend/config.py`의 `ALLOW_ORIGINS` 기본값, `.env.example` 참고),
+> 다른 호스트(예: Tailscale 주소)로 시연할 때는 해당 오리진을 `ALLOW_ORIGINS`에 추가하세요.
 
 현재 번들은 비압축입니다(`Build/`에 `.br`·`.gz` 산출물 없음).
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -104,7 +104,13 @@ docker compose up frontend
 `proxy_pass`에는 상수 대신 변수(`set $backend_upstream backend:8000;`)를 씁니다. 상수
 호스트명이면 nginx가 **기동 시점에** 이름을 해석하고 실패 시 아예 뜨지 않아 `depends_on`이
 필요해지는데, 변수를 쓰면 Docker 내장 DNS(`resolver 127.0.0.11`)로 **요청 시점에** 해석하므로
-backend를 기다리지 않아도 됩니다. backend가 없는 동안 `/api` 호출만 502가 납니다.
+backend를 기다리지 않아도 됩니다. backend가 없는 동안에는 `/api/` 호출만 502(이름 해석 실패·
+연결 거부) 또는 504(`proxy_connect_timeout 5s` 만료, 재시작 중 stale IP로 향한 경우)가 납니다.
+슬래시 없는 `/api`는 `location /api/` 프리픽스에 걸리지 않아 정적 라우트의 404입니다.
+
+`frontend` 서비스에 healthcheck를 추가할 일이 생기면 `/health`가 아니라 **`/nginx-health`**를
+쓰세요. `/health`는 backend로 프록시되므로, backend가 죽으면 frontend까지 unhealthy가 되어
+`depends_on`을 뺀 위 설계가 그대로 무효가 됩니다.
 
 `/api/v1/ws`(WebSocket)는 `map $http_upgrade $connection_upgrade`로 업그레이드 헤더를
 조건부 중계합니다. `/api/v1/analyze`는 LLM 호출로 오래 걸려 `proxy_read_timeout`을 300s로

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -18,9 +18,35 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # nginx가 스스로 내는 리다이렉트(예: /api → /api/ 자동 슬래시 보정)를 상대 경로로
+    # 낸다. 기본값 on이면 Location을 절대 URL로 만들면서 server_name(_)과 리스닝 포트
+    # 기준으로 조립해 "http://localhost/api/"처럼 실제 포트(8080)가 빠진다.
+    # proxy_set_header Host에서 $http_host를 쓴 것과 같은 이유다(실측 확인).
+    absolute_redirect off;
+
     # nginx:alpine 기본값이 on이라 Server 헤더와 에러 페이지에 버전이 그대로 나간다.
     # 이 설정은 backend 미기동 시의 502 페이지에도 적용된다(PR #252 리뷰).
     server_tokens off;
+
+    # 프록시 응답에도 붙도록 always를 준다(4xx·5xx에는 always 없이는 안 붙는다).
+    # CSP는 Unity WebGL 로더가 unsafe-eval을 요구하므로 별도 검증 후에 다룬다.
+    add_header X-Frame-Options SAMEORIGIN always;
+    add_header X-Content-Type-Options nosniff always;
+    add_header Referrer-Policy strict-origin-when-cross-origin always;
+
+    # nginx 자체 생존 확인용. /health는 backend로 프록시되므로 frontend의 healthcheck로
+    # 쓰면 backend가 죽었을 때 frontend까지 unhealthy가 되고, depends_on을 일부러 뺀
+    # 이 설정의 취지가 무효가 된다. compose에 frontend healthcheck를 넣게 되면
+    # 반드시 이 경로를 쓸 것(PR #252 리뷰).
+    # Content-Type은 add_header가 아니라 default_type으로 준다. location 레벨에
+    # add_header를 하나라도 두면 상위(server)의 add_header 집합 전체가 상속되지 않아
+    # 위 보안 헤더 3종이 이 응답에서만 빠진다. add_header는 교체가 아니라 추가라서
+    # Content-Type이 두 번 나가기도 한다(실측 확인).
+    location = /nginx-health {
+        access_log off;
+        default_type text/plain;
+        return 200 "ok\n";
+    }
 
     # --- backend 리버스 프록시 (#245) ---
     #
@@ -37,6 +63,11 @@ server {
     #
     # proxy_pass에 변수를 쓰고 URI 부분을 적지 않으면 원본 요청 URI가 그대로 전달된다.
     # 즉 /api/v1/portfolio → http://backend:8000/api/v1/portfolio.
+    #
+    # ⚠️ 아래 proxy_pass에 URI를 절대 붙이지 말 것. 상수 proxy_pass와 달리 변수 형태에서
+    # URI를 적으면(예: http://$backend_upstream/) location 프리픽스 치환이 아니라 요청
+    # URI 전체가 그 값으로 대체되어, 모든 요청이 backend의 /로 간다. 슬래시 하나로
+    # 전부 깨지는 자리다(PR #252 리뷰).
     resolver 127.0.0.11 ipv6=off valid=10s;
 
     # 프록시 공통 헤더·타임아웃. 정적 location은 프록시를 타지 않으므로 영향이 없다.
@@ -51,6 +82,12 @@ server {
     # X-Forwarded-For 뒤에 이어붙이므로, 공격자가 헤더를 위조하면 backend가 받는
     # 첫 값이 위조값이 된다. 이 구성에서는 nginx가 최앞단이라 덮어쓰는 쪽이 맞다.
     # 앞단에 CDN·LB를 두게 되면 $proxy_add_x_forwarded_for로 되돌려야 한다(PR #252 리뷰).
+    #
+    # 다만 지금 이 두 헤더는 backend에 도달해도 소비되지 않는다. uvicorn의
+    # forwarded_allow_ips 기본값이 127.0.0.1이라 compose 네트워크(172.x)에서 오는 nginx
+    # 연결은 신뢰 대상이 아니고, backend 코드에도 request.client·X-Forwarded·root_path
+    # 사용처가 없다. 즉 아래 두 줄은 동작 중인 보호가 아니라 장래 대비다. 실제로
+    # 쓰려면 backend/Dockerfile의 uvicorn CMD에 --forwarded-allow-ips가 필요하다.
     proxy_set_header X-Forwarded-For $remote_addr;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header Upgrade $http_upgrade;

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,5 +1,15 @@
-# Unity WebGL 번들(frontend/Build) 정적 서빙 설정.
+# Unity WebGL 번들(frontend/Build) 정적 서빙 + backend API 리버스 프록시 설정.
 # docker-compose.yml의 frontend 서비스가 /etc/nginx/conf.d/default.conf로 마운트한다.
+# 이 파일은 nginx 기본 nginx.conf의 http 블록 안에서 include되므로, 아래 map·server는
+# 모두 http 컨텍스트에 놓인다.
+
+# WebSocket 업그레이드 중계용. Connection: upgrade를 무조건 박으면 평범한 GET에도
+# 빈 Upgrade 헤더와 함께 나가므로, 클라이언트가 실제로 업그레이드를 요청했을 때만 보낸다.
+# /api/v1/ws(backend/main.py)가 이 경로를 탄다.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
 
 server {
     listen 80;
@@ -7,6 +17,51 @@ server {
 
     root /usr/share/nginx/html;
     index index.html;
+
+    # --- backend 리버스 프록시 (#245) ---
+    #
+    # 브라우저가 8000번을 직접 부르던 cross-origin 구조를 same-origin으로 바꾼다.
+    # 대시보드를 어떤 오리진(localhost·Tailscale·리버스 프록시 뒤)으로 열든 API 호출이
+    # 같은 오리진의 /api/로 나가므로 CORS가 개입하지 않고, ALLOW_ORIGINS를 오리진마다
+    # 손으로 늘릴 필요도 없어진다.
+    #
+    # frontend에 depends_on을 붙이지 않으려고 proxy_pass에 변수를 쓴다. 상수 호스트명을
+    # 쓰면 nginx가 기동 시점에 backend를 해석하고 실패하면 아예 뜨지 않는데, 변수를 쓰면
+    # 요청 시점에 resolver로 해석하므로 backend가 아직 없어도 정적 화면은 먼저 뜬다
+    # (그동안 /api 호출만 502). 127.0.0.11은 Docker 내장 DNS다. Docker DNS의 AAAA 응답에
+    # 기대지 않도록 ipv6=off를 둔다.
+    #
+    # proxy_pass에 변수를 쓰고 URI 부분을 적지 않으면 원본 요청 URI가 그대로 전달된다.
+    # 즉 /api/v1/portfolio → http://backend:8000/api/v1/portfolio.
+    resolver 127.0.0.11 ipv6=off valid=10s;
+
+    # 프록시 공통 헤더·타임아웃. 정적 location은 프록시를 타지 않으므로 영향이 없다.
+    proxy_http_version 1.1;
+    # $host가 아니라 $http_host다. $host는 포트를 떼므로 backend가 보는 Host가
+    # "localhost"가 되고, FastAPI가 trailing slash 등으로 307을 낼 때 Location이
+    # http://localhost/... 로 나가 포트(8080)가 사라진다. $http_host는 클라이언트가
+    # 보낸 host:port를 그대로 넘긴다.
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_connect_timeout 5s;
+    proxy_send_timeout 300s;
+    # /api/v1/analyze는 LLM·멀티 에이전트 호출이라 기본 60s로는 짧다.
+    proxy_read_timeout 300s;
+
+    location /api/ {
+        set $backend_upstream backend:8000;
+        proxy_pass http://$backend_upstream;
+    }
+
+    # 예전 vite dev server가 /api와 함께 프록시하던 경로. backend/main.py의 /health다.
+    location = /health {
+        set $backend_upstream backend:8000;
+        proxy_pass http://$backend_upstream;
+    }
 
     # Unity 로더는 .wasm을 WebAssembly.instantiateStreaming으로 받으므로 Content-Type이
     # 정확히 application/wasm이어야 한다(frontend/README.md 참고). nginx 1.21.5+ 기본

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -18,6 +18,10 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # nginx:alpine 기본값이 on이라 Server 헤더와 에러 페이지에 버전이 그대로 나간다.
+    # 이 설정은 backend 미기동 시의 502 페이지에도 적용된다(PR #252 리뷰).
+    server_tokens off;
+
     # --- backend 리버스 프록시 (#245) ---
     #
     # 브라우저가 8000번을 직접 부르던 cross-origin 구조를 same-origin으로 바꾼다.
@@ -43,7 +47,11 @@ server {
     # 보낸 host:port를 그대로 넘긴다.
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    # $proxy_add_x_forwarded_for가 아니라 $remote_addr다. 전자는 클라이언트가 보낸
+    # X-Forwarded-For 뒤에 이어붙이므로, 공격자가 헤더를 위조하면 backend가 받는
+    # 첫 값이 위조값이 된다. 이 구성에서는 nginx가 최앞단이라 덮어쓰는 쪽이 맞다.
+    # 앞단에 CDN·LB를 두게 되면 $proxy_add_x_forwarded_for로 되돌려야 한다(PR #252 리뷰).
+    proxy_set_header X-Forwarded-For $remote_addr;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $connection_upgrade;


### PR DESCRIPTION
## 📝 개요

nginx가 `/api/`·`/health`를 같은 compose 네트워크의 `backend:8000`으로 프록시하도록 해서, 브라우저 입장에서 대시보드와 API를 **같은 오리진(8080)**에 둡니다.

지금까지는 #243으로 Unity 번들은 nginx(8080)가, API는 backend(8000)가 서빙하는 cross-origin 구조였고, 접속하는 오리진마다 `ALLOW_ORIGINS`에 손으로 추가해야 했습니다. 프록시를 두면 로컬이든 Tailscale 주소든 리버스 프록시 뒤든 API 호출이 같은 오리진의 `/api/`로 나가므로 CORS가 아예 개입하지 않습니다.

이슈 #245의 "할 일" 4개 중 결정 항목들을 아래와 같이 정했습니다.

| 결정 사항 | 결론 |
| :--- | :--- |
| 프록시 도입 여부 | **도입** |
| `depends_on` 복원 vs `resolver` 회피책 | **`resolver` 회피책** — `depends_on` 추가하지 않음 |
| `/api/v1/ws` 업그레이드 동작 | **확인 완료** (아래 검증 표) |
| #246 방향 | **"하드코딩을 상대 경로로 교체 + WebGL 재빌드"로 축소 확정** |

### `depends_on` 대신 `resolver`를 고른 이유

`proxy_pass`에 상수 호스트명을 쓰면 nginx가 **기동 시점에** `backend`를 해석하고, 실패하면 아예 뜨지 않습니다. 그러면 #243에서 "정적 파일이라 backend에 의존하지 않는다"며 뗀 `depends_on`을 되돌려야 하고, backend가 healthy가 될 때까지 정적 화면조차 못 보게 됩니다.

대신 `proxy_pass`에 변수(`set $backend_upstream backend:8000;`)를 쓰고 Docker 내장 DNS(`resolver 127.0.0.11`)로 **요청 시점에** 해석하게 했습니다. backend가 아직 없어도 nginx는 뜨고 정적 화면이 먼저 보이며, 그동안 `/api` 호출만 502가 납니다. 이슈에서 "검토 필요"로 남겨 둔 회피책이 실제로 동작하는 것을 실측으로 확인했습니다.

### ⚠️ `ALLOW_ORIGINS`는 이 PR에서 제거하지 않습니다

현재 Unity 번들이 `http://localhost:8000`을 하드코딩해 **여전히 8000번을 직접 호출**하기 때문입니다. 번들이 상대 경로를 쓰도록 바뀌는 시점(#246, WebGL 재빌드 필요)부터 프록시만 타게 되며, 그때 `ALLOW_ORIGINS` 수동 관리가 실제로 사라집니다. 이 사정을 `.env.example`·`backend/config.py`·두 README에 주석으로 남겼습니다.

같은 이유로 **Unity C# 소스도 건드리지 않았습니다.** `frontend/README.md`가 `frontend/Assets/` 수정 시 WebGL 재빌드 후 `Build/`를 함께 커밋하도록 요구하는데, 그게 정확히 #246의 범위이고 `cbab593`에서 한 번 되돌린 이유입니다.

## 🚀 변경 사항

- `frontend/nginx.conf` — `/api/`·`/health`를 `http://backend:8000`으로 프록시
  - `resolver 127.0.0.11 ipv6=off valid=10s` + 변수 `proxy_pass`로 기동 시점 DNS 해석 회피
  - `map $http_upgrade $connection_upgrade`로 `/api/v1/ws` 업그레이드를 **조건부** 중계 (무조건 `Connection: upgrade`를 박으면 평범한 GET에도 빈 `Upgrade` 헤더가 나갑니다)
  - `proxy_read_timeout 300s` — `/api/v1/analyze`는 LLM·멀티 에이전트 호출이라 기본 60s로는 짧습니다
  - `Host`는 `$host`가 아니라 **`$http_host`** — `$host`는 포트를 떼므로 backend가 보는 Host가 `localhost`가 되고, FastAPI가 trailing slash 등으로 307을 낼 때 `Location`에서 포트(8080)가 사라집니다 (검증 중 실측으로 발견)
  - 공통 프록시 헤더·타임아웃은 `server` 컨텍스트에 두어 두 `location`의 중복 제거
- `docker-compose.yml` — `frontend` 서비스 주석 갱신. `depends_on`을 일부러 두지 않는 이유를 명시
- `README.md` / `frontend/README.md` — 프록시 구조, `resolver` 선택 이유, CORS를 아직 남기는 이유 문서화
- `backend/config.py` / `.env.example` — `ALLOW_ORIGINS`가 아직 필요한 이유와 언제 없어지는지를 주석으로 (동작 변경 없음, 주석만)

### 검증 (실측)

`nginx:alpine` + 가짜 ASGI backend로 격리 스택을 띄워 확인했습니다.

| 항목 | 결과 |
| :--- | :--- |
| `nginx -t` | 통과 |
| **backend 컨테이너 없이 nginx 단독 기동** | 정상 기동, `/` → 200, `/api/`·`/health` → 502, `/nginx-health` → 200 |
| `/api` (슬래시 없음) | 301 → `Location: /api/` — `location /api/` 프리픽스에 안 걸려 nginx 자동 슬래시 보정 |
| 보안 헤더 3종 | 정적 200·502·`/nginx-health` 모두에 부착 |
| URI 통과 | `/api/v1/portfolio?stock=…&provider=…` → path·query 무변형 전달 |
| 평범한 GET의 `Connection` | `close` (map이 의도대로 동작) |
| `/api/v1/ws` | **HTTP/1.1 101 Switching Protocols** |
| `Host` 헤더 | `localhost:8099` (포트 보존) |
| `proxy_read_timeout` | `/api/v1/slow?sec=75` → 75.0s 만에 200 (기본 60s 초과) |
| `.wasm` MIME | `application/wasm` 유지 |
| `backend/tests` | 454 passed, 2 skipped |

두 번째 항목이 `depends_on` 없이 가도 된다는 근거입니다. backend가 없는 동안 nginx 로그에는 `backend could not be resolved (Host not found)`만 찍히고 프로세스는 살아 있었습니다.

## 🔗 관련 이슈

- Closes #245 — 이슈의 "할 일" 4개(도입 결정 / `depends_on` vs `resolver` 선택 / WS 업그레이드 확인 / #246 방향 확정)가 모두 완료됩니다. 다만 제목의 "`ALLOW_ORIGINS` 수동 관리를 없애기"는 번들 리빌드가 있어야 실제로 끝나므로, **그 작업은 #246으로 이관했습니다**(#246 할 일 4번).
- #246 — 이 PR로 방향 확정 ("하드코딩을 상대 경로로 교체 + 리빌드"로 축소). 이 PR에서는 처리하지 않습니다.
- #244 — 주 재현 경로(임의 오리진에서 CORS 차단)는 #246까지 완료되면 사라지지만, backend가 실제로 죽었을 때 더미를 그리는 문제는 그대로 남으므로 별도 처리가 필요합니다.

## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [x] 변경 사항에 대한 문서(README 등)를 업데이트했나요?

## 📸 스크린샷 (선택 사항)

```
$ curl -s http://localhost:8099/api/v1/portfolio
{"path": "/api/v1/portfolio", "headers": {"host": "localhost:8099", "connection": "close", ...}}

$ curl -i -N -H "Connection: Upgrade" -H "Upgrade: websocket" \
       -H "Sec-WebSocket-Version: 13" -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
       http://localhost:8099/api/v1/ws
HTTP/1.1 101 Switching Protocols
Connection: upgrade
Upgrade: websocket
Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=
```
