### PR TITLE
fix: 전송 실패를 폴러까지 전파하고 재시도를 멱등하게 정리 (#249, #247)

### DIFF
--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -4,7 +4,7 @@ import re
 import secrets
 import time
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import Enum
 from datetime import datetime, timedelta
 from typing import Any, Callable
@@ -696,6 +696,11 @@ class TelegramCommandHandler:
         await self.notifier.send_chat_action("typing")
         try:
             result = await self.mcp_runner(TRADING_MCP_PARAMS, "get_balance", {})
+        # #249: try 안에 전송 호출은 없어 오늘은 실질 위험이 없지만, "except Exception →
+        # _send_text_or_raise로 재변환" 패턴 자체가 향후 try 본문에 send가 섞여도
+        # 조용히 삼키지 않도록 방어적으로 재전파한다(핸들러 전역 불변식).
+        except TelegramSendError:
+            raise
         except Exception as exc:
             await self._send_text_or_raise(f"조회 실패: {_short_error(exc)}")
             return
@@ -717,6 +722,8 @@ class TelegramCommandHandler:
                 "get_stock_quote",
                 {"stock_name": stock},
             )
+        except TelegramSendError:  # #249: 방어적 재전파, 위 _handle_balance 주석 참고
+            raise
         except Exception as exc:
             await self._send_text_or_raise(f"조회 실패: {_short_error(exc)}")
             return
@@ -742,14 +749,25 @@ class TelegramCommandHandler:
 
         try:
             await self._drop_expired_pending_order(chat_id, now)
-            has_pending = await self.pending_orders.has(chat_id)
+            pending = await self.pending_orders.get(chat_id)
+        except TelegramSendError:
+            raise
         except Exception as exc:
             await self._send_text_or_raise(f"주문 저장소 오류: {_short_error(exc)}")
             return
-        if has_pending:
-            await self._send_text_or_raise(
-                "이미 대기 중인 주문이 있습니다. /confirm 또는 /cancel로 먼저 처리하세요."
-            )
+        if pending is not None:
+            if pending.prompt_delivered:
+                await self._send_text_or_raise(
+                    "이미 대기 중인 주문이 있습니다. /confirm 또는 /cancel로 먼저 처리하세요."
+                )
+                return
+            # #247(멱등성): 이전 시도가 set_if_absent(부수효과 확정)까지는 성공했지만
+            # 확인 프롬프트 전송에서 실패했다(TelegramSendError) — 이 update는 poller가
+            # 재시도한 것이다. 새 주문을 또 만들면 두 번째 /buy로 오인되어 "이미 대기
+            # 중인 주문이 있습니다"를 돌려주고 사용자는 확인 버튼을 영영 못 받는다.
+            # 대신 이미 저장된 주문의 프롬프트를 그대로 재전송해 재시도가 원래
+            # 의도(확인 버튼 수신)로 수렴하게 한다.
+            await self._resend_order_prompt(chat_id, pending)
             return
 
         await self.notifier.send_chat_action("typing")
@@ -799,6 +817,14 @@ class TelegramCommandHandler:
                 ),
                 self.mcp_runner(TRADING_MCP_PARAMS, "get_balance", {}),
             )
+        except TelegramSendError:
+            # #249: 위 세 개의 send_text_or_raise(766~792행)는 이 try 안에 있다. 429 등으로
+            # 그중 하나가 TelegramSendError를 던지면 아래 except Exception이 이를 삼켜
+            # "주문 준비 실패: telegram send failed"로 재전송했다 — 원래 메시지가 사라지고
+            # (재전송이 성공하면) handle_update가 정상 종료해 poller가 성공으로 오판했다.
+            # 전송 실패는 이 명령의 오류가 아니라 사용자에게 말을 걸 수 없는 상태이므로
+            # 그대로 위로 전파해 poller의 전송-실패 전용 재시도 예산이 다루게 한다.
+            raise
         except Exception as exc:
             await self._send_text_or_raise(f"주문 준비 실패: {_short_error(exc)}")
             return
@@ -816,32 +842,92 @@ class TelegramCommandHandler:
         )
         try:
             stored = await self.pending_orders.set_if_absent(chat_id, order)
+        except TelegramSendError:
+            raise
         except Exception as exc:
             await self._send_text_or_raise(f"주문 저장 실패: {_short_error(exc)}")
             return
         if not stored:
-            # MCP 호출 사이에 같은 chat에서 /buy가 먼저 체결된 경우
+            # MCP 호출 사이에 같은 chat에서 /buy가 먼저 체결된 경우(레이스). 함수 진입
+            # 시점엔 대기 주문이 없었는데 resolve/validate 도중 다른 /buy가 새로 만든
+            # 것이므로, #247 재시도 케이스(진입 시점부터 이미 있던 주문)와 다르다 — 그
+            # 주문을 대신 전달할 근거가 없으므로 사용자가 직접 /confirm·/cancel을
+            # 선택하게 한다.
             await self._send_text_or_raise(
                 "이미 대기 중인 주문이 있습니다. /confirm 또는 /cancel로 먼저 처리하세요."
             )
             return
+        await self._deliver_order_prompt(chat_id, order, str(quote_result), str(balance_result))
+
+    async def _resend_order_prompt(self, chat_id: str, order: PendingOrder) -> None:
+        """#247: 저장은 됐지만 전송에 실패한 pending order의 프롬프트를 재전송한다.
+
+        새 명령을 다시 파싱하지 않고 이미 저장된 order를 그대로 쓴다 — 재시도가 다른
+        주문을 만들어내면 안 되기 때문이다. 시세·잔고는 저장해두지 않으므로(주문
+        내용만 저장) 다시 조회한다: 어차피 실시간 데이터라 매 전송마다 새로 조회하는
+        것이 기존 동작과 같다.
+        """
+        await self.notifier.send_chat_action("typing")
+        try:
+            quote_result, balance_result = await asyncio.gather(
+                self.mcp_runner(
+                    TRADING_MCP_PARAMS,
+                    "get_stock_quote",
+                    {"stock_name": order.stock_name},
+                ),
+                self.mcp_runner(TRADING_MCP_PARAMS, "get_balance", {}),
+            )
+        except TelegramSendError:
+            raise
+        except Exception as exc:
+            await self._send_text_or_raise(f"주문 준비 실패: {_short_error(exc)}")
+            return
+        await self._deliver_order_prompt(chat_id, order, str(quote_result), str(balance_result))
+
+    async def _deliver_order_prompt(
+        self,
+        chat_id: str,
+        order: PendingOrder,
+        quote_result: str,
+        balance_result: str,
+    ) -> None:
         await self._send_text_or_raise(
-            self._format_order_prompt(order, str(quote_result), str(balance_result)),
+            self._format_order_prompt(order, quote_result, balance_result),
             reply_markup=self._order_reply_markup(order),
         )
+        # #247: 전송이 성공한 뒤에만 delivered로 표시한다. 전송이 TelegramSendError를
+        # 던지면 이 줄에 도달하지 못하므로 저장소에는 prompt_delivered=False가 그대로
+        # 남고, 다음 재시도가 _resend_order_prompt로 다시 온다.
+        try:
+            await self.pending_orders.set(chat_id, replace(order, prompt_delivered=True))
+        except Exception as exc:
+            logger.warning("pending_order prompt_delivered 갱신 실패: %s", exc)
 
     async def _handle_cancel(self, chat_id: str) -> None:
         try:
             await self._drop_expired_pending_order(chat_id, self.now_factory())
-            has_pending = await self.pending_orders.has(chat_id)
+            pending = await self.pending_orders.get(chat_id)
+        except TelegramSendError:
+            raise
         except Exception as exc:
             await self._send_text_or_raise(f"주문 저장소 오류: {_short_error(exc)}")
             return
-        if not has_pending:
+        if pending is None:
             await self._send_text_or_raise("취소할 대기 주문이 없습니다.")
+            return
+        if pending.settled:
+            # #247: settled 레코드는 이미 체결까지 끝난 주문의 결과 재전송 대기 상태다.
+            # "취소"는 이미 끝난 체결을 없던 일로 만들 수 없으므로 체결 결과를 그대로
+            # 안내한다 — 삭제도 하지 않는다: /confirm 쪽 재시도가 여전히 이 레코드를
+            # 필요로 할 수 있다.
+            await self._send_text_or_raise(
+                f"이미 확정된 주문입니다.\n{pending.settled_message or ''}".rstrip()
+            )
             return
         try:
             await self.pending_orders.delete(chat_id)
+        except TelegramSendError:
+            raise
         except Exception as exc:
             await self._send_text_or_raise(f"주문 저장소 오류: {_short_error(exc)}")
             return
@@ -857,6 +943,8 @@ class TelegramCommandHandler:
             # claim(GETDEL): 원자적 읽기+삭제. 재시작 후 재전송된 Telegram update나
             # 멀티워커 경합에서 정확히 하나의 호출만 order를 받고 나머지는 None을 받는다.
             order = await self.pending_orders.claim(chat_id)
+        except TelegramSendError:
+            raise
         except Exception as exc:
             await self._send_text_or_raise(f"주문 저장소 오류: {_short_error(exc)}")
             return
@@ -864,9 +952,24 @@ class TelegramCommandHandler:
             await self._send_text_or_raise("확정할 대기 주문이 없습니다.")
             return
 
+        if order.settled:
+            # #247(멱등성): claim은 원자적이라 정상적으로는 이 chat에 대해 한 번만
+            # 미체결 PendingOrder를 돌려준다. settled=True로 저장된 레코드를 받았다는
+            # 것은 직전 /confirm이 place_order까지 성공했지만 결과 전송에서 실패해
+            # (TelegramSendError) poller가 이 update를 재시도했다는 뜻이다. place_order를
+            # 다시 부르면 중복 체결이므로, 저장해둔 체결 결과 메시지만 재전송한다.
+            await self._send_text_or_raise(order.settled_message or "주문 완료")
+            try:
+                await self.pending_orders.delete(chat_id)
+            except Exception as exc:
+                logger.warning("settled pending_order 정리 실패: %s", exc)
+            return
+
         await self.notifier.send_chat_action("typing")
         try:
             result = await self.order_gateway.place_order(order)
+        except TelegramSendError:
+            raise
         except Exception as exc:
             if isinstance(exc, HTTPException) and exc.status_code == 403:
                 # 403 = 실계좌 가드 미충족: 주문 미실행이 확실하므로 대기 주문 복원.
@@ -885,6 +988,9 @@ class TelegramCommandHandler:
                 return
 
             # 주문 실행 결과 불명확: claim으로 이미 삭제됨 — 추가 delete 불필요
+            # (settled 레코드도 만들지 않는다. place_order 성공 여부를 모르는 채로
+            # "체결됨"이라고 캐시해 두면 재시도가 실제로는 안 됐을 체결을 됐다고
+            # 우긴다 — #247 범위 밖. 실패가 확실한 경우만 안전하게 재시도로 수렴시킨다.)
             await self._send_text_or_raise(
                 "주문 실패 또는 상태 확인 필요: "
                 f"{_short_error(exc)}\n"
@@ -892,7 +998,7 @@ class TelegramCommandHandler:
             )
             return
 
-        # 주문 성공: claim으로 이미 삭제됨 — 추가 delete 불필요
+        # 주문 성공(부수효과 확정): claim으로 이미 삭제됨 — 추가 delete 불필요
         record_warning = ""
         if self.trade_recorder is not None:
             try:
@@ -900,7 +1006,25 @@ class TelegramCommandHandler:
             except Exception as exc:
                 logger.warning("Trade history recording failed: %s", exc)
                 record_warning = f"\n거래 이력 기록 실패: {_short_error(exc)}"
-        await self._send_text_or_raise(f"주문 완료: {result.message}{record_warning}")
+        message = f"주문 완료: {result.message}{record_warning}"
+        # #247: 전송 전에 체결 결과를 settled 레코드로 먼저 저장한다. place_order는 이미
+        # 끝났으므로, 이 저장 다음의 전송이 실패해도(TelegramSendError) 재시도는 이
+        # 레코드를 만나 place_order를 다시 부르지 않고 메시지만 재전송해야 한다. TTL은
+        # 원래 order의 저장소 TTL(600초)을 그대로 물려받아 전송 재시도 창(최대 335초)을
+        # 넉넉히 덮는다.
+        try:
+            await self.pending_orders.set(
+                chat_id, replace(order, settled=True, settled_message=message)
+            )
+        except Exception as exc:
+            logger.error("settled 결과 저장 실패: %s", exc)
+        await self._send_text_or_raise(message)
+        # 전송 성공: settled 레코드를 즉시 정리한다. 남겨두면 TTL(600초)이 끝날 때까지
+        # 재조회 없이도 그 chat의 다음 무관한 /confirm이 이 결과를 다시 받을 수 있다.
+        try:
+            await self.pending_orders.delete(chat_id)
+        except Exception as exc:
+            logger.warning("settled pending_order 정리 실패: %s", exc)
 
     def _parse_order_argument(self, argument: str) -> tuple[str, int, int, OrderType] | None:
         parts = argument.split()
@@ -982,6 +1106,13 @@ class TelegramCommandHandler:
     async def _drop_expired_pending_order(self, chat_id: str, now: datetime) -> None:
         order = await self.pending_orders.get(chat_id)
         if order is None:
+            return
+        if order.settled:
+            # #247: settled 레코드는 이미 place_order까지 끝난 뒤 결과 전송 재시도를
+            # 위해 남겨둔 것이다. created_at은 원래 /buy 시각이라 60초 만료 검사를
+            # 적용하면 안 된다 — 전송 실패 재시도 창(최대 335초, PR #242)이 60초보다
+            # 길어서 여기서 지우면 재시도가 체결 결과를 통째로 잃는다. 정리는 성공
+            # 전송 후 명시적 delete 또는 저장소 TTL(600초, PENDING_ORDER_TTL_SEC)이 맡는다.
             return
         created_at = order.created_at
         if created_at.tzinfo is None:
@@ -1230,6 +1361,8 @@ class TelegramCommandHandler:
                 "get_investor_trading",
                 {"stock_name": stock},
             )
+        except TelegramSendError:  # #249: 방어적 재전파, _handle_balance 주석 참고
+            raise
         except Exception as exc:
             await self._send_text_or_raise(f"조회 실패: {_short_error(exc)}")
             return
@@ -1260,6 +1393,8 @@ class TelegramCommandHandler:
                 self._earnings_analysis_prompt(stock, period, str(dart_result), str(news_result)),
                 conversation_id=f"telegram:{chat_id}:earnings:{_url_quote(stock, safe='')}",
             )
+        except TelegramSendError:  # #249: 방어적 재전파, _handle_balance 주석 참고
+            raise
         except Exception as exc:
             await self._send_text_or_raise(f"조회 실패: {_short_error(exc)}")
             return
@@ -1354,6 +1489,8 @@ class TelegramCommandHandler:
                 text,
                 conversation_id=f"telegram:{chat_id}",
             )
+        except TelegramSendError:  # #249: 방어적 재전파, _handle_balance 주석 참고
+            raise
         except Exception as exc:
             await self._send_text_or_raise(f"응답 생성 실패: {_short_error(exc)}")
             return

--- a/backend/tests/test_pending_order_store.py
+++ b/backend/tests/test_pending_order_store.py
@@ -594,6 +594,35 @@ async def test_duplicate_confirm_calls_place_order_only_once():
     assert notifier.messages[-1] == "확정할 대기 주문이 없습니다."
 
 
+@pytest.mark.asyncio
+async def test_redis_store_claim_removes_order_atomically():
+    """claim()은 getdel(원자적 읽기+삭제)을 써서, 첫 호출이 값을 가져가면 뒤이은
+    호출은 반드시 None을 받는다 (이슈 #63/#247, PR #242·#247 리뷰: settled 레코드
+    도입 이후에도 claim 자체의 원자성이 store 수준에서 고정돼야 한다).
+
+    #247에서 place_order 성공 후 settled 레코드를 다시 써넣도록 handler를 바꾸면서,
+    handler 수준의 회귀 테스트(test_duplicate_confirm_calls_place_order_only_once)는
+    "그 다음에 handler가 명시적으로 delete하는지"까지 함께 확인하게 됐다. 그 결과
+    claim()이 get()으로(비원자화) 바뀌어도 handler의 사후 delete가 상태를 정리해버려
+    handler 수준 테스트만으로는 이 mutation을 잡지 못한다. store 수준에서 claim() 두
+    번을 직접 호출해 원자성 자체를 고정한다.
+
+    이 테스트가 잡는 mutation: claim()에서 getdel을 get으로 바꾸는 것(비원자화).
+    get으로 바뀌면 첫 claim() 후에도 키가 지워지지 않아 두 번째 claim()이 같은
+    주문을 또 돌려준다 — 동시에 들어온 두 /confirm이 각각 place_order를 불러
+    중복 체결로 이어지는 근본 원인이다.
+    """
+    redis = FakeRedis()
+    store = RedisPendingOrderStore(redis)
+    await store.set("123", _ORDER_A)
+
+    first = await store.claim("123")
+    second = await store.claim("123")
+
+    assert first is not None and first.callback_token == "tok-a"
+    assert second is None
+
+
 # ---------------------------------------------------------------------------
 # set_if_absent NX 시맨틱 가드 (이슈 #63, PR #223 Improvement 1)
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -8,6 +8,7 @@ from fastapi import HTTPException
 
 import backend.telegram_commands as telegram_commands
 from backend.config import DART_MCP_PARAMS, NEWS_MCP_PARAMS, TRADING_MCP_PARAMS
+from backend.redis_state import InMemoryPendingOrderStore
 from backend.telegram_commands import (
     BUY_COMMAND_HELP,
     CATALYST_COMMAND_HELP,
@@ -3102,3 +3103,211 @@ async def test_cancel_after_confirm_send_failure_reports_already_settled():
     assert len(gateway.orders) == 1
     assert notifier.messages[-1].startswith("이미 확정된 주문입니다.")
     assert "주문 완료" in notifier.messages[-1]
+
+
+# ---------------------------------------------------------------------------
+# #249 동작 가드 — 돈이 오가는 경로(주문 준비·확정·취소)의 개별 except Exception이
+# TelegramSendError를 재전파하는지 "구조 검사"가 아니라 실제 handle_update 실행으로
+# 고정한다.
+#
+# 판단 근거: 구조 불변식 테스트(test_telegram_commands_invariants.py)는 소스에
+# `except TelegramSendError: raise`가 "있는지"는 보장하지만, 그게 handle_update
+# 호출 경로에서 실제로 동작하는지(예: 잘못된 위치에 놓여 오작동)까지는 보장하지
+# 않는다. 돈·주문 상태가 걸린 세 핸들러(_handle_order_command, _handle_confirm,
+# _handle_cancel과 그 도우미 _resend_order_prompt)는 동작으로도 이중 고정한다.
+# 부수효과가 없는 순수 조회 명령(_handle_balance/_handle_quote/_handle_trend/
+# _handle_earnings/_handle_chat_fallback)은 구조 검사만으로 충분하다고 판단해
+# 여기 포함하지 않았다 — 회귀해도 잘못된 오류 메시지 한 줄이 나갈 뿐, 중복 주문·
+# 중복 체결 같은 돈 문제로 이어지지 않는다.
+# ---------------------------------------------------------------------------
+
+class _SendErrorOnMethodStore:
+    """지정한 메서드 호출 시 TelegramSendError를 강제로 던지는 pending_order 저장소 프록시.
+
+    실제 저장소 메서드(get/set/delete/claim/set_if_absent/has)는 텔레그램 API를
+    부르지 않으므로 오늘은 TelegramSendError를 던지지 않는다. 이 프록시는 "이
+    try 블록 안에서 TelegramSendError가 발생한다면"을 가정해, 감싸는 except가
+    그것을 올바르게 재전파하는지를 실제 handle_update 실행으로 검증한다.
+    """
+
+    def __init__(self, delegate, *, raise_on: str):
+        self._delegate = delegate
+        self._raise_on = raise_on
+
+    def __getattr__(self, name):
+        if name == self._raise_on:
+            async def _raise(*args, **kwargs):
+                raise telegram_commands.TelegramSendError("simulated send failure")
+
+            return _raise
+        return getattr(self._delegate, name)
+
+
+@pytest.mark.asyncio
+async def test_order_command_pending_lookup_send_error_propagates():
+    """/buy의 대기 주문 조회 try(_drop_expired_pending_order + pending_orders.get)
+    안에서 TelegramSendError가 나면 그대로 위로 전파해야 한다."""
+    store = _SendErrorOnMethodStore(InMemoryPendingOrderStore(), raise_on="get")
+    handler = TelegramCommandHandler(
+        notifier=FakeNotifier(),
+        pending_order_store=store,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    with pytest.raises(telegram_commands.TelegramSendError):
+        await handler.handle_update(
+            {"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 1 75000"}}
+        )
+
+
+@pytest.mark.asyncio
+async def test_order_command_set_if_absent_send_error_propagates():
+    """/buy의 주문 저장(set_if_absent) try 안에서 TelegramSendError가 나면
+    재전파해야 한다."""
+
+    async def mcp_runner(server_params, tool_name, arguments):
+        if tool_name == "resolve_stock_code":
+            return "삼성전자 (005930, KOSPI)"
+        if tool_name == "get_stock_quote":
+            return "현재가: 74,500원"
+        if tool_name == "get_balance":
+            return "주문가능금액: 1,000,000원"
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    store = _SendErrorOnMethodStore(InMemoryPendingOrderStore(), raise_on="set_if_absent")
+    handler = TelegramCommandHandler(
+        notifier=FakeNotifier(),
+        pending_order_store=store,
+        mcp_runner=mcp_runner,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    with pytest.raises(telegram_commands.TelegramSendError):
+        await handler.handle_update(
+            {"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 1 75000"}}
+        )
+
+
+@pytest.mark.asyncio
+async def test_resend_order_prompt_quote_lookup_send_error_propagates():
+    """#247 재시도 경로(_resend_order_prompt)의 시세·잔고 재조회 try 안에서
+    TelegramSendError가 나면 재전파해야 한다."""
+    order = PendingOrder(
+        chat_id="123",
+        stock_name="삼성전자",
+        stock_code="005930",
+        side="BUY",
+        quantity=1,
+        price=75000,
+        created_at=datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+        callback_token="tok",
+        prompt_delivered=False,
+    )
+    store = InMemoryPendingOrderStore()
+    await store.set("123", order)
+
+    async def mcp_runner(server_params, tool_name, arguments):
+        raise telegram_commands.TelegramSendError("simulated send failure")
+
+    handler = TelegramCommandHandler(
+        notifier=FakeNotifier(),
+        pending_order_store=store,
+        mcp_runner=mcp_runner,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, 10, tzinfo=KST),
+    )
+
+    with pytest.raises(telegram_commands.TelegramSendError):
+        await handler.handle_update(
+            {"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 1 75000"}}
+        )
+
+
+@pytest.mark.asyncio
+async def test_confirm_claim_send_error_propagates():
+    """/confirm의 claim try(_drop_expired_pending_order + pending_orders.claim)
+    안에서 TelegramSendError가 나면 재전파해야 한다."""
+    store = _SendErrorOnMethodStore(InMemoryPendingOrderStore(), raise_on="claim")
+    handler = TelegramCommandHandler(
+        notifier=FakeNotifier(),
+        pending_order_store=store,
+        order_gateway=FakeOrderGateway(),
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    with pytest.raises(telegram_commands.TelegramSendError):
+        await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/confirm"}})
+
+
+@pytest.mark.asyncio
+async def test_confirm_place_order_send_error_propagates():
+    """/confirm의 place_order try 안에서 TelegramSendError가 나면(가상의 미래
+    리팩터를 가정) 재전파해야 한다."""
+
+    class _SendErrorGateway:
+        async def place_order(self, order):
+            raise telegram_commands.TelegramSendError("simulated send failure")
+
+    order = PendingOrder(
+        chat_id="123",
+        stock_name="삼성전자",
+        stock_code="005930",
+        side="BUY",
+        quantity=1,
+        price=75000,
+        created_at=datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+        callback_token="tok",
+        prompt_delivered=True,
+    )
+    store = InMemoryPendingOrderStore()
+    await store.set("123", order)
+
+    handler = TelegramCommandHandler(
+        notifier=FakeNotifier(),
+        pending_order_store=store,
+        order_gateway=_SendErrorGateway(),
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, 10, tzinfo=KST),
+    )
+
+    with pytest.raises(telegram_commands.TelegramSendError):
+        await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/confirm"}})
+
+
+@pytest.mark.asyncio
+async def test_cancel_pending_lookup_send_error_propagates():
+    """/cancel의 대기 주문 조회 try 안에서 TelegramSendError가 나면 재전파해야 한다."""
+    store = _SendErrorOnMethodStore(InMemoryPendingOrderStore(), raise_on="get")
+    handler = TelegramCommandHandler(
+        notifier=FakeNotifier(),
+        pending_order_store=store,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    with pytest.raises(telegram_commands.TelegramSendError):
+        await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/cancel"}})
+
+
+@pytest.mark.asyncio
+async def test_cancel_delete_send_error_propagates():
+    """/cancel의 삭제 try 안에서 TelegramSendError가 나면 재전파해야 한다."""
+    order = PendingOrder(
+        chat_id="123",
+        stock_name="삼성전자",
+        stock_code="005930",
+        side="BUY",
+        quantity=1,
+        price=75000,
+        created_at=datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+        callback_token="tok",
+    )
+    base_store = InMemoryPendingOrderStore()
+    await base_store.set("123", order)
+    store = _SendErrorOnMethodStore(base_store, raise_on="delete")
+
+    handler = TelegramCommandHandler(
+        notifier=FakeNotifier(),
+        pending_order_store=store,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, 10, tzinfo=KST),
+    )
+
+    with pytest.raises(telegram_commands.TelegramSendError):
+        await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/cancel"}})

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -2906,3 +2906,199 @@ async def test_help_and_bot_menu_include_catalysts_command(monkeypatch):
 
     assert "/catalysts <종목명> - 예정 촉매 이벤트 조회" in notifier.messages[-1]
     assert "catalysts" in [command["command"] for command in telegram_commands.TELEGRAM_BOT_COMMANDS]
+
+
+# ---------------------------------------------------------------------------
+# #249: except Exception이 TelegramSendError를 삼키지 않는다
+# #247: 부수효과 확정 후 전송 실패 재시도가 같은 결과로 수렴한다 (멱등성)
+# ---------------------------------------------------------------------------
+
+class _FailOnceForPrefixNotifier(FakeNotifier):
+    """지정한 접두사로 시작하는 메시지의 첫 전송만 실패시킨다(429 재시도 후 성공 시뮬레이션).
+
+    FakeNotifier(send_text_result=False)는 모든 전송을 실패시켜 "재시도가 성공하는"
+    시나리오(#249/#247의 핵심 — 429가 잠깐이고 재전송에서 서버가 복구되는 경우)를
+    표현할 수 없다. 이 fake는 딱 한 번, 지정한 메시지에서만 실패한다.
+    """
+
+    def __init__(self, *, fail_prefix: str, **kwargs):
+        super().__init__(**kwargs)
+        self._fail_prefix = fail_prefix
+        self._failed_once = False
+
+    async def send_text(self, text, *, reply_markup=None):
+        self.messages.append(text)
+        self.reply_markups.append(reply_markup)
+        if not self._failed_once and text.startswith(self._fail_prefix):
+            self._failed_once = True
+            return False
+        return True
+
+
+@pytest.mark.asyncio
+async def test_order_prepare_send_failure_propagates_instead_of_being_swallowed():
+    """#249: 준비 단계 안의 send_text_or_raise(766행 부근)가 던진 TelegramSendError를
+    감싸는 except Exception(802행 부근)이 삼켜 "주문 준비 실패: telegram send failed"로
+    재전송하면 안 된다. 재전송이 성공해도(429 복구) handle_update는 TelegramSendError를
+    던져야 poller가 전송 실패 전용 예산(SEND_FAILURE_RETRY_WINDOW_SECONDS)으로 다룬다.
+
+    이 테스트는 뮤테이션 ①(TelegramSendError 재전파 제거)의 회귀 가드다: 재전파를
+    없애면 아래 with pytest.raises가 실패한다(재전송이 성공해 handle_update가 정상
+    종료하므로).
+    """
+
+    async def mcp_runner(server_params, tool_name, arguments):
+        if tool_name == "resolve_stock_code":
+            # 코드 추출 실패 → stock_code is None 분기의 전송(766행 부근)을 태운다.
+            return "종목을 찾지 못했습니다"
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    notifier = _FailOnceForPrefixNotifier(fail_prefix="주문 준비 실패: 종목코드")
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    with pytest.raises(telegram_commands.TelegramSendError):
+        await handler.handle_update(
+            {"message": {"chat": {"id": 123}, "text": "/buy 알수없는종목 1 75000"}}
+        )
+
+    # 삼켜졌다면 여기서 "주문 준비 실패: telegram send failed" 재전송이 성공해
+    # 메시지가 하나 더 남았을 것이다. 재전파되면 원래 메시지 한 건만 남는다.
+    assert notifier.messages == ["주문 준비 실패: 종목코드를 확인할 수 없습니다."]
+    assert handler.pending_orders == {}
+
+
+@pytest.mark.asyncio
+async def test_buy_retry_after_prompt_send_failure_resends_same_prompt():
+    """#247: set_if_absent(부수효과 확정) 후 확인 프롬프트 전송이 실패해 poller가
+    handle_update를 재시도하면, 재시도는 "이미 대기 중인 주문이 있습니다"가 아니라
+    원래 의도했던 확인 프롬프트(버튼 포함)로 수렴해야 한다.
+
+    뮤테이션 ②(멱등성 보장 로직 무력화)의 회귀 가드: prompt_delivered 분기를 지우면
+    두 번째 handle_update가 "이미 대기 중인 주문이 있습니다"를 보내 아래 단언이 실패한다.
+    """
+
+    async def mcp_runner(server_params, tool_name, arguments):
+        if tool_name == "resolve_stock_code":
+            return "삼성전자 (005930, KOSPI)"
+        if tool_name == "get_stock_quote":
+            return "현재가: 74,500원"
+        if tool_name == "get_balance":
+            return "주문가능금액: 1,000,000원"
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    notifier = _FailOnceForPrefixNotifier(fail_prefix="삼성전자 매수 주문 확인")
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+    update = {"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 10 70000"}}
+
+    # 1차 시도: 부수효과(set_if_absent)는 성공하지만 프롬프트 전송이 실패한다.
+    with pytest.raises(telegram_commands.TelegramSendError):
+        await handler.handle_update(update)
+    assert "123" in handler.pending_orders
+    assert handler.pending_orders["123"].prompt_delivered is False
+
+    # poller가 같은 update를 재시도한다.
+    await handler.handle_update(update)
+
+    assert "이미 대기 중인 주문이 있습니다" not in "".join(notifier.messages)
+    # 두 건 모두 프롬프트다(1차: 실패한 시도, 2차: 성공한 재시도) — "이미 대기 중"으로
+    # 바뀌지 않고 같은 의도(확인 프롬프트)로 수렴했음을 고정한다.
+    prompt_messages = [m for m in notifier.messages if m.startswith("삼성전자 매수 주문 확인")]
+    assert len(prompt_messages) == 2
+    assert notifier.messages[-1] == prompt_messages[0] == prompt_messages[1]
+    assert handler.pending_orders["123"].prompt_delivered is True
+
+
+@pytest.mark.asyncio
+async def test_confirm_retry_after_result_send_failure_resends_completion_without_reordering():
+    """#247: place_order 성공(부수효과 확정) 후 결과 전송이 실패해 재시도되면,
+    place_order를 다시 부르지 않고(중복 체결 방지) 저장된 체결 결과 메시지만
+    재전송해야 한다.
+
+    뮤테이션 ②(멱등성 보장 로직 무력화)의 회귀 가드: settled 분기를 지우면 재시도가
+    claim()에서 None을 받아 "확정할 대기 주문이 없습니다"를 보내 아래 단언이 실패한다.
+    """
+
+    async def mcp_runner(server_params, tool_name, arguments):
+        if tool_name == "resolve_stock_code":
+            return "삼성전자 (005930, KOSPI)"
+        if tool_name == "get_stock_quote":
+            return "현재가: 74,500원"
+        if tool_name == "get_balance":
+            return "주문가능금액: 1,000,000원"
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    gateway = FakeOrderGateway()
+    notifier = _FailOnceForPrefixNotifier(fail_prefix="주문 완료")
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        order_gateway=gateway,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 1 75000"}}
+    )
+    confirm_update = {"message": {"chat": {"id": 123}, "text": "/confirm"}}
+
+    # 1차 시도: place_order는 성공하지만 결과 전송이 실패한다.
+    with pytest.raises(telegram_commands.TelegramSendError):
+        await handler.handle_update(confirm_update)
+    assert len(gateway.orders) == 1
+
+    # poller가 같은 update를 재시도한다.
+    await handler.handle_update(confirm_update)
+
+    assert len(gateway.orders) == 1  # place_order가 다시 호출되지 않았다 — 중복 체결 방지
+    assert "확정할 대기 주문이 없습니다" not in notifier.messages
+    # 두 건 모두 같은 체결 결과다(1차: 실패한 시도, 2차: 성공한 재시도) — place_order를
+    # 다시 부르지 않고 캐시된 settled_message를 그대로 재전송했음을 고정한다.
+    completion_messages = [m for m in notifier.messages if m.startswith("주문 완료")]
+    assert len(completion_messages) == 2
+    assert notifier.messages[-1] == completion_messages[0] == completion_messages[1]
+    assert handler.pending_orders == {}  # 성공 전송 후 settled 레코드가 정리된다
+
+
+@pytest.mark.asyncio
+async def test_cancel_after_confirm_send_failure_reports_already_settled():
+    """#247 경계 케이스: /confirm 결과 전송이 실패해 settled 레코드가 남은 채로
+    사용자가 /cancel을 보내면, 이미 끝난 체결을 취소했다고 거짓 응답하지 않고
+    체결 결과를 그대로 안내한다."""
+
+    async def mcp_runner(server_params, tool_name, arguments):
+        if tool_name == "resolve_stock_code":
+            return "삼성전자 (005930, KOSPI)"
+        if tool_name == "get_stock_quote":
+            return "현재가: 74,500원"
+        if tool_name == "get_balance":
+            return "주문가능금액: 1,000,000원"
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    gateway = FakeOrderGateway()
+    notifier = _FailOnceForPrefixNotifier(fail_prefix="주문 완료")
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        order_gateway=gateway,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 1 75000"}}
+    )
+    with pytest.raises(telegram_commands.TelegramSendError):
+        await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/confirm"}})
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/cancel"}})
+
+    assert len(gateway.orders) == 1
+    assert notifier.messages[-1].startswith("이미 확정된 주문입니다.")
+    assert "주문 완료" in notifier.messages[-1]

--- a/backend/tests/test_telegram_commands_invariants.py
+++ b/backend/tests/test_telegram_commands_invariants.py
@@ -1,0 +1,185 @@
+"""backend/telegram_commands.py 구조 불변식 테스트 (#249).
+
+개별 사이트를 하나씩 회귀 테스트로 고정하는 방식은 "지금 있는" 사이트만 지킨다 —
+내일 누군가 새 `except Exception`을 재전파 없이 추가해도 아무 테스트도 못 잡는다
+(리뷰에서 실측: 13곳 중 개별 제거로 검출된 곳은 1곳뿐이었다). 이 파일은 소스를
+정적으로 파싱해 "TelegramCommandHandler의 모든 `except Exception`은
+`except TelegramSendError: raise`를 먼저 두거나 이유와 함께 allowlist에 있어야
+한다"는 불변식을 한 번에, 그리고 앞으로도 계속 강제한다.
+
+allowlist에 있는 지점은 다음 중 하나를 만족해 개별 확인했다:
+- try 본문이 텔레그램 전송(notifier.send_text 경유, 즉 _send_text_or_raise)을
+  호출하지 않아 TelegramSendError가 애초에 발생할 수 없다.
+- except 핸들러 자체가 로그만 남기고 사용자에게 재전송하지 않는다(다음 재시도가
+  스스로 복구하거나, 실패해도 안전한 best-effort 부가 작업이다).
+새 항목을 allowlist에 추가하려면 이 표를 수정해야 하므로 리뷰 대상이 된다.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_TELEGRAM_COMMANDS_PATH = (
+    Path(__file__).resolve().parents[1] / "telegram_commands.py"
+)
+
+# (method_name, method 안에서 몇 번째 'except Exception'인가[0-based, 소스 줄 순서]) → 이유.
+_ALLOWLIST: dict[tuple[str, int], str] = {
+    ("_handle_order_callback", 0): (
+        "try 본문이 pending_orders.get()만 호출해 TelegramSendError가 발생할 수 없다. "
+        "except도 answer_callback_query로 응답하지 send_text_or_raise로 재전송하지 않는다."
+    ),
+    ("_handle_watch", 0): (
+        "관심종목별 시세 조회 실패를 목록 한 줄('조회 실패')로 흡수한다. try 본문이 "
+        "mcp_runner만 호출해 TelegramSendError가 발생할 수 없고, except도 텔레그램 API를 "
+        "호출하지 않는다."
+    ),
+    ("_deliver_order_prompt", 0): (
+        "확인 프롬프트 전송 '성공' 이후 prompt_delivered 상태 갱신(pending_orders.set) "
+        "실패를 로그만 남긴다. try 본문이 저장소 호출만 하므로 TelegramSendError가 발생할 "
+        "수 없고, 실패해도 사용자에게 재전송하지 않는다(다음 재시도가 다시 시도한다)."
+    ),
+    ("_handle_confirm", 1): (
+        "settled 레코드(체결 결과를 이미 전송한 뒤) 정리(delete) 실패를 로그만 남긴다. "
+        "try 본문이 저장소 삭제만 하므로 TelegramSendError가 발생할 수 없다."
+    ),
+    ("_handle_confirm", 3): (
+        "403 가드 실패 후 대기 주문 복원(set_if_absent) 실패를 로그만 남긴다. try 본문이 "
+        "저장소 호출만 하므로 TelegramSendError가 발생할 수 없다."
+    ),
+    ("_handle_confirm", 4): (
+        "거래 이력 기록(trade_recorder.record, DB 호출) 실패를 로그만 남기고 경고 문구로만 "
+        "반영한다. 텔레그램 API를 호출하지 않는다."
+    ),
+    ("_handle_confirm", 5): (
+        "체결 결과(settled) 저장 실패를 로그만 남긴다. try 본문이 저장소 호출만 하므로 "
+        "TelegramSendError가 발생할 수 없다."
+    ),
+    ("_handle_confirm", 6): (
+        "체결 결과 전송 성공 후 settled 레코드 정리(delete) 실패를 로그만 남긴다. try 본문이 "
+        "저장소 삭제만 하므로 TelegramSendError가 발생할 수 없다."
+    ),
+}
+
+
+def _is_bare_exception_handler(handler: ast.ExceptHandler) -> bool:
+    """`except Exception` / `except Exception as exc` (다른 이름 없이 정확히 Exception)."""
+    return isinstance(handler.type, ast.Name) and handler.type.id == "Exception"
+
+
+def _is_pure_telegram_send_error_reraise(handler: ast.ExceptHandler) -> bool:
+    """`except TelegramSendError:` 바로 뒤에 `raise` 한 줄만 있는 순수 재전파인가.
+
+    중간에 로그 등 다른 문장이 있어도(주석은 AST에 안 남으므로 무방) `raise`가
+    유일한 statement면 통과시킨다 — 이 저장소의 실제 코드가 `except
+    TelegramSendError:\n    raise` 사이에 설명 주석만 두는 패턴이기 때문이다.
+    """
+    if not (isinstance(handler.type, ast.Name) and handler.type.id == "TelegramSendError"):
+        return False
+    return len(handler.body) == 1 and isinstance(handler.body[0], ast.Raise) and handler.body[0].exc is None
+
+
+def bare_except_exception_sites(source: str, class_name: str) -> dict[str, list[tuple[int, bool]]]:
+    """class_name 클래스의 각 메서드 안에서 'except Exception' 핸들러를 소스 줄 순서로 나열한다.
+
+    반환값: {method_name: [(lineno, guarded), ...]} — guarded는 바로 앞 핸들러가
+    순수 TelegramSendError 재전파인지 여부.
+    """
+    tree = ast.parse(source)
+    class_node = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ClassDef) and node.name == class_name
+    )
+
+    by_method: dict[str, list[tuple[int, bool]]] = {}
+    for method in class_node.body:
+        if not isinstance(method, (ast.AsyncFunctionDef, ast.FunctionDef)):
+            continue
+        found: list[tuple[int, bool]] = []
+        for node in ast.walk(method):
+            if not isinstance(node, ast.Try):
+                continue
+            handlers = node.handlers
+            for i, handler in enumerate(handlers):
+                if not _is_bare_exception_handler(handler):
+                    continue
+                guarded = i > 0 and _is_pure_telegram_send_error_reraise(handlers[i - 1])
+                found.append((handler.lineno, guarded))
+        if found:
+            found.sort(key=lambda item: item[0])
+            by_method[method.name] = found
+    return by_method
+
+
+def test_handler_except_exception_reraises_telegram_send_error_or_is_allowlisted():
+    """#249: TelegramCommandHandler의 모든 'except Exception'은 TelegramSendError를
+    먼저 재전파하거나, 왜 그럴 필요가 없는지 _ALLOWLIST에 남겨야 한다.
+
+    개별 사이트 회귀 테스트(test_telegram_commands.py)보다 이 테스트가 강한 이유:
+    지금 있는 13곳뿐 아니라 앞으로 추가되는 'except Exception'도 자동으로 걸린다.
+    """
+    source = _TELEGRAM_COMMANDS_PATH.read_text(encoding="utf-8")
+    by_method = bare_except_exception_sites(source, "TelegramCommandHandler")
+
+    violations = []
+    for method_name, handlers in by_method.items():
+        for index, (lineno, guarded) in enumerate(handlers):
+            if guarded:
+                continue
+            if (method_name, index) in _ALLOWLIST:
+                continue
+            violations.append(f"{method_name} (#{index}, line {lineno})")
+
+    assert not violations, (
+        "TelegramCommandHandler의 except Exception은 TelegramSendError를 먼저 "
+        "재전파하거나(`except TelegramSendError:\\n    raise`) 이유와 함께 "
+        "_ALLOWLIST에 등록되어야 한다 (#249). 위반: " + ", ".join(violations)
+    )
+
+
+def test_allowlist_entries_still_exist_in_source():
+    """allowlist가 이미 삭제/이동된 사이트를 가리키는 죽은 항목으로 썩지 않게 한다.
+
+    allowlist의 (method, index)가 실제 소스에서 더 이상 존재하지 않으면(리팩터로
+    사이트가 줄어들었는데 표를 안 지운 경우) 여기서 알려준다.
+    """
+    source = _TELEGRAM_COMMANDS_PATH.read_text(encoding="utf-8")
+    by_method = bare_except_exception_sites(source, "TelegramCommandHandler")
+
+    stale = [
+        key
+        for key in _ALLOWLIST
+        if key[1] >= len(by_method.get(key[0], []))
+    ]
+    assert not stale, f"_ALLOWLIST에 더 이상 존재하지 않는 항목: {stale}"
+
+
+def test_bare_except_exception_sites_helper_detects_unguarded_handler():
+    """구조 검사 자체가 공허하지 않음을 직접 확인한다: 재전파 없는 새
+    'except Exception'을 섞은 가짜 소스에서 unguarded로 검출되는지 검사한다.
+
+    이게 없으면 위 두 테스트가 "우연히 항상 통과하는" 텅 빈 로직이어도 알 수 없다.
+    """
+    fake_source = (
+        "class TelegramCommandHandler:\n"
+        "    async def _guarded(self):\n"
+        "        try:\n"
+        "            await self.something()\n"
+        "        except TelegramSendError:\n"
+        "            raise\n"
+        "        except Exception as exc:\n"
+        "            await self._send_text_or_raise('a')\n"
+        "\n"
+        "    async def _unguarded(self):\n"
+        "        try:\n"
+        "            await self.something_else()\n"
+        "        except Exception as exc:\n"
+        "            await self._send_text_or_raise('b')\n"
+    )
+
+    by_method = bare_except_exception_sites(fake_source, "TelegramCommandHandler")
+
+    assert by_method["_guarded"] == [(7, True)]
+    assert by_method["_unguarded"] == [(13, False)]

--- a/backend/trading_orders.py
+++ b/backend/trading_orders.py
@@ -24,6 +24,19 @@ class PendingOrder:
     created_at: datetime
     order_type: OrderType = "LIMIT"
     callback_token: str = ""
+    # 아래 두 필드는 #247(멱등성) 전용이다. 전송 실패(TelegramSendError)로 poller가
+    # handle_update를 재시도할 때, 이미 확정된 부수효과(저장·체결)를 다시 실행하지 않고
+    # "같은 사용자 응답"으로 수렴시키기 위한 상태다.
+    #
+    # prompt_delivered: set_if_absent로 주문이 저장된 뒤 확인 프롬프트 전송까지
+    # 성공했는지. False인 채로 재시도를 만나면 새 주문을 또 만들지 않고 이
+    # 프롬프트를 재전송한다(telegram_commands._handle_order_command).
+    prompt_delivered: bool = False
+    # settled: place_order(체결)까지 끝났는지. True면 claim()이 이 레코드를 돌려줘도
+    # place_order를 다시 부르지 않고 settled_message만 재전송한다
+    # (telegram_commands._handle_confirm).
+    settled: bool = False
+    settled_message: str | None = None
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## 배경

두 이슈를 한 PR로 처리합니다. #249 본문이 *"[멱등성 이슈]와 함께 다루면 '어떤 전송이 재시도 가능한 지점인가'를 한 번에 정리할 수 있다"* 고 권했고, 실제로 같은 코드 경로라 따로 하면 서로 충돌합니다.

## #249 — `except Exception`이 `TelegramSendError`를 삼켰습니다

PR #242가 전송 실패를 `TelegramSendError`로 분리해 폴러가 별도 예산으로 다루게 했는데, 핸들러의 광범위한 `except Exception`이 이를 삼켰습니다.

```python
await self._send_text_or_raise("주문 준비 실패: ...")   # 여기서 429면
...
except Exception as exc:                                # 삼켜짐
    await self._send_text_or_raise(f"주문 준비 실패: {_short_error(exc)}")
```

폴러는 성공으로 판단해 offset을 전진시키고, 사용자는 원래 메시지 대신 `"주문 준비 실패: telegram send failed"`를 받으며 재시도 기회도 없습니다.

`except Exception` 앞에 `except TelegramSendError: raise`를 두어, 전송 실패가 폴러까지 올라가게 했습니다. 전송 실패는 "이 명령을 처리하다 생긴 오류"가 아니라 "사용자에게 말을 걸 수 없는 상태"라 사용자 메시지로 변환하는 것 자체가 무의미합니다.

## #247 — 부수효과 확정 후 전송 실패 시 재시도가 다른 결과로 끝났습니다

`set_if_absent`로 주문을 저장한 뒤의 전송이 실패해 폴러가 재시도하면, 두 번째 실행은 "이미 대기 주문이 있으므로" 다른 경로를 탔습니다.

`PendingOrder`에 상태 필드 두 개를 더해 재시도를 **같은 사용자 응답으로 수렴**시킵니다.

| 필드 | 의미 |
| --- | --- |
| `prompt_delivered` | 저장 후 확인 프롬프트 전송까지 성공했는가. `False`인 채 재시도를 만나면 새 주문을 만들지 않고 프롬프트를 재전송 |
| `settled` / `settled_message` | `place_order`까지 끝났는가. `claim()`이 이 레코드를 돌려주면 `place_order`를 다시 부르지 않고 저장된 결과만 재전송 |

`claim`이 GETDEL이라 체결 후 레코드가 사라지는 문제는, **체결 직후 `settled=True`로 재저장 → 전송 → 성공 시 삭제** 순서로 해결했습니다. 전송이 실패하면 그 레코드가 남아 재시도가 이를 받습니다.

**하위 호환**: 추가한 필드는 모두 기본값이 있어, 배포 시 Redis에 남아 있던 구버전 레코드가 `_deserialize`에서 그대로 살아납니다(`prompt_delivered=False, settled=False`). 실측 확인했습니다.

## 재전파 가드를 이중으로 고정했습니다

재전파를 **넣는 것**과 그것이 **지켜지는 것**은 다릅니다. 처음 구현 후 13곳의 재전파 블록을 하나씩 제거해 보니 **1곳만 검출**됐습니다 — 나머지 12곳은 누가 조용히 되돌려도 CI가 초록이었습니다.

이슈 #249가 경고한 지점이 정확히 이것입니다: *"변환 경로가 9곳 이상이라 일괄 변경 시 각 경로의 의미를 개별 확인해야 한다."*

### 1. 구조 불변식 테스트 (`test_telegram_commands_invariants.py`)

`ast`로 `telegram_commands.py`를 파싱해 **`TelegramCommandHandler`의 모든 `except Exception`이 앞선 `except TelegramSendError: raise`를 갖거나 allowlist에 있어야 한다**를 강제합니다.

13곳을 개별 테스트로 덮는 것보다 나은 이유는 **앞으로 추가되는 `except Exception`도 자동으로 걸린다**는 점입니다. 지금 13곳을 고정해도 내일 14번째가 재전파 없이 들어오면 아무도 못 잡습니다.

allowlist는 **8곳뿐이고 각각 개별 사유가 붙어 있습니다** — try 본문이 전송을 호출하지 않아 `TelegramSendError`가 발생할 수 없거나, except가 로그만 남기고 재전송하지 않는 경우입니다. 항목을 추가하려면 표를 수정해야 하므로 리뷰 대상이 됩니다.

보조 테스트 둘을 함께 뒀습니다:
- `test_allowlist_entries_still_exist_in_source` — 면제 항목이 사라진 코드를 가리키는 상태를 막습니다
- `test_bare_except_exception_sites_helper_detects_unguarded_handler` — **불변식 테스트 자체가 공허해지는 것**을 막습니다

### 2. 돈 경로는 동작 테스트로도

주문·확인·취소 경로는 구조 검사만으로 부족해, 전송이 `TelegramSendError`를 던졌을 때 `handle_update`가 예외를 전파하는지(= 폴러가 재시도 기회를 갖는지) 동작으로 고정했습니다.

## 검증 (직접 실행)

`pytest backend/` — **454 → 469 passed, 2 skipped** (실패 0건)

**재전파 13곳 개별 제거:**

| | 보강 전 | 최종 |
| --- | --- | --- |
| 개별 제거 시 검출 | **1/13곳** ❌ | **13/13곳** ✅ |

뮤테이션:

| 뮤턴트 | 결과 |
| --- | --- |
| `TelegramSendError` 재전파 (13곳 각각) | **13/13 red** ✅ |
| `settled` 재시도 분기 제거 (#247 핵심) | **1 failed** ✅ |
| `settled` 재저장 제거 | **2 failed** ✅ |
| `prompt_delivered` 분기 제거 | **2 failed** ✅ |
| `set_if_absent` NX 제거 (#223 기존 가드) | **2 failed** ✅ |

## 남는 한계 — 정직하게 적습니다

`place_order` 성공 직후 `set(settled=True)` **자체가 실패**하면(Redis 장애) 상태가 유실돼, 재시도가 "대기 중인 주문이 없습니다"를 받습니다. 체결은 됐는데 사용자는 모르는 상태입니다.

`logger.error`로 흔적을 남기며, **중복 체결 자체는 `mcp-trading`의 `OrderDedupStore`가 별도로 막고 있어** 돈이 두 번 나가지는 않습니다. 이 창을 완전히 닫으려면 체결 원장을 backend에도 두어야 하는데, 이 PR 범위를 넘습니다.

## 범위 밖

**#248(offset 영속화)** 은 폴러의 `offset`/`_handled_ahead`를 Redis에 영속화하는 별도 작업이고, 같은 파일이라 함께 건드리면 충돌합니다. 이 PR 머지 후 진행합니다.

Closes #249
Closes #247
