### PR TITLE
feat: 추론 과정 표시 — 진행 상태 메시지와 응답 근거 각주 (#260)

### DIFF
--- a/backend/services.py
+++ b/backend/services.py
@@ -598,16 +598,23 @@ async def _llm_ollama_chat(user_msg: str) -> str:
 
 
 class NatToolUse(NamedTuple):
-    """각주에 실을 도구 한 건 — 도구명과 성공 여부 (#260).
+    """각주에 실을 도구 한 건 — 도구명과 결과 상태 (#260).
 
-    finus_nat이 도구 강제 원장에서 만들어 보내는 ``{"name": ..., "ok": ...}``에 대응한다.
-    ``ok=False``는 도구를 호출했지만 오류 응답을 받았다는 뜻이다 — 각주에서 성공과
-    구분해 표시해야 한다. 실패한 호출을 "확인한 자료"로 보여주면 사용자는 답변이
-    그 데이터에 근거했다고 읽지만 실제로는 아니다.
+    finus_nat이 도구 강제 원장에서 만들어 보내는
+    ``{"name": ..., "ok": ..., "empty": ...}``에 대응한다.
+
+    ``ok=False``는 도구를 호출했지만 오류 응답을 받았다는 뜻이고,
+    ``ok=True, empty=True``는 호출은 성공했지만 결과 집합이 비었다는 뜻이다(#209).
+    셋 다 각주에서 구분해 표시해야 한다 — 실패나 빈 결과를 그냥 "확인한 자료"로
+    보여주면 사용자는 답변이 그 데이터에 근거했다고 읽지만 실제로는 아니다.
+
+    ``empty``에 기본값이 있는 이유: 이 필드를 싣지 않는 구버전 finus_nat과 섞일 수
+    있다. 기본값 ``False``는 "빈 결과라는 관측이 없음"이지 "데이터가 있었음"이 아니다.
     """
 
     name: str
     ok: bool
+    empty: bool = False
 
 
 class NatAnswer(str):
@@ -621,6 +628,12 @@ class NatAnswer(str):
 
     두 속성은 NAT 응답 페이로드의 **최상위 필드**에서 그대로 온다 — 답변 텍스트
     (``choices[0].message.content``)를 파싱해 만들지 않는다 (#129와 같은 원칙).
+
+    **주의 — 이 타입은 문자열 연산 한 번이면 소실된다.** ``str`` 서브클래스라
+    ``strip()``·``re.sub()``·f-string 등의 결과는 전부 plain ``str``이다. 답변
+    텍스트를 가공하는 계층이 ``llm_chat`` 경계 안에 새로 생기면
+    :meth:`with_text`로 갈아끼워야 한다. 그냥 반환하면 backend는 각주를 **조용히**
+    생략하도록 설계돼 있어(로그도 예외도 없다) 기능만 사라진다.
     """
 
     routed_agent: str | None
@@ -638,6 +651,15 @@ class NatAnswer(str):
         answer.tools_used = tuple(tools_used)
         return answer
 
+    def with_text(self, text: str) -> "NatAnswer":
+        """텍스트만 교체하고 추론 메타데이터를 유지한다 (#260).
+
+        ``llm_chat`` 안에서 응답 텍스트를 가공하는 계층(#230 PII 역치환 등)이 추가될 때
+        ``return transform(raw)``로 끝내면 서브클래스가 소실된다. 그 자리에
+        ``raw.with_text(transform(raw))``를 쓰면 각주가 살아남는다.
+        """
+        return NatAnswer(text, routed_agent=self.routed_agent, tools_used=self.tools_used)
+
 
 # 각주에 실을 도구 개수 상한. tools_used는 다른 서비스(NAT)가 보내는 값이라
 # 개수·길이가 backend에서 보장되지 않는다 — 비정상적으로 긴 목록이 텔레그램 메시지의
@@ -654,7 +676,8 @@ def _nat_reasoning_trace_from_payload(
     실어 보내는 값이다. 여기서는 **읽기만** 한다 — 답변 텍스트를 뒤져서 도구명이나
     에이전트명을 추측하지 않는다.
 
-    ``tools_used``는 ``[{"name": str, "ok": bool}]`` 형태다. 필드가 없거나 타입이
+    ``tools_used``는 ``[{"name": str, "ok": bool, "empty": bool}]`` 형태다
+    (``empty``는 구버전 finus_nat에는 없다). 필드가 없거나 타입이
     어긋나면 조용히 비운다. 두 필드를 싣지 않는 구버전 finus_nat과 혼용될 수 있고,
     각주는 답변에 덧붙는 부가 정보이므로 없다고 해서 응답 자체를 실패로 만들 이유가
     없다. 개수는 :data:`NAT_MAX_TOOLS_USED`로 자른다.
@@ -678,8 +701,11 @@ def _nat_reasoning_trace_from_payload(
             if name in seen:
                 continue
             seen.add(name)
-            # ok가 빠졌거나 bool이 아니면 실패로 본다 — 근거를 과장하지 않는 쪽으로 기운다.
-            tools_used.append(NatToolUse(name, item.get("ok") is True))
+            # ok/empty가 빠졌거나 bool이 아니면 각각 실패·비어있지 않음으로 본다.
+            # ok는 근거를 과장하지 않는 쪽으로 기울고, empty는 관측이 없다는 뜻이므로
+            # ok=False와 겹쳐 "실패인데 빈 결과"가 되지 않도록 ok일 때만 읽는다.
+            ok = item.get("ok") is True
+            tools_used.append(NatToolUse(name, ok, ok and item.get("empty") is True))
             if len(tools_used) >= NAT_MAX_TOOLS_USED:
                 logger.warning(
                     "NAT tools_used가 %d개를 넘어 잘라냅니다 (수신 %d개)",

--- a/backend/services.py
+++ b/backend/services.py
@@ -597,6 +597,66 @@ async def _llm_ollama_chat(user_msg: str) -> str:
     return (choice or "").strip()
 
 
+class NatAnswer(str):
+    """NAT 답변 텍스트 + 추론 메타데이터 (#260).
+
+    ``str`` 서브클래스인 이유: ``llm_chat("nat", ...)``의 반환값은 scheduler의
+    ``analysis_from_nat_text``, Telegram ``/earnings`` 핸들러 등 여러 곳에서 이미
+    문자열로 소비된다. 별도 타입을 새로 반환하면 그 호출부를 전부 고쳐야 하고,
+    "기존 응답 파서를 건드리지 않는다"는 이 작업의 전제가 깨진다. ``str``을
+    상속하면 기존 호출부는 그대로 동작하고, 각주가 필요한 호출부만 두 속성을 읽는다.
+
+    두 속성은 NAT 응답 페이로드의 **최상위 필드**에서 그대로 온다 — 답변 텍스트
+    (``choices[0].message.content``)를 파싱해 만들지 않는다 (#129와 같은 원칙).
+    """
+
+    routed_agent: str | None
+    tools_used: tuple[str, ...]
+
+    def __new__(
+        cls,
+        text: str,
+        *,
+        routed_agent: str | None = None,
+        tools_used: tuple[str, ...] = (),
+    ) -> "NatAnswer":
+        answer = super().__new__(cls, text)
+        answer.routed_agent = routed_agent
+        answer.tools_used = tuple(tools_used)
+        return answer
+
+
+def _nat_reasoning_trace_from_payload(
+    payload: dict[str, Any],
+) -> tuple[str | None, tuple[str, ...]]:
+    """NAT 응답 최상위의 ``routed_agent``/``tools_used``를 읽는다 (#260).
+
+    두 필드는 finus_nat이 supervisor의 라우팅 결과와 도구 강제 원장에서 만들어
+    실어 보내는 값이다. 여기서는 **읽기만** 한다 — 답변 텍스트를 뒤져서 도구명이나
+    에이전트명을 추측하지 않는다.
+
+    필드가 없거나 타입이 어긋나면 조용히 비운다. 두 필드를 싣지 않는 구버전
+    finus_nat과 혼용될 수 있고, 각주는 답변에 덧붙는 부가 정보이므로 없다고 해서
+    응답 자체를 실패로 만들 이유가 없다.
+    """
+    routed_raw = payload.get("routed_agent")
+    routed_agent = routed_raw.strip() if isinstance(routed_raw, str) else ""
+
+    tools_raw = payload.get("tools_used")
+    tools_used: list[str] = []
+    if isinstance(tools_raw, list):
+        for item in tools_raw:
+            if not isinstance(item, str):
+                continue
+            name = item.strip()
+            # 호출 순서 유지 + 중복 제거. finus_nat이 이미 그렇게 보내지만,
+            # 신뢰 경계 밖의 값이므로 backend에서도 같은 불변식을 세운다.
+            if name and name not in tools_used:
+                tools_used.append(name)
+
+    return (routed_agent or None), tuple(tools_used)
+
+
 def _nat_message_from_payload(payload: dict[str, Any]) -> str:
     if "error" in payload:
         err = payload["error"]
@@ -632,7 +692,7 @@ def _log_nat_response(resp: httpx.Response) -> None:
         )
 
 
-async def _llm_nat_chat(user_msg: str, *, conversation_id: str | None = None) -> str:
+async def _llm_nat_chat(user_msg: str, *, conversation_id: str | None = None) -> NatAnswer:
     url = f"{NAT_BASE_URL}/v1/chat/completions"
     cid = (conversation_id or NAT_CONVERSATION_ID).strip()
     headers = {
@@ -681,7 +741,7 @@ async def _llm_nat_chat(user_msg: str, *, conversation_id: str | None = None) ->
         raise HTTPException(status_code=502, detail="NAT 응답이 JSON 객체가 아닙니다.")
 
     try:
-        return _nat_message_from_payload(payload)
+        message = _nat_message_from_payload(payload)
     except (KeyError, IndexError, TypeError) as exc:
         body_snip = resp.text[:1200] if resp.text else ""
         raise HTTPException(
@@ -691,6 +751,11 @@ async def _llm_nat_chat(user_msg: str, *, conversation_id: str | None = None) ->
                 f"body[:1200]={body_snip!r}"
             ),
         ) from exc
+
+    # #260: 답변 텍스트는 위에서 기존 파서가 그대로 뽑았고, 여기서는 추론 메타데이터만
+    # 덧붙인다. NatAnswer는 str이므로 이 반환값을 문자열로 쓰는 기존 호출부는 불변이다.
+    routed_agent, tools_used = _nat_reasoning_trace_from_payload(payload)
+    return NatAnswer(message, routed_agent=routed_agent, tools_used=tools_used)
 
 
 async def run_mcp_tool(

--- a/backend/services.py
+++ b/backend/services.py
@@ -3,7 +3,7 @@ import httpx
 import logging
 import re
 from datetime import date
-from typing import Any, Literal, Optional, get_args
+from typing import Any, Literal, NamedTuple, Optional, get_args, overload
 from urllib.parse import quote as _url_quote
 from fastapi import HTTPException
 from anthropic import AsyncAnthropic
@@ -597,6 +597,19 @@ async def _llm_ollama_chat(user_msg: str) -> str:
     return (choice or "").strip()
 
 
+class NatToolUse(NamedTuple):
+    """각주에 실을 도구 한 건 — 도구명과 성공 여부 (#260).
+
+    finus_nat이 도구 강제 원장에서 만들어 보내는 ``{"name": ..., "ok": ...}``에 대응한다.
+    ``ok=False``는 도구를 호출했지만 오류 응답을 받았다는 뜻이다 — 각주에서 성공과
+    구분해 표시해야 한다. 실패한 호출을 "확인한 자료"로 보여주면 사용자는 답변이
+    그 데이터에 근거했다고 읽지만 실제로는 아니다.
+    """
+
+    name: str
+    ok: bool
+
+
 class NatAnswer(str):
     """NAT 답변 텍스트 + 추론 메타데이터 (#260).
 
@@ -611,14 +624,14 @@ class NatAnswer(str):
     """
 
     routed_agent: str | None
-    tools_used: tuple[str, ...]
+    tools_used: tuple[NatToolUse, ...]
 
     def __new__(
         cls,
         text: str,
         *,
         routed_agent: str | None = None,
-        tools_used: tuple[str, ...] = (),
+        tools_used: tuple[NatToolUse, ...] = (),
     ) -> "NatAnswer":
         answer = super().__new__(cls, text)
         answer.routed_agent = routed_agent
@@ -626,33 +639,54 @@ class NatAnswer(str):
         return answer
 
 
+# 각주에 실을 도구 개수 상한. tools_used는 다른 서비스(NAT)가 보내는 값이라
+# 개수·길이가 backend에서 보장되지 않는다 — 비정상적으로 긴 목록이 텔레그램 메시지의
+# 본문 자리를 밀어내지 않도록 파싱 단계에서 잘라 둔다.
+NAT_MAX_TOOLS_USED = 16
+
+
 def _nat_reasoning_trace_from_payload(
     payload: dict[str, Any],
-) -> tuple[str | None, tuple[str, ...]]:
+) -> tuple[str | None, tuple[NatToolUse, ...]]:
     """NAT 응답 최상위의 ``routed_agent``/``tools_used``를 읽는다 (#260).
 
     두 필드는 finus_nat이 supervisor의 라우팅 결과와 도구 강제 원장에서 만들어
     실어 보내는 값이다. 여기서는 **읽기만** 한다 — 답변 텍스트를 뒤져서 도구명이나
     에이전트명을 추측하지 않는다.
 
-    필드가 없거나 타입이 어긋나면 조용히 비운다. 두 필드를 싣지 않는 구버전
-    finus_nat과 혼용될 수 있고, 각주는 답변에 덧붙는 부가 정보이므로 없다고 해서
-    응답 자체를 실패로 만들 이유가 없다.
+    ``tools_used``는 ``[{"name": str, "ok": bool}]`` 형태다. 필드가 없거나 타입이
+    어긋나면 조용히 비운다. 두 필드를 싣지 않는 구버전 finus_nat과 혼용될 수 있고,
+    각주는 답변에 덧붙는 부가 정보이므로 없다고 해서 응답 자체를 실패로 만들 이유가
+    없다. 개수는 :data:`NAT_MAX_TOOLS_USED`로 자른다.
     """
     routed_raw = payload.get("routed_agent")
     routed_agent = routed_raw.strip() if isinstance(routed_raw, str) else ""
 
     tools_raw = payload.get("tools_used")
-    tools_used: list[str] = []
+    tools_used: list[NatToolUse] = []
+    seen: set[str] = set()
     if isinstance(tools_raw, list):
         for item in tools_raw:
-            if not isinstance(item, str):
+            if not isinstance(item, dict):
                 continue
-            name = item.strip()
+            name = item.get("name")
+            if not isinstance(name, str) or not name.strip():
+                continue
+            name = name.strip()
             # 호출 순서 유지 + 중복 제거. finus_nat이 이미 그렇게 보내지만,
             # 신뢰 경계 밖의 값이므로 backend에서도 같은 불변식을 세운다.
-            if name and name not in tools_used:
-                tools_used.append(name)
+            if name in seen:
+                continue
+            seen.add(name)
+            # ok가 빠졌거나 bool이 아니면 실패로 본다 — 근거를 과장하지 않는 쪽으로 기운다.
+            tools_used.append(NatToolUse(name, item.get("ok") is True))
+            if len(tools_used) >= NAT_MAX_TOOLS_USED:
+                logger.warning(
+                    "NAT tools_used가 %d개를 넘어 잘라냅니다 (수신 %d개)",
+                    NAT_MAX_TOOLS_USED,
+                    len(tools_raw),
+                )
+                break
 
     return (routed_agent or None), tuple(tools_used)
 
@@ -877,6 +911,28 @@ def normalize_llm_provider(
             "openai | anthropic | ollama | nat(API 전용) 중 하나를 사용하세요."
         ),
     )
+
+
+# provider별 반환 타입 오버로드 (#260): "nat"만 추론 메타데이터를 실은 NatAnswer를
+# 돌려준다. NatAnswer는 str 서브클래스라 단순 유니온(`str | NatAnswer`)으로는 타입
+# 체커에게 아무 정보도 못 준다 — str로 접히기 때문이다. Literal 오버로드로 갈라야
+# routed_agent/tools_used를 읽는 호출부가 체커의 도움을 받는다.
+@overload
+async def llm_chat(
+    provider_key: Literal["nat"],
+    user_msg: str,
+    *,
+    conversation_id: str | None = None,
+) -> NatAnswer: ...
+
+
+@overload
+async def llm_chat(
+    provider_key: Literal["openai", "anthropic", "ollama"],
+    user_msg: str,
+    *,
+    conversation_id: str | None = None,
+) -> str: ...
 
 
 async def llm_chat(

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -178,15 +178,125 @@ LOOKUP_COMMAND_HELP = "\n".join(
 )
 TELEGRAM_MESSAGE_LIMIT = 4000
 TELEGRAM_TRUNCATION_SUFFIX = "...(이하 생략)"
+
+# ---- 추론 과정 표시 (#260) ----
+
+NAT_PROGRESS_MESSAGE = "⏳ 분석 중입니다..."
+# 텔레그램은 같은 메시지에 대한 잦은 편집을 제한한다. 굵직한 단계에만 쓰도록 상한을 둔다.
+MAX_PROGRESS_EDITS = 2
+REASONING_FOOTNOTE_SEPARATOR = "─────"
+
+# NAT supervisor 브랜치명 → 사용자에게 보여줄 한국어 라벨.
+# 키는 finus_nat/configs/router*.yml의 branches[].name과 같아야 한다.
+AGENT_LABELS: dict[str, str] = {
+    "trading_agent": "트레이딩 에이전트",
+    "monitoring_agent": "모니터링 에이전트",
+    "news_agent": "뉴스 에이전트",
+    "recommend_agent": "추천 에이전트",
+    "strategy_agent": "전략 에이전트",
+    "diary_agent": "매매일지 에이전트",
+}
+
+# 도구 강제 원장(finus_nat/src/nat_finus_nat/finus_api.py의 _record_to_ledger 호출부)에
+# 기록되는 내부 도구명 → 사용자에게 보여줄 한국어 라벨.
+# 매핑에 없는 도구는 내부 이름을 그대로 노출한다 — 조용히 감추면 각주가 "확인한 자료"를
+# 실제보다 적게 보여주게 되어, 근거를 보여준다는 목적 자체가 무너진다.
+TOOL_LABELS: dict[str, str] = {
+    "finus_account_balance": "KIS 시세·계좌 조회",
+    "finus_market_news": "뉴스 검색",
+    "finus_disclosure_signal": "지분공시 조회",
+    "finus_earnings_report": "DART 실적 조회",
+    "finus_mcp_trading_today_orders": "당일 주문·체결 조회",
+    "finus_mcp_trading_get_balance": "계좌 잔고 조회",
+    "finus_mcp_trading_balance_rlz_pl": "실현손익 조회",
+    "finus_save_diary": "매매일지 저장",
+    "finus_list_diaries": "매매일지 조회",
+}
+
 _telegram_command_task: asyncio.Task | None = None
 
 
-def _telegram_text(text: str) -> str:
+def _telegram_text(text: str, limit: int = TELEGRAM_MESSAGE_LIMIT) -> str:
     stripped = text.strip()
-    if len(stripped) <= TELEGRAM_MESSAGE_LIMIT:
+    if len(stripped) <= limit:
         return stripped
-    keep = TELEGRAM_MESSAGE_LIMIT - len(TELEGRAM_TRUNCATION_SUFFIX)
+    keep = limit - len(TELEGRAM_TRUNCATION_SUFFIX)
     return f"{stripped[:keep]}{TELEGRAM_TRUNCATION_SUFFIX}"
+
+
+def _reasoning_footnote(routed_agent: Any, tools_used: Any) -> str:
+    """담당 에이전트·확인한 자료 각주를 만든다. 근거가 없으면 빈 문자열 (#260).
+
+    입력은 NAT 응답의 ``routed_agent``/``tools_used`` 필드에서만 온다 — 답변 텍스트를
+    파싱해 에이전트명이나 도구명을 추측하지 않는다 (#129와 같은 원칙). 파싱으로 만들면
+    "실제로 호출한 도구"가 아니라 "모델이 호출했다고 주장하는 도구"가 되어, 근거로
+    보여주는 각주가 오히려 환각을 사실처럼 전달하는 표면이 된다.
+
+    두 값이 모두 없으면(구버전 finus_nat 등) 각주를 조용히 생략한다. 라우팅은 됐는데
+    도구가 하나도 실행되지 않은 경우는 "없음"으로 드러낸다 — 도구 없이 나온 답변이라는
+    사실 자체가 사용자가 알아야 할 근거다.
+    """
+    agent = routed_agent.strip() if isinstance(routed_agent, str) else ""
+    tools = (
+        [name.strip() for name in tools_used if isinstance(name, str) and name.strip()]
+        if isinstance(tools_used, (list, tuple))
+        else []
+    )
+    if not agent and not tools:
+        return ""
+
+    labels: list[str] = []
+    for name in tools:
+        label = TOOL_LABELS.get(name, name)
+        if label not in labels:  # 서로 다른 내부 도구가 같은 라벨로 접힐 수 있다
+            labels.append(label)
+
+    parts: list[str] = []
+    if agent:
+        parts.append(f"🤖 {AGENT_LABELS.get(agent, agent)}")
+    parts.append(f"📚 확인한 자료: {', '.join(labels) if labels else '없음'}")
+    return f"{REASONING_FOOTNOTE_SEPARATOR}\n{' · '.join(parts)}"
+
+
+def _answer_with_footnote(answer: str, footnote: str) -> str:
+    """답변 본문과 각주를 텔레그램 길이 한도 안에 함께 담는다 (#260).
+
+    각주 자리를 먼저 확보한 뒤 본문을 나머지에 맞춰 자른다. 합친 뒤에 자르면 긴 답변에서
+    각주가 통째로 잘려나가, 정작 근거가 필요한 답변에서만 근거가 사라진다.
+    """
+    if not footnote:
+        return _telegram_text(answer)
+    block = f"\n\n{footnote}"
+    return f"{_telegram_text(answer, TELEGRAM_MESSAGE_LIMIT - len(block))}{block}"
+
+
+def _nat_answer_message(result: Any) -> str:
+    """NAT 응답을 각주까지 붙인 텔레그램 메시지로 만든다 (#260).
+
+    ``routed_agent``/``tools_used``는 ``services.NatAnswer``가 실어 오는 속성이다.
+    속성이 없는 값(구버전 경로, 문자열만 주는 대역)이면 각주 없이 본문만 보낸다.
+    """
+    footnote = _reasoning_footnote(
+        getattr(result, "routed_agent", None),
+        getattr(result, "tools_used", ()),
+    )
+    return _answer_with_footnote(str(result), footnote)
+
+
+@dataclass
+class _ProgressMessage:
+    """진행 메시지 한 건의 상태 — 편집 대상 message_id와 남은 편집 예산 (#260).
+
+    ``message_id``가 없으면(전송 실패, 또는 message_id를 주지 못하는 notifier) 편집할
+    수 없으므로 최종 답변은 새 메시지로 나간다.
+    """
+
+    message_id: int | None = None
+    edits_used: int = 0
+
+    @property
+    def editable(self) -> bool:
+        return self.message_id is not None and self.edits_used < MAX_PROGRESS_EDITS
 
 
 def _short_error(exc: Exception) -> str:
@@ -1346,8 +1456,39 @@ class TelegramCommandHandler:
             lines.append(line)
         return "\n".join(lines).strip()
 
+    async def _send_progress_message(self, text: str) -> _ProgressMessage:
+        """진행 메시지를 보내고 이후 편집에 쓸 상태를 반환한다 (#260).
+
+        message_id를 돌려주지 못하는 notifier에서는 진행 메시지만 일반 전송하고
+        편집 불가 상태를 반환한다 — 최종 답변은 새 메시지로 나간다.
+
+        전송 실패는 삼킨다. 진행 표시는 답변에 덧붙는 편의 기능이므로, 이걸로
+        질의 처리 자체를 실패시키면 사용자는 답도 못 받는다.
+        """
+        send_returning_id = getattr(self.notifier, "send_text_returning_id", None)
+        if callable(send_returning_id):
+            return _ProgressMessage(message_id=await send_returning_id(text))
+        await self.notifier.send_text(text)
+        return _ProgressMessage()
+
+    async def _replace_progress_message(self, progress: _ProgressMessage, text: str) -> None:
+        """진행 메시지를 *text*로 교체한다. 편집할 수 없으면 새 메시지로 보낸다 (#260)."""
+        if progress.editable:
+            progress.edits_used += 1
+            edit_message_text = getattr(self.notifier, "edit_message_text", None)
+            if callable(edit_message_text) and await edit_message_text(progress.message_id, text):
+                return
+            logger.info(
+                "진행 메시지 편집 실패 — 새 메시지로 폴백합니다 (message_id=%s)",
+                progress.message_id,
+            )
+        await self._send_text_or_raise(text)
+
     async def _handle_chat_fallback(self, text: str, chat_id: str) -> None:
         await self.notifier.send_chat_action("typing")
+        # #260: NAT 응답까지 수십 초가 걸린다. typing 액션은 5초 뒤 사라지므로
+        # 접수 즉시 진행 메시지를 남기고, 응답이 오면 그 메시지를 답변으로 교체한다.
+        progress = await self._send_progress_message(NAT_PROGRESS_MESSAGE)
         try:
             result = await self.llm_runner(
                 "nat",
@@ -1355,9 +1496,10 @@ class TelegramCommandHandler:
                 conversation_id=f"telegram:{chat_id}",
             )
         except Exception as exc:
-            await self._send_text_or_raise(f"응답 생성 실패: {_short_error(exc)}")
+            # 실패해도 진행 메시지를 교체한다 — 안 그러면 "분석 중"이 영원히 남는다.
+            await self._replace_progress_message(progress, f"응답 생성 실패: {_short_error(exc)}")
             return
-        await self._send_text_or_raise(_telegram_text(str(result)))
+        await self._replace_progress_message(progress, _nat_answer_message(result))
 
     @asynccontextmanager
     async def _state(self):

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -1687,11 +1687,11 @@ class TelegramCommandHandler:
         message_id를 돌려주지 못하는 notifier에서는 일반 전송만 하고 ``None``을
         반환한다 — 이 경우 진행 메시지는 대화에 그대로 남는다.
 
-        전송 실패는 여기서 잡지 않고 삼켜져서 들어온다: ``TelegramNotifier``의
-        ``send_text_returning_id``/``send_text``가 내부에서 예외를 잡아 각각 ``None``·
-        무시로 떨어뜨린다. 진행 표시는 답변에 덧붙는 편의 기능이므로 이걸로 질의 처리
-        자체를 실패시키면 사용자는 답도 못 받는다 — 그 성질이 필요해서 여기서 다시
-        감싸 두었다. notifier는 생성자로 주입 가능하므로 대역이 예외를 던질 수 있다.
+        전송 실패는 여기서 삼킨다. ``TelegramNotifier``의 ``send_text_returning_id``/
+        ``send_text``는 이미 내부에서 예외를 잡아 각각 ``None``·무시로 떨어뜨리지만,
+        notifier는 생성자로 주입 가능하므로 대역이 예외를 던질 수 있다. 진행 표시는
+        답변에 덧붙는 편의 기능이라 이걸로 질의 처리 자체를 실패시키면 사용자는 답도
+        못 받는다 — 그래서 주입된 구현이 무엇이든 여기서 한 겹 감싼다.
         """
         try:
             send_returning_id = getattr(self.notifier, "send_text_returning_id", None)

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -33,7 +33,12 @@ from .redis_state import (
 )
 from .services import llm_chat, run_mcp_tool
 from .watchlist_repo import SqliteWatchlistRepo
-from .telegram_notifier import TELEGRAM_ALERT_MODES, TelegramNotifier, telegram_notifier
+from .telegram_notifier import (
+    TELEGRAM_ALERT_MODES,
+    TELEGRAM_MESSAGE_LIMIT,
+    TelegramNotifier,
+    telegram_notifier,
+)
 from .timeutil import KST
 from .trading_orders import (
     McpTradingOrderGateway,
@@ -176,15 +181,18 @@ LOOKUP_COMMAND_HELP = "\n".join(
         f"{TREND_COMMAND_HELP}  예: /trend 삼성전자",
     ]
 )
-TELEGRAM_MESSAGE_LIMIT = 4000
 TELEGRAM_TRUNCATION_SUFFIX = "...(이하 생략)"
 
 # ---- 추론 과정 표시 (#260) ----
 
 NAT_PROGRESS_MESSAGE = "⏳ 분석 중입니다..."
-# 텔레그램은 같은 메시지에 대한 잦은 편집을 제한한다. 굵직한 단계에만 쓰도록 상한을 둔다.
-MAX_PROGRESS_EDITS = 2
+# 진행 메시지 삭제가 거부됐을 때 남길 종료 표시. "분석 중"이 영원히 남지 않게 한다.
+PROGRESS_DONE_MESSAGE = "✅ 분석 완료"
 REASONING_FOOTNOTE_SEPARATOR = "─────"
+# 각주 전체 길이 상한. 각주 자리를 먼저 확보하고 본문을 자르는 구조라, 각주가 길어지면
+# 본문 몫이 그만큼 줄어든다. 상한이 없으면 본문 예산이 음수가 되어 답변이 통째로
+# 사라진 채 각주만 남을 수 있다.
+REASONING_FOOTNOTE_MAX_CHARS = 300
 
 # NAT supervisor 브랜치명 → 사용자에게 보여줄 한국어 라벨.
 # 키는 finus_nat/configs/router*.yml의 branches[].name과 같아야 한다.
@@ -220,7 +228,8 @@ def _telegram_text(text: str, limit: int = TELEGRAM_MESSAGE_LIMIT) -> str:
     stripped = text.strip()
     if len(stripped) <= limit:
         return stripped
-    keep = limit - len(TELEGRAM_TRUNCATION_SUFFIX)
+    # max(0, ...): limit이 말줄임 접미사보다 짧아도 음수 인덱스로 뒤집히지 않게 한다.
+    keep = max(0, limit - len(TELEGRAM_TRUNCATION_SUFFIX))
     return f"{stripped[:keep]}{TELEGRAM_TRUNCATION_SUFFIX}"
 
 
@@ -235,27 +244,37 @@ def _reasoning_footnote(routed_agent: Any, tools_used: Any) -> str:
     두 값이 모두 없으면(구버전 finus_nat 등) 각주를 조용히 생략한다. 라우팅은 됐는데
     도구가 하나도 실행되지 않은 경우는 "없음"으로 드러낸다 — 도구 없이 나온 답변이라는
     사실 자체가 사용자가 알아야 할 근거다.
+
+    호출했지만 실패한 도구는 ``(실패)``를 붙여 성공과 구분한다. 실패를 그냥 "확인한
+    자료"로 적으면 사용자는 답변이 그 데이터에 근거했다고 읽는다 — 실제로는 아니므로,
+    근거를 보여준다는 이 기능의 목적과 정반대의 오독이 된다. 그렇다고 목록에서 빼면
+    시도조차 안 한 것처럼 보이므로, 빼지 않고 결과를 함께 적는다.
     """
     agent = routed_agent.strip() if isinstance(routed_agent, str) else ""
-    tools = (
-        [name.strip() for name in tools_used if isinstance(name, str) and name.strip()]
-        if isinstance(tools_used, (list, tuple))
-        else []
-    )
+    tools = list(tools_used) if isinstance(tools_used, (list, tuple)) else []
     if not agent and not tools:
         return ""
 
-    labels: list[str] = []
-    for name in tools:
-        label = TOOL_LABELS.get(name, name)
-        if label not in labels:  # 서로 다른 내부 도구가 같은 라벨로 접힐 수 있다
-            labels.append(label)
+    entries: list[str] = []
+    for tool in tools:
+        name = getattr(tool, "name", None)
+        if not isinstance(name, str) or not name.strip():
+            continue
+        entry = TOOL_LABELS.get(name.strip(), name.strip())
+        if getattr(tool, "ok", False) is not True:
+            entry = f"{entry}(실패)"
+        if entry not in entries:  # 서로 다른 내부 도구가 같은 라벨로 접힐 수 있다
+            entries.append(entry)
+
+    if not agent and not entries:
+        return ""
 
     parts: list[str] = []
     if agent:
         parts.append(f"🤖 {AGENT_LABELS.get(agent, agent)}")
-    parts.append(f"📚 확인한 자료: {', '.join(labels) if labels else '없음'}")
-    return f"{REASONING_FOOTNOTE_SEPARATOR}\n{' · '.join(parts)}"
+    parts.append(f"📚 확인한 자료: {', '.join(entries) if entries else '없음'}")
+    footnote = f"{REASONING_FOOTNOTE_SEPARATOR}\n{' · '.join(parts)}"
+    return _telegram_text(footnote, REASONING_FOOTNOTE_MAX_CHARS)
 
 
 def _answer_with_footnote(answer: str, footnote: str) -> str:
@@ -281,22 +300,6 @@ def _nat_answer_message(result: Any) -> str:
         getattr(result, "tools_used", ()),
     )
     return _answer_with_footnote(str(result), footnote)
-
-
-@dataclass
-class _ProgressMessage:
-    """진행 메시지 한 건의 상태 — 편집 대상 message_id와 남은 편집 예산 (#260).
-
-    ``message_id``가 없으면(전송 실패, 또는 message_id를 주지 못하는 notifier) 편집할
-    수 없으므로 최종 답변은 새 메시지로 나간다.
-    """
-
-    message_id: int | None = None
-    edits_used: int = 0
-
-    @property
-    def editable(self) -> bool:
-        return self.message_id is not None and self.edits_used < MAX_PROGRESS_EDITS
 
 
 def _short_error(exc: Exception) -> str:
@@ -1456,39 +1459,51 @@ class TelegramCommandHandler:
             lines.append(line)
         return "\n".join(lines).strip()
 
-    async def _send_progress_message(self, text: str) -> _ProgressMessage:
-        """진행 메시지를 보내고 이후 편집에 쓸 상태를 반환한다 (#260).
+    async def _send_progress_message(self, text: str) -> int | None:
+        """진행 메시지를 보내고 나중에 치울 message_id를 반환한다 (#260).
 
-        message_id를 돌려주지 못하는 notifier에서는 진행 메시지만 일반 전송하고
-        편집 불가 상태를 반환한다 — 최종 답변은 새 메시지로 나간다.
+        message_id를 돌려주지 못하는 notifier에서는 일반 전송만 하고 ``None``을
+        반환한다 — 이 경우 진행 메시지는 대화에 그대로 남는다.
 
         전송 실패는 삼킨다. 진행 표시는 답변에 덧붙는 편의 기능이므로, 이걸로
         질의 처리 자체를 실패시키면 사용자는 답도 못 받는다.
         """
         send_returning_id = getattr(self.notifier, "send_text_returning_id", None)
         if callable(send_returning_id):
-            return _ProgressMessage(message_id=await send_returning_id(text))
+            return await send_returning_id(text)
         await self.notifier.send_text(text)
-        return _ProgressMessage()
+        return None
 
-    async def _replace_progress_message(self, progress: _ProgressMessage, text: str) -> None:
-        """진행 메시지를 *text*로 교체한다. 편집할 수 없으면 새 메시지로 보낸다 (#260)."""
-        if progress.editable:
-            progress.edits_used += 1
-            edit_message_text = getattr(self.notifier, "edit_message_text", None)
-            if callable(edit_message_text) and await edit_message_text(progress.message_id, text):
-                return
-            logger.info(
-                "진행 메시지 편집 실패 — 새 메시지로 폴백합니다 (message_id=%s)",
-                progress.message_id,
-            )
-        await self._send_text_or_raise(text)
+    async def _clear_progress_message(self, message_id: int | None) -> None:
+        """진행 메시지를 치운다 — 삭제하고, 삭제가 거부되면 종료 표시로 편집한다 (#260).
+
+        최종 답변을 이 메시지의 **편집으로 내보내지 않는 이유**: 텔레그램은 메시지
+        편집에 대해 푸시 알림을 보내지 않고 읽지 않음 표시도 갱신하지 않는다. 편집으로
+        답을 내보내면 수십 초를 기다리다 앱을 닫은 사용자가 정작 답변 도착 알림을 받지
+        못한다 — 체감 응답성을 높이려는 기능이 알림 가치를 뒤집는 셈이다.
+        답변은 항상 새 메시지로 보낸다.
+
+        실패는 삼킨다. 진행 메시지 정리는 답변 전달보다 덜 중요하다.
+        """
+        if message_id is None:
+            return
+
+        delete_message = getattr(self.notifier, "delete_message", None)
+        if callable(delete_message) and await delete_message(message_id):
+            return
+
+        edit_message_text = getattr(self.notifier, "edit_message_text", None)
+        if callable(edit_message_text) and await edit_message_text(message_id, PROGRESS_DONE_MESSAGE):
+            return
+
+        logger.info("진행 메시지를 정리하지 못했습니다 (message_id=%s)", message_id)
 
     async def _handle_chat_fallback(self, text: str, chat_id: str) -> None:
         await self.notifier.send_chat_action("typing")
         # #260: NAT 응답까지 수십 초가 걸린다. typing 액션은 5초 뒤 사라지므로
-        # 접수 즉시 진행 메시지를 남기고, 응답이 오면 그 메시지를 답변으로 교체한다.
-        progress = await self._send_progress_message(NAT_PROGRESS_MESSAGE)
+        # 접수 즉시 진행 메시지를 남기고, 응답이 오면 그 메시지를 치운 뒤 답변을
+        # 새 메시지로 보낸다(편집은 푸시 알림을 발생시키지 않는다).
+        progress_message_id = await self._send_progress_message(NAT_PROGRESS_MESSAGE)
         try:
             result = await self.llm_runner(
                 "nat",
@@ -1496,10 +1511,12 @@ class TelegramCommandHandler:
                 conversation_id=f"telegram:{chat_id}",
             )
         except Exception as exc:
-            # 실패해도 진행 메시지를 교체한다 — 안 그러면 "분석 중"이 영원히 남는다.
-            await self._replace_progress_message(progress, f"응답 생성 실패: {_short_error(exc)}")
-            return
-        await self._replace_progress_message(progress, _nat_answer_message(result))
+            reply = f"응답 생성 실패: {_short_error(exc)}"
+        else:
+            reply = _nat_answer_message(result)
+        # 실패해도 진행 메시지를 치운다 — 안 그러면 "분석 중"이 영원히 남는다.
+        await self._clear_progress_message(progress_message_id)
+        await self._send_text_or_raise(reply)
 
     @asynccontextmanager
     async def _state(self):

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -245,10 +245,12 @@ def _reasoning_footnote(routed_agent: Any, tools_used: Any) -> str:
     도구가 하나도 실행되지 않은 경우는 "없음"으로 드러낸다 — 도구 없이 나온 답변이라는
     사실 자체가 사용자가 알아야 할 근거다.
 
-    호출했지만 실패한 도구는 ``(실패)``를 붙여 성공과 구분한다. 실패를 그냥 "확인한
-    자료"로 적으면 사용자는 답변이 그 데이터에 근거했다고 읽는다 — 실제로는 아니므로,
-    근거를 보여준다는 이 기능의 목적과 정반대의 오독이 된다. 그렇다고 목록에서 빼면
-    시도조차 안 한 것처럼 보이므로, 빼지 않고 결과를 함께 적는다.
+    호출했지만 실패한 도구는 ``(실패)``, 성공했지만 결과가 비었던 도구는 ``(결과 없음)``을
+    붙여 데이터를 얻은 호출과 구분한다. 둘 다 그냥 "확인한 자료"로 적으면 사용자는 답변이
+    그 데이터에 근거했다고 읽는다 — 실제로는 아니므로, 근거를 보여준다는 이 기능의 목적과
+    정반대의 오독이 된다. 빈 결과는 특히 NAT가 "[조회 결과 없음] ..."을 본문으로 돌려주는
+    경로(#209)와 겹쳐, 본문은 데이터가 없다고 말하는데 각주만 자료를 확인했다고 말하게
+    된다. 그렇다고 목록에서 빼면 시도조차 안 한 것처럼 보이므로, 빼지 않고 결과를 함께 적는다.
     """
     agent = routed_agent.strip() if isinstance(routed_agent, str) else ""
     tools = list(tools_used) if isinstance(tools_used, (list, tuple)) else []
@@ -263,6 +265,8 @@ def _reasoning_footnote(routed_agent: Any, tools_used: Any) -> str:
         entry = TOOL_LABELS.get(name.strip(), name.strip())
         if getattr(tool, "ok", False) is not True:
             entry = f"{entry}(실패)"
+        elif getattr(tool, "empty", False) is True:
+            entry = f"{entry}(결과 없음)"
         if entry not in entries:  # 서로 다른 내부 도구가 같은 라벨로 접힐 수 있다
             entries.append(entry)
 
@@ -1465,13 +1469,21 @@ class TelegramCommandHandler:
         message_id를 돌려주지 못하는 notifier에서는 일반 전송만 하고 ``None``을
         반환한다 — 이 경우 진행 메시지는 대화에 그대로 남는다.
 
-        전송 실패는 삼킨다. 진행 표시는 답변에 덧붙는 편의 기능이므로, 이걸로
-        질의 처리 자체를 실패시키면 사용자는 답도 못 받는다.
+        전송 실패는 여기서 잡지 않고 삼켜져서 들어온다: ``TelegramNotifier``의
+        ``send_text_returning_id``/``send_text``가 내부에서 예외를 잡아 각각 ``None``·
+        무시로 떨어뜨린다. 진행 표시는 답변에 덧붙는 편의 기능이므로 이걸로 질의 처리
+        자체를 실패시키면 사용자는 답도 못 받는다 — 그 성질이 필요해서 여기서 다시
+        감싸 두었다. notifier는 생성자로 주입 가능하므로 대역이 예외를 던질 수 있다.
         """
-        send_returning_id = getattr(self.notifier, "send_text_returning_id", None)
-        if callable(send_returning_id):
-            return await send_returning_id(text)
-        await self.notifier.send_text(text)
+        try:
+            send_returning_id = getattr(self.notifier, "send_text_returning_id", None)
+            if callable(send_returning_id):
+                return await send_returning_id(text)
+            await self.notifier.send_text(text)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.error("진행 메시지를 보내지 못했습니다: %s", exc)
         return None
 
     async def _clear_progress_message(self, message_id: int | None) -> None:
@@ -1688,6 +1700,13 @@ class TelegramCommandPoller:
         전송에서 실패하는 경로(/buy의 set_if_absent 후 프롬프트 전송, /confirm의 체결 후
         결과 전송)는 재시도해도 원래 의도를 달성하지 못하고 다른 메시지로 끝난다.
         이 PR 범위 밖이라 별도 이슈로 다룬다 (PR #242 리뷰).
+
+        자연어 경로(_handle_chat_fallback)도 같은 성질을 갖는다 (#260): 재시도마다
+        진행 메시지를 새로 보낸다. 전송 실패 재시도는 대개 429 flood-wait 구간이라
+        정리(deleteMessage/editMessageText)도 함께 실패하기 쉽고, 그 경우 "분석 중"
+        메시지가 최대 예산 횟수만큼 채팅에 남는다. 진행 메시지 전송 실패는 notifier가
+        삼켜 예산에도 잡히지 않으므로, 답변 전송이 막혀 있는 동안에도 같은 채팅의
+        rate limit을 추가로 소모한다. 예산을 손볼 때 함께 보라 (PR #263 리뷰).
 
         그 경로의 재실행 횟수는 예산과 같다 — 일반 실패 4회, 전송 실패 10회다.
         예산을 시간 기반으로 넓히면서 기존 3회보다 늘었다. 자연어 메시지처럼 부수효과가

--- a/backend/telegram_notifier.py
+++ b/backend/telegram_notifier.py
@@ -10,6 +10,9 @@ from .config import TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID, is_placeholder_secret
 logger = logging.getLogger(__name__)
 _TELEGRAM_BOT_URL_RE = re.compile(r"(https://api\.telegram\.org/bot)[^/\s\"]+")
 
+# 텔레그램 sendMessage 본문 상한(4096자)보다 여유를 둔 실사용 상한.
+TELEGRAM_MESSAGE_LIMIT = 4000
+
 URGENT_TELEGRAM_LEVELS = {"high", "critical"}
 TELEGRAM_ALERT_MODES = {"urgent", "all", "off"}
 
@@ -72,9 +75,9 @@ def should_send_telegram_alert(
 def _message_id_from_send_response(response: Any) -> int | None:
     """sendMessage 응답 본문에서 ``message_id``를 뽑는다 (#260).
 
-    본문을 읽을 수 없거나 형식이 다르면 ``None``을 반환해 "편집 불가"로 떨어뜨린다.
-    전송 자체는 이미 성공한 뒤이므로 예외로 올리지 않는다 — 호출부는 편집 대신
-    새 메시지 전송으로 폴백하면 된다.
+    본문을 읽을 수 없거나 형식이 다르면 ``None``을 반환해 "후속 조작 불가"로
+    떨어뜨린다. 전송 자체는 이미 성공한 뒤이므로 예외로 올리지 않는다 — 호출부는
+    진행 메시지 정리를 건너뛰면 된다.
     """
     try:
         body = response.json()
@@ -133,7 +136,7 @@ class TelegramNotifier:
         ]
         if summary:
             lines.append(f"Summary: {summary}")
-        return "\n".join(lines)[:4000]
+        return "\n".join(lines)[:TELEGRAM_MESSAGE_LIMIT]
 
     def format_morning_briefing(self, briefing: dict[str, Any]) -> str:
         lines = [
@@ -149,7 +152,7 @@ class TelegramNotifier:
             "⚡ 주요 촉매 이벤트",
             *self._format_bullets(briefing.get("catalysts")),
         ]
-        return "\n".join(lines)[:4000]
+        return "\n".join(lines)[:TELEGRAM_MESSAGE_LIMIT]
 
     @staticmethod
     def _format_bullets(items: Any) -> list[str]:
@@ -195,7 +198,7 @@ class TelegramNotifier:
             return False
 
         try:
-            await self._post_message(text[:4000], reply_markup=reply_markup)
+            await self._post_message(text[:TELEGRAM_MESSAGE_LIMIT], reply_markup=reply_markup)
             return True
         except Exception as exc:
             logger.error("Telegram message send failed: %s", exc)
@@ -209,24 +212,50 @@ class TelegramNotifier:
     ) -> int | None:
         """메시지를 보내고 ``message_id``를 반환한다. 실패하면 ``None`` (#260).
 
-        진행 메시지처럼 나중에 ``editMessageText``로 갱신할 메시지에 쓴다.
-        성공/실패 bool을 주는 :meth:`send_text`와 달리 편집에 필요한 식별자를 준다.
+        진행 메시지처럼 나중에 지우거나 고칠 메시지에 쓴다. 성공/실패 bool을 주는
+        :meth:`send_text`와 달리 후속 조작에 필요한 식별자를 준다.
         """
         if not self.enabled:
             return None
 
         try:
-            response = await self._post_message(text[:4000], reply_markup=reply_markup)
+            response = await self._post_message(text[:TELEGRAM_MESSAGE_LIMIT], reply_markup=reply_markup)
         except Exception as exc:
             logger.error("Telegram message send failed: %s", exc)
             return None
         return _message_id_from_send_response(response)
 
+    async def delete_message(self, message_id: int) -> bool:
+        """``deleteMessage``로 메시지를 지운다. 거부되면 ``False`` (#260).
+
+        진행 메시지를 치우는 데 쓴다. 실패해도 예외로 올리지 않는다 — 진행 표시
+        정리는 답변 전달보다 덜 중요하다.
+        """
+        if not self.enabled:
+            return False
+
+        url = f"https://api.telegram.org/bot{self.bot_token}/deleteMessage"
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.post(
+                    url,
+                    json={"chat_id": self.chat_id, "message_id": message_id},
+                )
+                response.raise_for_status()
+            return True
+        except Exception as exc:
+            logger.error("Telegram message delete failed: %s", exc)
+            return False
+
     async def edit_message_text(self, message_id: int, text: str) -> bool:
         """``editMessageText``로 기존 메시지 본문을 교체한다 (#260).
 
         메시지가 너무 오래됐거나(48시간 초과) 이미 삭제된 경우 등 편집이 거부되면
-        ``False``를 반환한다. 호출부는 이를 새 메시지 전송으로 폴백하는 신호로 쓴다.
+        ``False``를 반환한다.
+
+        최종 답변을 내보내는 용도로는 쓰지 않는다 — 텔레그램은 편집에 대해 푸시 알림을
+        보내지 않는다. 진행 메시지 삭제가 실패했을 때 "분석 중"이 영원히 남지 않도록
+        종료 표시로 바꾸는 폴백 경로에 쓴다.
         """
         if not self.enabled:
             return False
@@ -239,7 +268,7 @@ class TelegramNotifier:
                     json={
                         "chat_id": self.chat_id,
                         "message_id": message_id,
-                        "text": text[:4000],
+                        "text": text[:TELEGRAM_MESSAGE_LIMIT],
                         "disable_web_page_preview": True,
                     },
                 )

--- a/backend/telegram_notifier.py
+++ b/backend/telegram_notifier.py
@@ -69,6 +69,26 @@ def should_send_telegram_alert(
     )
 
 
+def _message_id_from_send_response(response: Any) -> int | None:
+    """sendMessage 응답 본문에서 ``message_id``를 뽑는다 (#260).
+
+    본문을 읽을 수 없거나 형식이 다르면 ``None``을 반환해 "편집 불가"로 떨어뜨린다.
+    전송 자체는 이미 성공한 뒤이므로 예외로 올리지 않는다 — 호출부는 편집 대신
+    새 메시지 전송으로 폴백하면 된다.
+    """
+    try:
+        body = response.json()
+    except Exception:
+        return None
+    if not isinstance(body, dict) or body.get("ok") is not True:
+        return None
+    result = body.get("result")
+    if not isinstance(result, dict):
+        return None
+    message_id = result.get("message_id")
+    return message_id if isinstance(message_id, int) else None
+
+
 class TelegramNotifier:
     def __init__(
         self,
@@ -181,6 +201,54 @@ class TelegramNotifier:
             logger.error("Telegram message send failed: %s", exc)
             return False
 
+    async def send_text_returning_id(
+        self,
+        text: str,
+        *,
+        reply_markup: dict[str, Any] | None = None,
+    ) -> int | None:
+        """메시지를 보내고 ``message_id``를 반환한다. 실패하면 ``None`` (#260).
+
+        진행 메시지처럼 나중에 ``editMessageText``로 갱신할 메시지에 쓴다.
+        성공/실패 bool을 주는 :meth:`send_text`와 달리 편집에 필요한 식별자를 준다.
+        """
+        if not self.enabled:
+            return None
+
+        try:
+            response = await self._post_message(text[:4000], reply_markup=reply_markup)
+        except Exception as exc:
+            logger.error("Telegram message send failed: %s", exc)
+            return None
+        return _message_id_from_send_response(response)
+
+    async def edit_message_text(self, message_id: int, text: str) -> bool:
+        """``editMessageText``로 기존 메시지 본문을 교체한다 (#260).
+
+        메시지가 너무 오래됐거나(48시간 초과) 이미 삭제된 경우 등 편집이 거부되면
+        ``False``를 반환한다. 호출부는 이를 새 메시지 전송으로 폴백하는 신호로 쓴다.
+        """
+        if not self.enabled:
+            return False
+
+        url = f"https://api.telegram.org/bot{self.bot_token}/editMessageText"
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.post(
+                    url,
+                    json={
+                        "chat_id": self.chat_id,
+                        "message_id": message_id,
+                        "text": text[:4000],
+                        "disable_web_page_preview": True,
+                    },
+                )
+                response.raise_for_status()
+            return True
+        except Exception as exc:
+            logger.error("Telegram message edit failed: %s", exc)
+            return False
+
     async def answer_callback_query(
         self,
         callback_query_id: str,
@@ -259,7 +327,12 @@ class TelegramNotifier:
         text: str,
         *,
         reply_markup: dict[str, Any] | None = None,
-    ) -> None:
+    ) -> Any:
+        """sendMessage를 호출하고 HTTP 응답을 반환한다.
+
+        반환값은 message_id가 필요한 :meth:`send_text_returning_id`만 사용한다.
+        :meth:`send_text`는 예전처럼 성공/실패만 보고 무시한다.
+        """
         url = f"https://api.telegram.org/bot{self.bot_token}/sendMessage"
         payload = {
             "chat_id": self.chat_id,
@@ -271,6 +344,7 @@ class TelegramNotifier:
         async with httpx.AsyncClient(timeout=10.0) as client:
             response = await client.post(url, json=payload)
             response.raise_for_status()
+        return response
 
 
 telegram_notifier = TelegramNotifier()

--- a/backend/telegram_notifier.py
+++ b/backend/telegram_notifier.py
@@ -356,7 +356,7 @@ class TelegramNotifier:
         text: str,
         *,
         reply_markup: dict[str, Any] | None = None,
-    ) -> Any:
+    ) -> httpx.Response:
         """sendMessage를 호출하고 HTTP 응답을 반환한다.
 
         반환값은 message_id가 필요한 :meth:`send_text_returning_id`만 사용한다.

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -968,7 +968,10 @@ async def test_llm_nat_chat_carries_reasoning_metadata(monkeypatch):
         json={
             "choices": [{"message": {"content": "삼성전자 뉴스입니다."}}],
             "routed_agent": "news_agent",
-            "tools_used": ["finus_account_balance", "finus_market_news"],
+            "tools_used": [
+                {"name": "finus_account_balance", "ok": False},
+                {"name": "finus_market_news", "ok": True},
+            ],
         },
     )
     monkeypatch.setattr(services.httpx, "AsyncClient", mock_async_client_factory(response))
@@ -977,7 +980,10 @@ async def test_llm_nat_chat_carries_reasoning_metadata(monkeypatch):
 
     assert result == "삼성전자 뉴스입니다."
     assert result.routed_agent == "news_agent"
-    assert result.tools_used == ("finus_account_balance", "finus_market_news")
+    assert result.tools_used == (
+        services.NatToolUse("finus_account_balance", ok=False),
+        services.NatToolUse("finus_market_news", ok=True),
+    )
 
 
 @pytest.mark.asyncio
@@ -1046,12 +1052,34 @@ def test_nat_reasoning_trace_dedupes_and_keeps_call_order():
     routed_agent, tools_used = services._nat_reasoning_trace_from_payload(
         {
             "routed_agent": "  news_agent  ",
-            "tools_used": ["finus_market_news", "", 7, "finus_market_news", "finus_save_diary"],
+            "tools_used": [
+                {"name": " finus_market_news ", "ok": True},
+                {"name": ""},
+                "문자열은 무시",
+                {"name": "finus_market_news", "ok": True},
+                {"name": "finus_save_diary"},
+            ],
         }
     )
 
     assert routed_agent == "news_agent"
-    assert tools_used == ("finus_market_news", "finus_save_diary")
+    # ok가 없는 항목은 실패로 본다 — 근거를 과장하지 않는 쪽으로 기운다.
+    assert tools_used == (
+        services.NatToolUse("finus_market_news", ok=True),
+        services.NatToolUse("finus_save_diary", ok=False),
+    )
+
+
+def test_nat_reasoning_trace_caps_tool_count():
+    """다른 서비스가 보내는 값이므로 개수를 backend에서 잘라 둔다 (각주가 본문을 밀어냄 방지)."""
+    _, tools_used = services._nat_reasoning_trace_from_payload(
+        {
+            "routed_agent": "news_agent",
+            "tools_used": [{"name": f"tool_{i}", "ok": True} for i in range(100)],
+        }
+    )
+
+    assert len(tools_used) == services.NAT_MAX_TOOLS_USED
 
 
 # ── A (#162): 도구 없는 provider 출력 범위 축소 ──────────────────────────────

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -957,6 +957,103 @@ async def test_llm_nat_chat_logs_json_parse_failure(monkeypatch, caplog):
     assert "NAT response body preview: not-json" in caplog.text
 
 
+# ── #260: NAT 응답의 추론 메타데이터(routed_agent / tools_used) ──────────────
+
+
+@pytest.mark.asyncio
+async def test_llm_nat_chat_carries_reasoning_metadata(monkeypatch):
+    """응답 최상위의 routed_agent/tools_used가 NatAnswer 속성으로 실려 온다."""
+    response = httpx.Response(
+        200,
+        json={
+            "choices": [{"message": {"content": "삼성전자 뉴스입니다."}}],
+            "routed_agent": "news_agent",
+            "tools_used": ["finus_account_balance", "finus_market_news"],
+        },
+    )
+    monkeypatch.setattr(services.httpx, "AsyncClient", mock_async_client_factory(response))
+
+    result = await services._llm_nat_chat("삼성전자 뉴스")
+
+    assert result == "삼성전자 뉴스입니다."
+    assert result.routed_agent == "news_agent"
+    assert result.tools_used == ("finus_account_balance", "finus_market_news")
+
+
+@pytest.mark.asyncio
+async def test_llm_nat_chat_result_is_a_plain_string_for_existing_callers(monkeypatch):
+    """NatAnswer는 str이므로 기존 호출부(scheduler 파서 등)가 그대로 동작한다."""
+    raw = (
+        '{"summary":"요약",'
+        '"details":{"decision":"BUY","confidence_score":0.7,'
+        '"reason":"수급 개선","target_stock":"삼성전자"},'
+        '"source_news":[],"trading_trend":null}'
+    )
+    response = httpx.Response(
+        200,
+        json={
+            "choices": [{"message": {"content": raw}}],
+            "routed_agent": "strategy_agent",
+            "tools_used": [],
+        },
+    )
+    monkeypatch.setattr(services.httpx, "AsyncClient", mock_async_client_factory(response))
+
+    result = await services._llm_nat_chat("삼성전자 분석")
+
+    assert isinstance(result, str)
+    assert str(result) == raw
+    # scheduler 경로의 파서가 메타데이터 추가와 무관하게 그대로 동작한다.
+    parsed = services.analysis_from_nat_text(str(result), "삼성전자")
+    assert parsed["summary"] == "요약"
+    assert parsed["details"]["decision"] == "BUY"
+
+
+@pytest.mark.asyncio
+async def test_llm_nat_chat_without_metadata_yields_empty_trace(monkeypatch):
+    """두 필드를 싣지 않는 구버전 finus_nat 응답도 그대로 처리된다."""
+    response = httpx.Response(200, json={"choices": [{"message": {"content": "답변"}}]})
+    monkeypatch.setattr(services.httpx, "AsyncClient", mock_async_client_factory(response))
+
+    result = await services._llm_nat_chat("질문")
+
+    assert result == "답변"
+    assert result.routed_agent is None
+    assert result.tools_used == ()
+
+
+@pytest.mark.asyncio
+async def test_llm_nat_chat_ignores_malformed_metadata(monkeypatch):
+    """타입이 어긋난 메타데이터는 조용히 버린다 — 각주 때문에 응답을 실패시키지 않는다."""
+    response = httpx.Response(
+        200,
+        json={
+            "choices": [{"message": {"content": "답변"}}],
+            "routed_agent": 42,
+            "tools_used": {"not": "a list"},
+        },
+    )
+    monkeypatch.setattr(services.httpx, "AsyncClient", mock_async_client_factory(response))
+
+    result = await services._llm_nat_chat("질문")
+
+    assert result == "답변"
+    assert result.routed_agent is None
+    assert result.tools_used == ()
+
+
+def test_nat_reasoning_trace_dedupes_and_keeps_call_order():
+    routed_agent, tools_used = services._nat_reasoning_trace_from_payload(
+        {
+            "routed_agent": "  news_agent  ",
+            "tools_used": ["finus_market_news", "", 7, "finus_market_news", "finus_save_diary"],
+        }
+    )
+
+    assert routed_agent == "news_agent"
+    assert tools_used == ("finus_market_news", "finus_save_diary")
+
+
 # ── A (#162): 도구 없는 provider 출력 범위 축소 ──────────────────────────────
 
 

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -1082,6 +1082,85 @@ def test_nat_reasoning_trace_caps_tool_count():
     assert len(tools_used) == services.NAT_MAX_TOOLS_USED
 
 
+def test_nat_reasoning_trace_reads_the_empty_result_flag():
+    """ok=True지만 결과가 비었던 호출을 데이터를 얻은 호출과 구분해 싣는다 (#209).
+
+    각주에서 '(결과 없음)'으로 표시하려면 이 경계에서 상태가 살아 있어야 한다.
+    empty를 버리면 NAT가 '[조회 결과 없음]'을 본문으로 돌려준 답변에도 각주는
+    '확인한 자료: 뉴스 검색'이라고 적어 본문과 정면으로 어긋난다.
+    """
+    _, tools_used = services._nat_reasoning_trace_from_payload(
+        {
+            "routed_agent": "news_agent",
+            "tools_used": [
+                {"name": "finus_market_news", "ok": True, "empty": True},
+                {"name": "finus_earnings_report", "ok": True, "empty": False},
+                {"name": "finus_account_balance", "ok": True},
+            ],
+        }
+    )
+
+    assert tools_used == (
+        services.NatToolUse("finus_market_news", ok=True, empty=True),
+        services.NatToolUse("finus_earnings_report", ok=True, empty=False),
+        # empty를 싣지 않는 구버전 finus_nat — '빈 결과라는 관측이 없음'으로 읽는다.
+        services.NatToolUse("finus_account_balance", ok=True, empty=False),
+    )
+
+
+def test_nat_reasoning_trace_never_marks_a_failed_call_as_empty():
+    """ok=False와 empty=True가 동시에 서지 않게 한다 — 각주 표기가 갈라지지 않는다."""
+    _, tools_used = services._nat_reasoning_trace_from_payload(
+        {"tools_used": [{"name": "finus_market_news", "ok": False, "empty": True}]}
+    )
+
+    assert tools_used == (services.NatToolUse("finus_market_news", ok=False, empty=False),)
+
+
+@pytest.mark.asyncio
+async def test_llm_chat_preserves_nat_reasoning_metadata(monkeypatch):
+    """llm_chat 경계를 통과해도 NatAnswer가 살아남아야 한다 (PR #263 리뷰).
+
+    NatAnswer는 str 서브클래스라 문자열 연산 한 번(strip/sub/f-string)이면 메타데이터가
+    소실된다. 프로덕션 경로는 TelegramCommandHandler(llm_runner=llm_chat)인데 기존
+    테스트는 _llm_nat_chat을 직접 부르거나 llm_runner를 가짜로 주입해서, 정작 이 경계는
+    아무도 덮지 않았다. 각주는 설계상 '조용히' 생략되므로 — 로그도 예외도 남지 않는다 —
+    이 경계에서는 테스트가 유일한 방어선이다. 특히 #230(PII 마스킹)처럼 llm_chat 안에서
+    응답 텍스트를 가공하는 계층이 추가될 때 여기서 걸린다.
+    """
+
+    async def fake_nat(user_msg, *, conversation_id=None):
+        return services.NatAnswer(
+            "답변",
+            routed_agent="news_agent",
+            tools_used=(services.NatToolUse("finus_market_news", ok=True),),
+        )
+
+    monkeypatch.setattr(services, "_llm_nat_chat", fake_nat)
+
+    result = await services.llm_chat("nat", "질의")
+
+    assert isinstance(result, services.NatAnswer)
+    assert result.routed_agent == "news_agent"
+    assert result.tools_used == (services.NatToolUse("finus_market_news", ok=True),)
+
+
+def test_nat_answer_with_text_keeps_reasoning_metadata():
+    """텍스트를 가공하는 계층은 with_text로 갈아끼워야 각주가 살아남는다 (PR #263 리뷰)."""
+    original = services.NatAnswer(
+        "원본 답변",
+        routed_agent="trading_agent",
+        tools_used=(services.NatToolUse("finus_account_balance", ok=True, empty=True),),
+    )
+
+    replaced = original.with_text(original.replace("원본", "가공된"))
+
+    assert isinstance(replaced, services.NatAnswer)
+    assert str(replaced) == "가공된 답변"
+    assert replaced.routed_agent == "trading_agent"
+    assert replaced.tools_used == original.tools_used
+
+
 # ── A (#162): 도구 없는 provider 출력 범위 축소 ──────────────────────────────
 
 

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -12,7 +12,10 @@ from backend.telegram_commands import (
     BUY_COMMAND_HELP,
     CATALYST_COMMAND_HELP,
     EARNINGS_COMMAND_HELP,
+    MAX_PROGRESS_EDITS,
+    NAT_PROGRESS_MESSAGE,
     QUOTE_COMMAND_HELP,
+    REASONING_FOOTNOTE_SEPARATOR,
     TELEGRAM_INTERACTIVE_HELP,
     TRADE_COMMAND_HELP,
     LOOKUP_COMMAND_HELP,
@@ -22,7 +25,10 @@ from backend.telegram_commands import (
     UNRESOLVED_STOCK_WARNING,
     TelegramCommandHandler,
     TelegramCommandPoller,
+    _ProgressMessage,
+    _reasoning_footnote,
 )
+from backend.services import NatAnswer
 from backend.trading_orders import OrderExecutionResult, PendingOrder
 
 KST = ZoneInfo("Asia/Seoul")
@@ -2906,3 +2912,232 @@ async def test_help_and_bot_menu_include_catalysts_command(monkeypatch):
 
     assert "/catalysts <종목명> - 예정 촉매 이벤트 조회" in notifier.messages[-1]
     assert "catalysts" in [command["command"] for command in telegram_commands.TELEGRAM_BOT_COMMANDS]
+
+
+# ── #260: 추론 과정 표시 (진행 메시지 + 응답 근거 각주) ──────────────────────
+
+
+class EditingFakeNotifier(FakeNotifier):
+    """editMessageText를 지원하는 notifier 대역.
+
+    messages에는 sendMessage로 나간 것만, edits에는 편집으로 나간 것만 쌓인다 —
+    "진행 메시지를 새로 보냈는지 / 기존 메시지를 고쳤는지"를 구분해 검증하기 위함이다.
+    """
+
+    def __init__(self, *, edit_result=True, message_id=4242, **kwargs):
+        super().__init__(**kwargs)
+        self.edit_result = edit_result
+        self.message_id = message_id
+        self.edits = []
+
+    async def send_text_returning_id(self, text, *, reply_markup=None):
+        self.messages.append(text)
+        self.reply_markups.append(reply_markup)
+        return self.message_id
+
+    async def edit_message_text(self, message_id, text):
+        self.edits.append((message_id, text))
+        return self.edit_result
+
+
+def _nat_runner(result):
+    async def runner(provider, text, *, conversation_id=None):
+        return result
+
+    return runner
+
+
+async def _ask(handler, text="삼성전자 뉴스 알려줘", chat_id=123):
+    await handler.handle_update({"message": {"chat": {"id": chat_id}, "text": text}})
+
+
+@pytest.mark.asyncio
+async def test_progress_message_is_sent_and_edited_into_the_answer():
+    notifier = EditingFakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        llm_runner=_nat_runner(NatAnswer("삼성전자 뉴스입니다.")),
+    )
+
+    await _ask(handler)
+
+    assert notifier.actions == ["typing"]
+    assert notifier.messages == [NAT_PROGRESS_MESSAGE]
+    assert notifier.edits == [(4242, "삼성전자 뉴스입니다.")]
+
+
+@pytest.mark.asyncio
+async def test_answer_carries_reasoning_footnote_with_korean_labels():
+    notifier = EditingFakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        llm_runner=_nat_runner(
+            NatAnswer(
+                "삼성전자 뉴스입니다.",
+                routed_agent="news_agent",
+                tools_used=("finus_account_balance", "finus_market_news"),
+            )
+        ),
+    )
+
+    await _ask(handler)
+
+    _, final_text = notifier.edits[-1]
+    assert final_text == (
+        "삼성전자 뉴스입니다.\n\n"
+        f"{REASONING_FOOTNOTE_SEPARATOR}\n"
+        "🤖 뉴스 에이전트 · 📚 확인한 자료: KIS 시세·계좌 조회, 뉴스 검색"
+    )
+
+
+@pytest.mark.asyncio
+async def test_footnote_is_omitted_when_response_has_no_metadata():
+    """구버전 finus_nat 응답(메타데이터 없음)에서는 각주를 조용히 생략한다."""
+    notifier = EditingFakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        llm_runner=_nat_runner("메타데이터 없는 답변"),  # 평범한 str
+    )
+
+    await _ask(handler)
+
+    _, final_text = notifier.edits[-1]
+    assert final_text == "메타데이터 없는 답변"
+    assert REASONING_FOOTNOTE_SEPARATOR not in final_text
+
+
+@pytest.mark.asyncio
+async def test_footnote_shows_no_sources_when_ledger_was_empty():
+    """도구 없이 나온 답변이라는 사실 자체가 사용자가 알아야 할 근거다."""
+    notifier = EditingFakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        llm_runner=_nat_runner(NatAnswer("일반론입니다.", routed_agent="strategy_agent")),
+    )
+
+    await _ask(handler)
+
+    _, final_text = notifier.edits[-1]
+    assert final_text.endswith("🤖 전략 에이전트 · 📚 확인한 자료: 없음")
+
+
+@pytest.mark.asyncio
+async def test_unmapped_tool_name_falls_back_to_internal_name():
+    """매핑에 없는 도구는 내부 이름 그대로 노출한다 — 조용히 감추지 않는다."""
+    notifier = EditingFakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        llm_runner=_nat_runner(
+            NatAnswer("답변", routed_agent="news_agent", tools_used=("finus_brand_new_tool",))
+        ),
+    )
+
+    await _ask(handler)
+
+    _, final_text = notifier.edits[-1]
+    assert final_text.endswith("📚 확인한 자료: finus_brand_new_tool")
+
+
+@pytest.mark.asyncio
+async def test_edit_failure_falls_back_to_a_new_message():
+    """편집이 거부되면(오래된 메시지 등) 답변을 새 메시지로 보낸다."""
+    notifier = EditingFakeNotifier(edit_result=False)
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        llm_runner=_nat_runner(NatAnswer("최종 답변")),
+    )
+
+    await _ask(handler)
+
+    assert notifier.edits == [(4242, "최종 답변")]
+    assert notifier.messages == [NAT_PROGRESS_MESSAGE, "최종 답변"]
+
+
+@pytest.mark.asyncio
+async def test_missing_message_id_falls_back_to_a_new_message():
+    """message_id를 확보하지 못하면 편집을 시도하지 않고 새 메시지로 보낸다."""
+    notifier = EditingFakeNotifier(message_id=None)
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        llm_runner=_nat_runner(NatAnswer("최종 답변")),
+    )
+
+    await _ask(handler)
+
+    assert notifier.edits == []
+    assert notifier.messages == [NAT_PROGRESS_MESSAGE, "최종 답변"]
+
+
+@pytest.mark.asyncio
+async def test_notifier_without_edit_support_sends_two_plain_messages():
+    """편집을 지원하지 않는 notifier에서도 진행 표시와 답변이 모두 전달된다."""
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        llm_runner=_nat_runner(NatAnswer("최종 답변")),
+    )
+
+    await _ask(handler)
+
+    assert notifier.messages == [NAT_PROGRESS_MESSAGE, "최종 답변"]
+
+
+@pytest.mark.asyncio
+async def test_llm_failure_replaces_the_progress_message():
+    """실패해도 진행 메시지를 교체한다 — 안 그러면 '분석 중'이 영원히 남는다."""
+    notifier = EditingFakeNotifier()
+
+    async def failing_runner(provider, text, *, conversation_id=None):
+        raise HTTPException(status_code=502, detail="NAT 연결 실패")
+
+    handler = TelegramCommandHandler(notifier=notifier, llm_runner=failing_runner)
+
+    await _ask(handler)
+
+    assert notifier.edits == [(4242, "응답 생성 실패: NAT 연결 실패")]
+
+
+def test_progress_message_edit_budget_is_capped():
+    """텔레그램 편집 빈도 제한 때문에 편집 횟수에 상한을 둔다."""
+    progress = _ProgressMessage(message_id=1)
+
+    assert progress.editable is True
+    progress.edits_used = MAX_PROGRESS_EDITS
+    assert progress.editable is False
+
+
+def test_progress_message_without_id_is_never_editable():
+    assert _ProgressMessage(message_id=None).editable is False
+
+
+def test_reasoning_footnote_is_empty_without_any_evidence():
+    assert _reasoning_footnote(None, ()) == ""
+    assert _reasoning_footnote("", []) == ""
+
+
+def test_reasoning_footnote_ignores_malformed_metadata():
+    """타입이 어긋난 값은 각주를 만들지 않는다 — 신뢰 경계 밖의 값이다."""
+    assert _reasoning_footnote(42, "not-a-list") == ""
+
+
+@pytest.mark.asyncio
+async def test_footnote_survives_truncation_of_a_long_answer():
+    """긴 답변이 잘려도 각주는 남는다 — 각주 자리를 먼저 확보한 뒤 본문을 자른다."""
+    notifier = EditingFakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        llm_runner=_nat_runner(
+            NatAnswer(
+                "가" * (TELEGRAM_MESSAGE_LIMIT * 2),
+                routed_agent="news_agent",
+                tools_used=("finus_market_news",),
+            )
+        ),
+    )
+
+    await _ask(handler)
+
+    _, final_text = notifier.edits[-1]
+    assert len(final_text) <= TELEGRAM_MESSAGE_LIMIT
+    assert TELEGRAM_TRUNCATION_SUFFIX in final_text
+    assert final_text.endswith("🤖 뉴스 에이전트 · 📚 확인한 자료: 뉴스 검색")

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -12,8 +12,8 @@ from backend.telegram_commands import (
     BUY_COMMAND_HELP,
     CATALYST_COMMAND_HELP,
     EARNINGS_COMMAND_HELP,
-    MAX_PROGRESS_EDITS,
     NAT_PROGRESS_MESSAGE,
+    PROGRESS_DONE_MESSAGE,
     QUOTE_COMMAND_HELP,
     REASONING_FOOTNOTE_SEPARATOR,
     TELEGRAM_INTERACTIVE_HELP,
@@ -25,10 +25,9 @@ from backend.telegram_commands import (
     UNRESOLVED_STOCK_WARNING,
     TelegramCommandHandler,
     TelegramCommandPoller,
-    _ProgressMessage,
     _reasoning_footnote,
 )
-from backend.services import NatAnswer
+from backend.services import NatAnswer, NatToolUse
 from backend.trading_orders import OrderExecutionResult, PendingOrder
 
 KST = ZoneInfo("Asia/Seoul")
@@ -2913,27 +2912,32 @@ async def test_help_and_bot_menu_include_catalysts_command(monkeypatch):
     assert "/catalysts <종목명> - 예정 촉매 이벤트 조회" in notifier.messages[-1]
     assert "catalysts" in [command["command"] for command in telegram_commands.TELEGRAM_BOT_COMMANDS]
 
-
 # ── #260: 추론 과정 표시 (진행 메시지 + 응답 근거 각주) ──────────────────────
 
 
-class EditingFakeNotifier(FakeNotifier):
-    """editMessageText를 지원하는 notifier 대역.
+class ProgressFakeNotifier(FakeNotifier):
+    """진행 메시지 삭제·편집을 지원하는 notifier 대역.
 
-    messages에는 sendMessage로 나간 것만, edits에는 편집으로 나간 것만 쌓인다 —
-    "진행 메시지를 새로 보냈는지 / 기존 메시지를 고쳤는지"를 구분해 검증하기 위함이다.
+    messages에는 sendMessage로 나간 것만, deletes/edits에는 각각 삭제·편집 호출이
+    쌓인다 — 최종 답변이 편집이 아니라 새 메시지로 나가는지 검증하기 위함이다.
     """
 
-    def __init__(self, *, edit_result=True, message_id=4242, **kwargs):
+    def __init__(self, *, delete_result=True, edit_result=True, message_id=4242, **kwargs):
         super().__init__(**kwargs)
+        self.delete_result = delete_result
         self.edit_result = edit_result
         self.message_id = message_id
+        self.deletes = []
         self.edits = []
 
     async def send_text_returning_id(self, text, *, reply_markup=None):
         self.messages.append(text)
         self.reply_markups.append(reply_markup)
         return self.message_id
+
+    async def delete_message(self, message_id):
+        self.deletes.append(message_id)
+        return self.delete_result
 
     async def edit_message_text(self, message_id, text):
         self.edits.append((message_id, text))
@@ -2952,8 +2956,13 @@ async def _ask(handler, text="삼성전자 뉴스 알려줘", chat_id=123):
 
 
 @pytest.mark.asyncio
-async def test_progress_message_is_sent_and_edited_into_the_answer():
-    notifier = EditingFakeNotifier()
+async def test_progress_message_is_sent_then_cleared_and_answer_is_a_new_message():
+    """최종 답변은 편집이 아니라 새 메시지로 나간다.
+
+    텔레그램은 메시지 편집에 푸시 알림을 보내지 않는다. 편집으로 답을 내보내면
+    수십 초를 기다리다 앱을 닫은 사용자가 답변 도착 알림을 받지 못한다.
+    """
+    notifier = ProgressFakeNotifier()
     handler = TelegramCommandHandler(
         notifier=notifier,
         llm_runner=_nat_runner(NatAnswer("삼성전자 뉴스입니다.")),
@@ -2962,86 +2971,15 @@ async def test_progress_message_is_sent_and_edited_into_the_answer():
     await _ask(handler)
 
     assert notifier.actions == ["typing"]
-    assert notifier.messages == [NAT_PROGRESS_MESSAGE]
-    assert notifier.edits == [(4242, "삼성전자 뉴스입니다.")]
+    assert notifier.messages == [NAT_PROGRESS_MESSAGE, "삼성전자 뉴스입니다."]
+    assert notifier.deletes == [4242]
+    assert notifier.edits == []
 
 
 @pytest.mark.asyncio
-async def test_answer_carries_reasoning_footnote_with_korean_labels():
-    notifier = EditingFakeNotifier()
-    handler = TelegramCommandHandler(
-        notifier=notifier,
-        llm_runner=_nat_runner(
-            NatAnswer(
-                "삼성전자 뉴스입니다.",
-                routed_agent="news_agent",
-                tools_used=("finus_account_balance", "finus_market_news"),
-            )
-        ),
-    )
-
-    await _ask(handler)
-
-    _, final_text = notifier.edits[-1]
-    assert final_text == (
-        "삼성전자 뉴스입니다.\n\n"
-        f"{REASONING_FOOTNOTE_SEPARATOR}\n"
-        "🤖 뉴스 에이전트 · 📚 확인한 자료: KIS 시세·계좌 조회, 뉴스 검색"
-    )
-
-
-@pytest.mark.asyncio
-async def test_footnote_is_omitted_when_response_has_no_metadata():
-    """구버전 finus_nat 응답(메타데이터 없음)에서는 각주를 조용히 생략한다."""
-    notifier = EditingFakeNotifier()
-    handler = TelegramCommandHandler(
-        notifier=notifier,
-        llm_runner=_nat_runner("메타데이터 없는 답변"),  # 평범한 str
-    )
-
-    await _ask(handler)
-
-    _, final_text = notifier.edits[-1]
-    assert final_text == "메타데이터 없는 답변"
-    assert REASONING_FOOTNOTE_SEPARATOR not in final_text
-
-
-@pytest.mark.asyncio
-async def test_footnote_shows_no_sources_when_ledger_was_empty():
-    """도구 없이 나온 답변이라는 사실 자체가 사용자가 알아야 할 근거다."""
-    notifier = EditingFakeNotifier()
-    handler = TelegramCommandHandler(
-        notifier=notifier,
-        llm_runner=_nat_runner(NatAnswer("일반론입니다.", routed_agent="strategy_agent")),
-    )
-
-    await _ask(handler)
-
-    _, final_text = notifier.edits[-1]
-    assert final_text.endswith("🤖 전략 에이전트 · 📚 확인한 자료: 없음")
-
-
-@pytest.mark.asyncio
-async def test_unmapped_tool_name_falls_back_to_internal_name():
-    """매핑에 없는 도구는 내부 이름 그대로 노출한다 — 조용히 감추지 않는다."""
-    notifier = EditingFakeNotifier()
-    handler = TelegramCommandHandler(
-        notifier=notifier,
-        llm_runner=_nat_runner(
-            NatAnswer("답변", routed_agent="news_agent", tools_used=("finus_brand_new_tool",))
-        ),
-    )
-
-    await _ask(handler)
-
-    _, final_text = notifier.edits[-1]
-    assert final_text.endswith("📚 확인한 자료: finus_brand_new_tool")
-
-
-@pytest.mark.asyncio
-async def test_edit_failure_falls_back_to_a_new_message():
-    """편집이 거부되면(오래된 메시지 등) 답변을 새 메시지로 보낸다."""
-    notifier = EditingFakeNotifier(edit_result=False)
+async def test_delete_failure_falls_back_to_a_done_marker_edit():
+    """삭제가 거부되면 '분석 중'이 영원히 남지 않도록 종료 표시로 바꾼다."""
+    notifier = ProgressFakeNotifier(delete_result=False)
     handler = TelegramCommandHandler(
         notifier=notifier,
         llm_runner=_nat_runner(NatAnswer("최종 답변")),
@@ -3049,14 +2987,15 @@ async def test_edit_failure_falls_back_to_a_new_message():
 
     await _ask(handler)
 
-    assert notifier.edits == [(4242, "최종 답변")]
+    assert notifier.deletes == [4242]
+    assert notifier.edits == [(4242, PROGRESS_DONE_MESSAGE)]
     assert notifier.messages == [NAT_PROGRESS_MESSAGE, "최종 답변"]
 
 
 @pytest.mark.asyncio
-async def test_missing_message_id_falls_back_to_a_new_message():
-    """message_id를 확보하지 못하면 편집을 시도하지 않고 새 메시지로 보낸다."""
-    notifier = EditingFakeNotifier(message_id=None)
+async def test_answer_is_still_delivered_when_progress_cleanup_fails_entirely():
+    """정리에 다 실패해도 답변은 나간다 — 진행 표시는 답변 전달보다 덜 중요하다."""
+    notifier = ProgressFakeNotifier(delete_result=False, edit_result=False)
     handler = TelegramCommandHandler(
         notifier=notifier,
         llm_runner=_nat_runner(NatAnswer("최종 답변")),
@@ -3064,13 +3003,28 @@ async def test_missing_message_id_falls_back_to_a_new_message():
 
     await _ask(handler)
 
+    assert notifier.messages == [NAT_PROGRESS_MESSAGE, "최종 답변"]
+
+
+@pytest.mark.asyncio
+async def test_missing_message_id_skips_cleanup():
+    """message_id를 확보하지 못하면 정리를 시도하지 않는다."""
+    notifier = ProgressFakeNotifier(message_id=None)
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        llm_runner=_nat_runner(NatAnswer("최종 답변")),
+    )
+
+    await _ask(handler)
+
+    assert notifier.deletes == []
     assert notifier.edits == []
     assert notifier.messages == [NAT_PROGRESS_MESSAGE, "최종 답변"]
 
 
 @pytest.mark.asyncio
-async def test_notifier_without_edit_support_sends_two_plain_messages():
-    """편집을 지원하지 않는 notifier에서도 진행 표시와 답변이 모두 전달된다."""
+async def test_notifier_without_cleanup_support_sends_two_plain_messages():
+    """삭제·편집을 지원하지 않는 notifier에서도 진행 표시와 답변이 모두 전달된다."""
     notifier = FakeNotifier()
     handler = TelegramCommandHandler(
         notifier=notifier,
@@ -3083,9 +3037,8 @@ async def test_notifier_without_edit_support_sends_two_plain_messages():
 
 
 @pytest.mark.asyncio
-async def test_llm_failure_replaces_the_progress_message():
-    """실패해도 진행 메시지를 교체한다 — 안 그러면 '분석 중'이 영원히 남는다."""
-    notifier = EditingFakeNotifier()
+async def test_llm_failure_clears_progress_and_reports_the_error():
+    notifier = ProgressFakeNotifier()
 
     async def failing_runner(provider, text, *, conversation_id=None):
         raise HTTPException(status_code=502, detail="NAT 연결 실패")
@@ -3094,20 +3047,108 @@ async def test_llm_failure_replaces_the_progress_message():
 
     await _ask(handler)
 
-    assert notifier.edits == [(4242, "응답 생성 실패: NAT 연결 실패")]
+    assert notifier.deletes == [4242]
+    assert notifier.messages == [NAT_PROGRESS_MESSAGE, "응답 생성 실패: NAT 연결 실패"]
 
 
-def test_progress_message_edit_budget_is_capped():
-    """텔레그램 편집 빈도 제한 때문에 편집 횟수에 상한을 둔다."""
-    progress = _ProgressMessage(message_id=1)
-
-    assert progress.editable is True
-    progress.edits_used = MAX_PROGRESS_EDITS
-    assert progress.editable is False
+# ---- 각주 ----
 
 
-def test_progress_message_without_id_is_never_editable():
-    assert _ProgressMessage(message_id=None).editable is False
+@pytest.mark.asyncio
+async def test_answer_carries_reasoning_footnote_with_korean_labels():
+    notifier = ProgressFakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        llm_runner=_nat_runner(
+            NatAnswer(
+                "삼성전자 뉴스입니다.",
+                routed_agent="news_agent",
+                tools_used=(
+                    NatToolUse("finus_account_balance", ok=True),
+                    NatToolUse("finus_market_news", ok=True),
+                ),
+            )
+        ),
+    )
+
+    await _ask(handler)
+
+    assert notifier.messages[-1] == (
+        "삼성전자 뉴스입니다.\n\n"
+        f"{REASONING_FOOTNOTE_SEPARATOR}\n"
+        "🤖 뉴스 에이전트 · 📚 확인한 자료: KIS 시세·계좌 조회, 뉴스 검색"
+    )
+
+
+@pytest.mark.asyncio
+async def test_failed_tool_is_marked_in_the_footnote():
+    """실패한 호출을 그냥 '확인한 자료'로 적으면 사용자가 근거를 오독한다."""
+    notifier = ProgressFakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        llm_runner=_nat_runner(
+            NatAnswer(
+                "잔고를 확인하지 못했습니다.",
+                routed_agent="trading_agent",
+                tools_used=(NatToolUse("finus_account_balance", ok=False),),
+            )
+        ),
+    )
+
+    await _ask(handler)
+
+    assert notifier.messages[-1].endswith(
+        "🤖 트레이딩 에이전트 · 📚 확인한 자료: KIS 시세·계좌 조회(실패)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_footnote_is_omitted_when_response_has_no_metadata():
+    """구버전 finus_nat 응답(메타데이터 없음)에서는 각주를 조용히 생략한다."""
+    notifier = ProgressFakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        llm_runner=_nat_runner("메타데이터 없는 답변"),  # 평범한 str
+    )
+
+    await _ask(handler)
+
+    assert notifier.messages[-1] == "메타데이터 없는 답변"
+    assert REASONING_FOOTNOTE_SEPARATOR not in notifier.messages[-1]
+
+
+@pytest.mark.asyncio
+async def test_footnote_shows_no_sources_when_ledger_was_empty():
+    """도구 없이 나온 답변이라는 사실 자체가 사용자가 알아야 할 근거다."""
+    notifier = ProgressFakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        llm_runner=_nat_runner(NatAnswer("일반론입니다.", routed_agent="strategy_agent")),
+    )
+
+    await _ask(handler)
+
+    assert notifier.messages[-1].endswith("🤖 전략 에이전트 · 📚 확인한 자료: 없음")
+
+
+@pytest.mark.asyncio
+async def test_unmapped_tool_name_falls_back_to_internal_name():
+    """매핑에 없는 도구는 내부 이름 그대로 노출한다 — 조용히 감추지 않는다."""
+    notifier = ProgressFakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        llm_runner=_nat_runner(
+            NatAnswer(
+                "답변",
+                routed_agent="news_agent",
+                tools_used=(NatToolUse("finus_brand_new_tool", ok=True),),
+            )
+        ),
+    )
+
+    await _ask(handler)
+
+    assert notifier.messages[-1].endswith("📚 확인한 자료: finus_brand_new_tool")
 
 
 def test_reasoning_footnote_is_empty_without_any_evidence():
@@ -3118,26 +3159,61 @@ def test_reasoning_footnote_is_empty_without_any_evidence():
 def test_reasoning_footnote_ignores_malformed_metadata():
     """타입이 어긋난 값은 각주를 만들지 않는다 — 신뢰 경계 밖의 값이다."""
     assert _reasoning_footnote(42, "not-a-list") == ""
+    assert _reasoning_footnote("", ["문자열은 name 속성이 없다"]) == ""
+
+
+def test_reasoning_footnote_length_is_capped():
+    """각주 자리를 먼저 확보하는 구조라, 각주가 무한정 길면 본문 예산이 음수가 된다."""
+    footnote = _reasoning_footnote(
+        "news_agent",
+        tuple(NatToolUse("아주_긴_도구_이름_" * 5 + str(i), ok=True) for i in range(50)),
+    )
+
+    assert 0 < len(footnote) <= telegram_commands.REASONING_FOOTNOTE_MAX_CHARS
 
 
 @pytest.mark.asyncio
 async def test_footnote_survives_truncation_of_a_long_answer():
     """긴 답변이 잘려도 각주는 남는다 — 각주 자리를 먼저 확보한 뒤 본문을 자른다."""
-    notifier = EditingFakeNotifier()
+    notifier = ProgressFakeNotifier()
     handler = TelegramCommandHandler(
         notifier=notifier,
         llm_runner=_nat_runner(
             NatAnswer(
                 "가" * (TELEGRAM_MESSAGE_LIMIT * 2),
                 routed_agent="news_agent",
-                tools_used=("finus_market_news",),
+                tools_used=(NatToolUse("finus_market_news", ok=True),),
             )
         ),
     )
 
     await _ask(handler)
 
-    _, final_text = notifier.edits[-1]
+    final_text = notifier.messages[-1]
     assert len(final_text) <= TELEGRAM_MESSAGE_LIMIT
     assert TELEGRAM_TRUNCATION_SUFFIX in final_text
     assert final_text.endswith("🤖 뉴스 에이전트 · 📚 확인한 자료: 뉴스 검색")
+
+
+@pytest.mark.asyncio
+async def test_answer_stays_within_the_limit_even_with_a_maximal_footnote():
+    """각주가 상한까지 길어져도 본문이 통째로 사라지지 않는다."""
+    notifier = ProgressFakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        llm_runner=_nat_runner(
+            NatAnswer(
+                "나" * (TELEGRAM_MESSAGE_LIMIT * 2),
+                routed_agent="news_agent",
+                tools_used=tuple(
+                    NatToolUse("도구_" * 10 + str(i), ok=True) for i in range(16)
+                ),
+            )
+        ),
+    )
+
+    await _ask(handler)
+
+    final_text = notifier.messages[-1]
+    assert len(final_text) <= TELEGRAM_MESSAGE_LIMIT
+    assert final_text.startswith("나" * 100)

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -1,6 +1,7 @@
 import asyncio
 from datetime import date, datetime
 from types import SimpleNamespace
+from typing import NamedTuple
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -2955,6 +2956,42 @@ async def _ask(handler, text="삼성전자 뉴스 알려줘", chat_id=123):
     await handler.handle_update({"message": {"chat": {"id": chat_id}, "text": text}})
 
 
+def test_progress_messages_are_actually_visible_text():
+    """진행 문구 상수 자체를 고정한다 (PR #263 리뷰 — 뮤테이션 생존).
+
+    아래 진행 메시지 테스트들은 전부 NAT_PROGRESS_MESSAGE 상수를 참조해 비교하므로,
+    문구가 빈 문자열이 되어도 전부 초록이다. 실제로 빈 텍스트를 보내면 텔레그램이
+    'Bad Request: message text is empty'로 거부해 진행 표시가 통째로 사라진다.
+    """
+    assert NAT_PROGRESS_MESSAGE.strip()
+    assert PROGRESS_DONE_MESSAGE.strip()
+
+
+@pytest.mark.asyncio
+async def test_progress_message_send_failure_does_not_block_the_answer():
+    """notifier가 예외를 던져도 답변은 나간다 (PR #263 리뷰).
+
+    TelegramNotifier는 전송 실패를 내부에서 삼키지만 notifier는 생성자로 주입 가능하다.
+    진행 표시는 답변에 덧붙는 편의 기능이므로, 이걸로 질의 처리를 실패시키면 사용자는
+    답도 못 받는다.
+    """
+    notifier = ProgressFakeNotifier()
+
+    async def exploding_send(text, *, reply_markup=None):
+        raise RuntimeError("sendMessage 실패")
+
+    notifier.send_text_returning_id = exploding_send
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        llm_runner=_nat_runner(NatAnswer("최종 답변")),
+    )
+
+    await _ask(handler)
+
+    assert notifier.messages == ["최종 답변"]
+    assert notifier.deletes == []  # message_id가 없으니 정리도 건너뛴다
+
+
 @pytest.mark.asyncio
 async def test_progress_message_is_sent_then_cleared_and_answer_is_a_new_message():
     """최종 답변은 편집이 아니라 새 메시지로 나간다.
@@ -3100,6 +3137,71 @@ async def test_failed_tool_is_marked_in_the_footnote():
     assert notifier.messages[-1].endswith(
         "🤖 트레이딩 에이전트 · 📚 확인한 자료: KIS 시세·계좌 조회(실패)"
     )
+
+
+@pytest.mark.asyncio
+async def test_empty_result_tool_is_marked_in_the_footnote():
+    """빈 결과를 그냥 '확인한 자료'로 적으면 본문과 각주가 정면으로 어긋난다 (PR #263 리뷰).
+
+    NAT는 읽기 도구가 전부 빈 결과일 때 '[조회 결과 없음] ...'을 본문으로 돌려준다(#209).
+    그 답변에 '확인한 자료: 뉴스 검색'이라고만 적으면, 본문은 데이터가 없다고 말하는데
+    각주는 자료를 확인했다고 말하게 된다 — 답변은 그 데이터에 근거하지 않았다.
+    """
+    notifier = ProgressFakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        llm_runner=_nat_runner(
+            NatAnswer(
+                "[조회 결과 없음] 요청하신 조건으로 조회했으나 데이터가 없습니다.",
+                routed_agent="news_agent",
+                tools_used=(NatToolUse("finus_market_news", ok=True, empty=True),),
+            )
+        ),
+    )
+
+    await _ask(handler)
+
+    assert notifier.messages[-1].endswith(
+        "🤖 뉴스 에이전트 · 📚 확인한 자료: 뉴스 검색(결과 없음)"
+    )
+
+
+def test_footnote_separates_data_empty_and_failure():
+    """세 상태가 각각 다른 표기를 얻는다 — 성공만 무표기다."""
+    footnote = _reasoning_footnote(
+        "news_agent",
+        (
+            NatToolUse("finus_market_news", ok=True),
+            NatToolUse("finus_earnings_report", ok=True, empty=True),
+            NatToolUse("finus_account_balance", ok=False),
+        ),
+    )
+
+    assert footnote.endswith(
+        "📚 확인한 자료: 뉴스 검색, DART 실적 조회(결과 없음), KIS 시세·계좌 조회(실패)"
+    )
+
+
+def test_failure_marker_wins_over_empty_marker():
+    """ok=False면 empty는 읽지 않는다 — '실패인데 빈 결과'라는 표기가 나오지 않는다."""
+    footnote = _reasoning_footnote(
+        "news_agent", (NatToolUse("finus_market_news", ok=False, empty=True),)
+    )
+
+    assert footnote.endswith("📚 확인한 자료: 뉴스 검색(실패)")
+    assert "결과 없음" not in footnote
+
+
+def test_footnote_tolerates_tools_without_the_empty_attribute():
+    """empty를 싣지 않는 구버전 finus_nat 값도 각주를 만든다 (getattr 기본값 경로)."""
+
+    class LegacyToolUse(NamedTuple):
+        name: str
+        ok: bool
+
+    footnote = _reasoning_footnote("news_agent", (LegacyToolUse("finus_market_news", True),))
+
+    assert footnote.endswith("📚 확인한 자료: 뉴스 검색")
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_telegram_notifier.py
+++ b/backend/tests/test_telegram_notifier.py
@@ -545,6 +545,8 @@ async def test_delete_message_returns_false_on_failure(monkeypatch):
 @pytest.mark.asyncio
 async def test_delete_message_is_inert_when_notifier_disabled():
     assert await TelegramNotifier("", "").delete_message(1) is False
+
+
 def _http_status_error(status_code, body):
     request = httpx.Request("POST", "https://api.telegram.org/bottoken/sendMessage")
     response = httpx.Response(status_code, json=body, request=request)

--- a/backend/tests/test_telegram_notifier.py
+++ b/backend/tests/test_telegram_notifier.py
@@ -3,7 +3,11 @@ import logging
 import httpx
 import pytest
 
-from backend.telegram_notifier import TelegramNotifier, should_send_telegram_alert
+from backend.telegram_notifier import (
+    TELEGRAM_MESSAGE_LIMIT,
+    TelegramNotifier,
+    should_send_telegram_alert,
+)
 
 
 def test_should_send_telegram_alert_requires_high_or_critical_with_flag():
@@ -406,6 +410,22 @@ async def test_send_text_returning_id_returns_none_on_unusable_body(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_send_text_returning_id_rejects_a_body_that_says_not_ok(monkeypatch):
+    """2xx + ok:false 본문의 message_id는 쓰지 않는다 (PR #263 리뷰 — 뮤테이션 생존).
+
+    ok:false면 result가 무엇이든 그 메시지는 만들어지지 않았다. 그 id로 삭제·편집을
+    시도하면 남의 메시지를 건드리거나 조용히 실패한다.
+    """
+    monkeypatch.setattr(
+        "backend.telegram_notifier.httpx.AsyncClient",
+        _fake_client_factory([], _FakeResponse({"ok": False, "result": {"message_id": 4242}})),
+    )
+    notifier = TelegramNotifier("token", "123")
+
+    assert await notifier.send_text_returning_id("⏳") is None
+
+
+@pytest.mark.asyncio
 async def test_send_text_returning_id_returns_none_on_send_failure(monkeypatch):
     monkeypatch.setattr(
         "backend.telegram_notifier.httpx.AsyncClient",
@@ -437,6 +457,38 @@ async def test_edit_message_text_posts_edit_payload(monkeypatch):
             },
         )
     ]
+
+
+@pytest.mark.asyncio
+async def test_edit_message_text_truncates_to_the_telegram_limit(monkeypatch):
+    """공개 API이므로 한도를 넘는 본문이 들어와도 잘라 보낸다 (PR #263 리뷰 — 뮤테이션 생존).
+
+    현재 호출부는 짧은 종료 표시 하나뿐이라 절단이 발동하지 않지만, 넘겨 보내면
+    텔레그램이 400으로 거부하고 진행 메시지가 '분석 중'인 채로 남는다.
+    """
+    calls = []
+    monkeypatch.setattr(
+        "backend.telegram_notifier.httpx.AsyncClient",
+        _fake_client_factory(calls, _FakeResponse({"ok": True})),
+    )
+    notifier = TelegramNotifier("token", "123")
+
+    assert await notifier.edit_message_text(4242, "가" * (TELEGRAM_MESSAGE_LIMIT + 500)) is True
+    assert len(calls[0][1]["text"]) == TELEGRAM_MESSAGE_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_send_text_truncates_to_the_telegram_limit(monkeypatch):
+    """sendMessage도 같은 한도로 자른다 — 각주 계산이 이 상수를 전제로 한다."""
+    calls = []
+    monkeypatch.setattr(
+        "backend.telegram_notifier.httpx.AsyncClient",
+        _fake_client_factory(calls, _FakeResponse({"ok": True, "result": {"message_id": 1}})),
+    )
+    notifier = TelegramNotifier("token", "123")
+
+    assert await notifier.send_text("나" * (TELEGRAM_MESSAGE_LIMIT + 500)) is True
+    assert len(calls[0][1]["text"]) == TELEGRAM_MESSAGE_LIMIT
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_telegram_notifier.py
+++ b/backend/tests/test_telegram_notifier.py
@@ -457,3 +457,38 @@ async def test_progress_helpers_are_inert_when_notifier_disabled():
 
     assert await notifier.send_text_returning_id("⏳") is None
     assert await notifier.edit_message_text(1, "답변") is False
+
+
+@pytest.mark.asyncio
+async def test_delete_message_posts_delete_payload(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "backend.telegram_notifier.httpx.AsyncClient",
+        _fake_client_factory(calls, _FakeResponse({"ok": True})),
+    )
+    notifier = TelegramNotifier("token", "123")
+
+    assert await notifier.delete_message(4242) is True
+    assert calls == [
+        (
+            "https://api.telegram.org/bottoken/deleteMessage",
+            {"chat_id": "123", "message_id": 4242},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_delete_message_returns_false_on_failure(monkeypatch):
+    """삭제 거부는 예외가 아니라 False — 호출부가 종료 표시 편집으로 폴백한다."""
+    monkeypatch.setattr(
+        "backend.telegram_notifier.httpx.AsyncClient",
+        _fake_client_factory([], _FakeResponse(error=httpx.HTTPError("message can't be deleted"))),
+    )
+    notifier = TelegramNotifier("token", "123")
+
+    assert await notifier.delete_message(4242) is False
+
+
+@pytest.mark.asyncio
+async def test_delete_message_is_inert_when_notifier_disabled():
+    assert await TelegramNotifier("", "").delete_message(1) is False

--- a/backend/tests/test_telegram_notifier.py
+++ b/backend/tests/test_telegram_notifier.py
@@ -338,3 +338,122 @@ async def test_load_bot_username_fetches_and_caches_get_me(monkeypatch):
     assert await notifier.load_bot_username() == "finus_bot"
     assert await notifier.load_bot_username() == "finus_bot"
     assert calls == [("https://api.telegram.org/bottoken/getMe", {})]
+
+
+# ── #260: 진행 메시지 전송(message_id 확보) · 편집 ──────────────────────────
+
+
+def _fake_client_factory(calls, response):
+    class FakeAsyncClient:
+        def __init__(self, *, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return None
+
+        async def post(self, url, *, json):
+            calls.append((url, json))
+            return response
+
+    return FakeAsyncClient
+
+
+class _FakeResponse:
+    def __init__(self, body=None, error=None):
+        self._body = body
+        self._error = error
+
+    def raise_for_status(self):
+        if self._error is not None:
+            raise self._error
+
+    def json(self):
+        if self._body is None:
+            raise ValueError("no body")
+        return self._body
+
+
+@pytest.mark.asyncio
+async def test_send_text_returning_id_extracts_message_id(monkeypatch):
+    calls = []
+    response = _FakeResponse({"ok": True, "result": {"message_id": 4242}})
+    monkeypatch.setattr(
+        "backend.telegram_notifier.httpx.AsyncClient",
+        _fake_client_factory(calls, response),
+    )
+    notifier = TelegramNotifier("token", "123")
+
+    message_id = await notifier.send_text_returning_id("⏳ 분석 중입니다...")
+
+    assert message_id == 4242
+    assert calls[0][0] == "https://api.telegram.org/bottoken/sendMessage"
+    assert calls[0][1]["text"] == "⏳ 분석 중입니다..."
+
+
+@pytest.mark.asyncio
+async def test_send_text_returning_id_returns_none_on_unusable_body(monkeypatch):
+    """본문을 읽을 수 없으면 전송은 성공했어도 '편집 불가'로 떨어뜨린다."""
+    monkeypatch.setattr(
+        "backend.telegram_notifier.httpx.AsyncClient",
+        _fake_client_factory([], _FakeResponse(body=None)),
+    )
+    notifier = TelegramNotifier("token", "123")
+
+    assert await notifier.send_text_returning_id("⏳") is None
+
+
+@pytest.mark.asyncio
+async def test_send_text_returning_id_returns_none_on_send_failure(monkeypatch):
+    monkeypatch.setattr(
+        "backend.telegram_notifier.httpx.AsyncClient",
+        _fake_client_factory([], _FakeResponse(error=httpx.HTTPError("boom"))),
+    )
+    notifier = TelegramNotifier("token", "123")
+
+    assert await notifier.send_text_returning_id("⏳") is None
+
+
+@pytest.mark.asyncio
+async def test_edit_message_text_posts_edit_payload(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "backend.telegram_notifier.httpx.AsyncClient",
+        _fake_client_factory(calls, _FakeResponse({"ok": True})),
+    )
+    notifier = TelegramNotifier("token", "123")
+
+    assert await notifier.edit_message_text(4242, "최종 답변") is True
+    assert calls == [
+        (
+            "https://api.telegram.org/bottoken/editMessageText",
+            {
+                "chat_id": "123",
+                "message_id": 4242,
+                "text": "최종 답변",
+                "disable_web_page_preview": True,
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_edit_message_text_returns_false_on_failure(monkeypatch):
+    """편집 실패는 예외가 아니라 False — 호출부가 새 메시지로 폴백한다."""
+    monkeypatch.setattr(
+        "backend.telegram_notifier.httpx.AsyncClient",
+        _fake_client_factory([], _FakeResponse(error=httpx.HTTPError("message is too old"))),
+    )
+    notifier = TelegramNotifier("token", "123")
+
+    assert await notifier.edit_message_text(4242, "최종 답변") is False
+
+
+@pytest.mark.asyncio
+async def test_progress_helpers_are_inert_when_notifier_disabled():
+    notifier = TelegramNotifier("", "")
+
+    assert await notifier.send_text_returning_id("⏳") is None
+    assert await notifier.edit_message_text(1, "답변") is False

--- a/finus_nat/README.md
+++ b/finus_nat/README.md
@@ -19,6 +19,12 @@ router.yml과 router_nomemory.yml은 기본적으로 최근 대화 히스토리�
 응답에 담당 에이전트와 실제 실행된 도구 목록을 실어 보내, 텔레그램 봇이 답변 하단에
 근거 각주를 렌더링합니다 (#260).
 
+`tools_used`의 각 항목은 `{"name": str, "ok": bool, "empty": bool}`입니다. 도구 강제
+원장이 구분하는 세 상태를 그대로 넘깁니다 — 오류(`ok=false`), 성공했지만 0행
+(`ok=true, empty=true`, #209), 데이터 있음(`ok=true, empty=false`). 상태를 빼고 이름만
+넘기면 소비자가 실패·빈 결과까지 "확인한 자료"로 표시해, 답변이 근거하지 않은 데이터를
+근거로 제시하게 됩니다. 표기는 소비자가 정합니다(backend는 `(실패)`/`(결과 없음)`).
+
 **router_nomemory.yml(기본값)에서만 동작합니다.** router.yml(`--memory`)은 최상위
 workflow가 vendor `auto_memory_agent`인데, 그 `_response_fn` 시그니처가
 `(input_message: str) -> str`이라 안쪽에서 `ChatResponse`에 붙인 두 필드가 래퍼를

--- a/finus_nat/README.md
+++ b/finus_nat/README.md
@@ -14,6 +14,17 @@ finus_nat/scripts/run.sh 으로 실행하여 cli 환경에서 에이전트를 �
 router.yml과 router_nomemory.yml은 기본적으로 최근 대화 히스토리를 SQLite에 저장하고 다음 요청에 다시 주입합니다. NAT는 HTTP `conversation-id` 헤더로 세션을 구분합니다.
 이는 OpenAI compatible /v1/chat/completion을 사용하기 위함입니다.
 
+## 추론 각주 (routed_agent / tools_used)
+
+응답에 담당 에이전트와 실제 실행된 도구 목록을 실어 보내, 텔레그램 봇이 답변 하단에
+근거 각주를 렌더링합니다 (#260).
+
+**router_nomemory.yml(기본값)에서만 동작합니다.** router.yml(`--memory`)은 최상위
+workflow가 vendor `auto_memory_agent`인데, 그 `_response_fn` 시그니처가
+`(input_message: str) -> str`이라 안쪽에서 `ChatResponse`에 붙인 두 필드가 래퍼를
+통과하면서 버려집니다. backend는 필드가 없으면 각주를 조용히 생략하므로, 메모리
+모드에서는 경고 없이 각주만 사라집니다.
+
 ## 1. Mem0 self-hosted server 설정
 
 설치하지 않아도 테스트 및 구동에는 문제가 없습니다. 에이전트는 자동으로 router_nomemory.yml을 사용하게 됩니다.

--- a/finus_nat/configs/router.yml
+++ b/finus_nat/configs/router.yml
@@ -61,6 +61,12 @@ functions:
     db_path: ${FINUS_TRANSCRIPT_DB_PATH:-.state/conversations.sqlite3}
     max_history_messages: 30
 
+# ⚠️ 이 모드에서는 추론 각주(#260)가 표시되지 않습니다.
+# 최상위 workflow인 vendor auto_memory_agent의 _response_fn 시그니처가
+# (input_message: str) -> str 이라, 안쪽 transcript_router_agent가 ChatResponse에
+# 붙인 routed_agent/tools_used가 이 래퍼를 통과하면서 버려집니다.
+# backend는 두 필드가 없으면 각주를 조용히 생략하므로 경고 없이 각주만 사라집니다.
+# router_nomemory.yml(기본값)에서는 정상 동작합니다.
 workflow: # Mem0 auto_memory_agent를 설정합니다.
   _type: auto_memory_agent
   inner_agent_name: transcript_router_agent

--- a/finus_nat/src/nat_finus_nat/agents.py
+++ b/finus_nat/src/nat_finus_nat/agents.py
@@ -604,13 +604,17 @@ def with_reasoning_trace(response: ChatResponse, trace: ReasoningTrace) -> ChatR
     빈 값을 실어 보내는 것보다 없는 편이 소비자 입장에서 명확하다 — backend는
     필드가 없으면 각주를 조용히 생략한다. 반대로 라우팅은 됐는데 도구가 하나도
     실행되지 않은 경우는 관측 결과 그 자체이므로 ``tools_used: []``로 싣는다.
+
+    ``tools_used``는 ``[{"name": ..., "ok": ...}]`` 형태다. 실패한 호출을 이름만
+    실어 보내면 소비자가 그것까지 "확인한 자료"로 표시하게 된다 —
+    :class:`ToolUse` docstring 참고.
     """
     if trace.routed_agent is None and not trace.tools_used:
         return response
     return response.model_copy(
         update={
             "routed_agent": trace.routed_agent,
-            "tools_used": list(trace.tools_used),
+            "tools_used": [{"name": tool.name, "ok": tool.ok} for tool in trace.tools_used],
         }
     )
 

--- a/finus_nat/src/nat_finus_nat/agents.py
+++ b/finus_nat/src/nat_finus_nat/agents.py
@@ -605,16 +605,19 @@ def with_reasoning_trace(response: ChatResponse, trace: ReasoningTrace) -> ChatR
     필드가 없으면 각주를 조용히 생략한다. 반대로 라우팅은 됐는데 도구가 하나도
     실행되지 않은 경우는 관측 결과 그 자체이므로 ``tools_used: []``로 싣는다.
 
-    ``tools_used``는 ``[{"name": ..., "ok": ...}]`` 형태다. 실패한 호출을 이름만
-    실어 보내면 소비자가 그것까지 "확인한 자료"로 표시하게 된다 —
-    :class:`ToolUse` docstring 참고.
+    ``tools_used``는 ``[{"name": ..., "ok": ..., "empty": ...}]`` 형태다. 결과 상태를
+    빼고 이름만 실어 보내면 소비자가 실패한 호출과 빈 결과까지 "확인한 자료"로
+    표시하게 된다 — :class:`ToolUse` docstring 참고.
     """
     if trace.routed_agent is None and not trace.tools_used:
         return response
     return response.model_copy(
         update={
             "routed_agent": trace.routed_agent,
-            "tools_used": [{"name": tool.name, "ok": tool.ok} for tool in trace.tools_used],
+            "tools_used": [
+                {"name": tool.name, "ok": tool.ok, "empty": tool.empty}
+                for tool in trace.tools_used
+            ],
         }
     )
 

--- a/finus_nat/src/nat_finus_nat/agents.py
+++ b/finus_nat/src/nat_finus_nat/agents.py
@@ -28,7 +28,12 @@ from nat.data_models.component_ref import FunctionRef
 from nat.data_models.component_ref import LLMRef
 from nat.data_models.function import FunctionBaseConfig
 from nat.utils.type_converter import GlobalTypeConverter
-from nat_finus_nat.finus_api import DATA_TOOL_LEDGER, DataToolLedger
+from nat_finus_nat.finus_api import (
+    DATA_TOOL_LEDGER,
+    REASONING_TRACE,
+    DataToolLedger,
+    ReasoningTrace,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -154,6 +159,34 @@ _CORRECTIVE_TOOL_PREFIX = (
 )
 
 
+# ---- Reasoning trace recording (#260) ----
+
+
+def _trace_ledger_tools(ledger: DataToolLedger) -> None:
+    """*ledger*에 기록된 도구를 현재 요청의 추론 기록에 병합한다.
+
+    기록 원천은 도구 강제 원장뿐이다 — 모델 출력 텍스트를 파싱하지 않는다
+    (#129와 같은 원칙: provenance는 코드가 관측한 것에서만 만든다).
+
+    추론 기록 박스가 없으면(박스를 심지 않는 config나 CLI 경로) 조용히 no-op한다.
+    각주는 답변에 덧붙는 부가 정보이므로, 없다고 해서 답변 경로를 막지 않는다.
+    """
+    trace = REASONING_TRACE.get()
+    if trace is not None:
+        trace.record_ledger_tools(ledger)
+
+
+def _trace_route(branch_name: str) -> None:
+    """supervisor가 고른 브랜치명을 현재 요청의 추론 기록에 남긴다.
+
+    ``_choose_branch``가 ``_normalize_branch``로 허용 목록에 정규화한 뒤의 값만
+    들어온다 — LLM이 출력한 원문 문자열이 그대로 흘러가지 않는다.
+    """
+    trace = REASONING_TRACE.get()
+    if trace is not None:
+        trace.record_route(branch_name)
+
+
 async def _run_with_gate(
     *,
     inner: Any,
@@ -178,6 +211,7 @@ async def _run_with_gate(
         result = await inner.ainvoke(ChatRequestOrMessage(input_message=query))
     finally:
         DATA_TOOL_LEDGER.reset(token)
+        _trace_ledger_tools(ledger)  # #260: 실행된 도구를 각주용 기록에 병합
     answer = chat_response_plain_text(result)
 
     if not _check_tool_enforcement(answer, ledger, chat_request):
@@ -225,6 +259,7 @@ async def _run_with_gate(
         result2 = await inner.ainvoke(ChatRequestOrMessage(input_message=corrective_query))
     finally:
         DATA_TOOL_LEDGER.reset(token2)
+        _trace_ledger_tools(ledger2)  # #260: 재시도에서 실행된 도구도 병합(중복 제거)
     answer2 = chat_response_plain_text(result2)
 
     if not _check_tool_enforcement(answer2, ledger2, chat_request):
@@ -428,11 +463,15 @@ async def fe_branch(config: FeBranchConfig, builder: Builder):
             # Deterministic path: assembles tool output directly without going through
             # _run_with_gate. A ledger box is still required so that _record_to_ledger
             # inside the news tool does not log a spurious ERROR on every happy-path call.
-            token = DATA_TOOL_LEDGER.set(DataToolLedger())
+            ledger = DataToolLedger()
+            token = DATA_TOOL_LEDGER.set(ledger)
             try:
                 direct = await _holdings_news_answer(builder, chat_request)
             finally:
                 DATA_TOOL_LEDGER.reset(token)
+                # #260: 게이트를 거치지 않는 경로지만 도구는 실제로 실행됐다.
+                # 각주에서 이 뉴스 조회가 누락되지 않도록 여기서도 병합한다.
+                _trace_ledger_tools(ledger)
             if direct is not None:
                 return direct
         inner = await builder.get_function(inner_name)
@@ -539,6 +578,7 @@ async def finus_supervisor_agent(config: FinusSupervisorAgentConfig, builder: Bu
     async def _response_fn(chat_request_or_message: ChatRequestOrMessage) -> ChatResponse:
         chat_request = GlobalTypeConverter.get().convert(chat_request_or_message, to_type=ChatRequest)
         selected = await _choose_branch(chat_request)
+        _trace_route(selected)  # #260: 라우팅 결과는 코드가 고른 값 — 각주의 담당 에이전트
         forward = chat_request.model_copy(update={"messages": messages_without_memory(chat_request.messages)})
         result = await branch_functions[selected].ainvoke(forward)
         if isinstance(result, ChatResponse):
@@ -546,6 +586,33 @@ async def finus_supervisor_agent(config: FinusSupervisorAgentConfig, builder: Bu
         return ChatResponse.from_string(str(result), usage=Usage())
 
     yield FunctionInfo.from_fn(_response_fn, description=config.description)
+
+
+def with_reasoning_trace(response: ChatResponse, trace: ReasoningTrace) -> ChatResponse:
+    """*response*에 ``routed_agent``/``tools_used``를 **추가**한다 (#260).
+
+    기존 필드(``choices``/``usage``/``model`` 등)는 건드리지 않는다 — backend의
+    ``_nat_message_from_payload``와 scheduler의 ``analysis_from_nat_text``가
+    그대로 동작해야 한다. ``ChatResponse.model_config``가 ``extra="allow"``라
+    추가 필드는 그대로 직렬화되고, 두 필드를 모르는 소비자는 무시하면 된다.
+
+    두 값의 출처는 코드 기록뿐이다 — supervisor의 분기 선택 결과와 도구 강제
+    원장이며, 모델 출력 텍스트에서 파싱하지 않는다 (#129와 같은 원칙).
+    :class:`ReasoningTrace` docstring 참고.
+
+    관측된 것이 아무것도 없으면(라우팅도 도구 실행도 없음) 필드를 붙이지 않는다.
+    빈 값을 실어 보내는 것보다 없는 편이 소비자 입장에서 명확하다 — backend는
+    필드가 없으면 각주를 조용히 생략한다. 반대로 라우팅은 됐는데 도구가 하나도
+    실행되지 않은 경우는 관측 결과 그 자체이므로 ``tools_used: []``로 싣는다.
+    """
+    if trace.routed_agent is None and not trace.tools_used:
+        return response
+    return response.model_copy(
+        update={
+            "routed_agent": trace.routed_agent,
+            "tools_used": list(trace.tools_used),
+        }
+    )
 
 
 def nat_chat_extra_headers(conversation_id: str) -> dict[str, str]:
@@ -711,7 +778,15 @@ async def finus_sqlite_transcript_agent(config: FinusSqliteTranscriptAgentConfig
         forward_messages = history + chat_request.messages
         forward = _chat_request_with_messages(chat_request, forward_messages)
 
-        result = await inner_agent.ainvoke(forward)
+        # #260: 추론 기록 박스를 workflow 최상단에서 한 번만 심는다. 안쪽(supervisor,
+        # _run_with_gate)은 박스를 mutate하기만 한다 — ContextVar.set()은 LangGraph의
+        # copy_context() 경계를 넘어 바깥으로 전파되지 않기 때문이다(DataToolLedger와 동일).
+        trace = ReasoningTrace()
+        trace_token = REASONING_TRACE.set(trace)
+        try:
+            result = await inner_agent.ainvoke(forward)
+        finally:
+            REASONING_TRACE.reset(trace_token)
         assistant = chat_response_plain_text(result)
 
         to_store: list[tuple[str, str]] = []
@@ -726,10 +801,11 @@ async def finus_sqlite_transcript_agent(config: FinusSqliteTranscriptAgentConfig
         _append_messages(db_path, conversation_id, to_store)
 
         if isinstance(result, ChatResponse):
-            return result
+            return with_reasoning_trace(result, trace)
         if chat_request_or_message.is_string:
+            # 문자열 반환 경로(chat_cli 등)는 실을 곳이 없으므로 각주 메타데이터를 붙이지 않는다.
             return str(result)
-        return ChatResponse.from_string(str(result), usage=Usage())
+        return with_reasoning_trace(ChatResponse.from_string(str(result), usage=Usage()), trace)
 
     yield FunctionInfo.from_fn(_response_fn, description=config.description)
 

--- a/finus_nat/src/nat_finus_nat/finus_api.py
+++ b/finus_nat/src/nat_finus_nat/finus_api.py
@@ -84,6 +84,53 @@ DATA_TOOL_LEDGER: ContextVar["DataToolLedger | None"] = ContextVar(
     "finus_data_tool_ledger", default=None
 )
 
+
+# ---- Reasoning trace for the response footnote (#260) ----
+
+
+@dataclass
+class ReasoningTrace:
+    """한 요청에서 코드가 관측한 추론 경로 — 어느 브랜치로 갔고 어떤 도구가 실행됐는지.
+
+    **출처 원칙 (#129와 같은 원칙):** 두 값 모두 코드가 남긴 기록에서만 만든다.
+
+    - ``routed_agent`` — supervisor의 ``_choose_branch``가 반환한 브랜치명. 브랜치
+      허용 목록으로 정규화된 값이므로 임의 문자열이 들어올 수 없다.
+    - ``tools_used`` — 도구 강제 원장(:class:`DataToolLedger`)에 기록된 도구명.
+      모든 Fin-Us 도구가 ``_record_to_ledger``를 거치므로 "실제로 실행된 도구"다.
+
+    LLM 출력 텍스트를 파싱해서 채우지 않는다. 파싱으로 만들면 "실행된 도구"가 아니라
+    "모델이 실행했다고 주장하는 도구"가 되어, 근거로 보여주는 각주가 오히려 환각을
+    사용자에게 사실처럼 전달하는 표면이 된다.
+
+    :class:`DataToolLedger`와 같은 이유로 **mutable box**다: ``ContextVar.set()``은
+    LangGraph가 내부적으로 만드는 ``copy_context()`` 경계를 넘어 바깥으로 전파되지
+    않는다. 최상단에서 박스 하나를 심고, 안쪽에서는 박스를 mutate하기만 한다.
+    """
+
+    routed_agent: str | None = None
+    tools_used: list[str] = field(default_factory=list)
+
+    def record_route(self, branch_name: str) -> None:
+        """supervisor가 고른 브랜치명을 기록한다 (마지막 라우팅이 최종 값)."""
+        self.routed_agent = branch_name
+
+    def record_ledger_tools(self, ledger: "DataToolLedger") -> None:
+        """*ledger*에 기록된 도구명을 호출 순서대로 병합한다 (중복 제거).
+
+        게이트 재시도(``_run_with_gate``의 2차 시도)는 원장을 새로 만들므로 이
+        메서드가 여러 번 호출된다. 중복 제거는 "한 번이라도 실행된 도구" 집합을
+        순서를 유지한 채 만든다.
+        """
+        for record in ledger.records:
+            if record.tool_name not in self.tools_used:
+                self.tools_used.append(record.tool_name)
+
+
+REASONING_TRACE: ContextVar["ReasoningTrace | None"] = ContextVar(
+    "finus_reasoning_trace", default=None
+)
+
 _ERROR_JSON_PREFIX_RE = re.compile(r'^\s*\{"error"')
 
 # 각 MCP 서버가 조회 결과가 없을 때 출력하는 리터럴 부분문자열.

--- a/finus_nat/src/nat_finus_nat/finus_api.py
+++ b/finus_nat/src/nat_finus_nat/finus_api.py
@@ -89,16 +89,50 @@ DATA_TOOL_LEDGER: ContextVar["DataToolLedger | None"] = ContextVar(
 
 
 class ToolUse(NamedTuple):
-    """각주에 실을 도구 한 건 — 도구명과 성공 여부.
+    """각주에 실을 도구 한 건 — 도구명과 결과 상태.
 
     ``ok``는 원장의 ``DataToolRecord.ok``를 그대로 옮긴 값이다(오류 응답이 아님).
     성공 여부를 함께 싣는 이유: 이름만 보내면 소비자가 실패한 호출까지 "확인한
     자료"로 표시하게 되고, 사용자는 답변이 그 데이터에 근거했다고 읽는다. 실제로는
     아니므로, 근거를 보여준다는 이 기능의 목적과 정반대의 오독이 된다.
+
+    ``empty``는 같은 논리의 세 번째 상태다 — ``ok=True``지만 결과 집합이 비어 있는
+    경우(#209). 오류가 아니므로 실패로 적으면 틀리지만, 표시 없이 "확인한 자료"로
+    적으면 **답변이 근거하지 않은 데이터**를 근거로 제시하게 된다. 특히
+    ``_run_with_gate``가 ``only_empty_reads()``에서 반환하는 `[조회 결과 없음]` 답변은
+    본문이 "데이터가 없다"고 말하는데 각주만 "자료를 확인했다"고 말하는 정면 충돌이
+    된다. 세 상태를 그대로 넘기고 표기는 소비자가 정한다.
+
+    기본값이 있는 이유: 이 필드를 모르는 구버전 소비자·호출부와 섞여도 깨지지 않게
+    한다. 기본값 ``False``는 "빈 결과라는 관측이 없음"이지 "데이터가 있었음"이
+    아니므로, ``ok``와 함께 읽어야 한다.
     """
 
     name: str
     ok: bool
+    empty: bool = False
+
+
+def _tool_use_from_record(record: DataToolRecord) -> ToolUse:
+    """원장 기록 한 건을 각주용 :class:`ToolUse`로 옮긴다.
+
+    ``empty``는 ``ok=True``일 때만 의미가 있다 — 오류 응답은 결과 집합이 비었는지를
+    말하지 않는다. ``ok=False``면 항상 ``empty=False``로 눕혀, 소비자가 두 필드를
+    따로 읽어도 "실패인데 빈 결과"라는 모순된 조합을 보지 않게 한다.
+    """
+    return ToolUse(record.tool_name, record.ok, record.ok and record.empty)
+
+
+def _tool_use_rank(tool: ToolUse) -> int:
+    """도구 결과의 '좋음' 순위 — 실패(0) < 빈 결과(1) < 데이터 있음(2).
+
+    같은 도구를 여러 번 호출했을 때 어느 결과를 각주에 남길지 정하는 데만 쓴다.
+    쓰기 도구(``finus_save_diary``)는 성공해도 ``empty=False``이므로 2가 된다 —
+    조회 결과가 아니라 "실제로 저장했다"는 뜻이라 맞는 순위다.
+    """
+    if not tool.ok:
+        return 0
+    return 1 if tool.empty else 2
 
 
 @dataclass
@@ -135,18 +169,22 @@ class ReasoningTrace:
         메서드가 여러 번 호출된다. 중복 제거는 "한 번이라도 실행된 도구" 집합을
         순서를 유지한 채 만든다.
 
-        같은 도구를 여러 번 호출해 **한 번이라도 성공**했다면 ``ok=True``로 올린다 —
-        결국 그 데이터를 얻었다는 뜻이고, 실제로 재시도 루프에서 흔한 경로다.
+        같은 도구를 여러 번 호출했다면 **가장 좋은 결과**를 남긴다
+        (:func:`_tool_use_rank` 기준: 실패 < 빈 결과 < 데이터 있음). 재시도 루프에서
+        흔한 경로다 — 1차에서 실패하거나 빈 결과였다가 2차에서 데이터를 얻으면,
+        결국 그 데이터를 얻은 것이므로 각주도 그렇게 말해야 한다. 반대 방향으로
+        내리지는 않는다: 한 번 얻은 데이터가 뒤 호출의 실패로 사라지지 않는다.
         """
         for record in ledger.records:
+            fresh = _tool_use_from_record(record)
             for index, seen in enumerate(self.tools_used):
-                if seen.name != record.tool_name:
+                if seen.name != fresh.name:
                     continue
-                if record.ok and not seen.ok:
-                    self.tools_used[index] = ToolUse(seen.name, True)
+                if _tool_use_rank(fresh) > _tool_use_rank(seen):
+                    self.tools_used[index] = fresh
                 break
             else:
-                self.tools_used.append(ToolUse(record.tool_name, record.ok))
+                self.tools_used.append(fresh)
 
 
 REASONING_TRACE: ContextVar["ReasoningTrace | None"] = ContextVar(

--- a/finus_nat/src/nat_finus_nat/finus_api.py
+++ b/finus_nat/src/nat_finus_nat/finus_api.py
@@ -88,6 +88,19 @@ DATA_TOOL_LEDGER: ContextVar["DataToolLedger | None"] = ContextVar(
 # ---- Reasoning trace for the response footnote (#260) ----
 
 
+class ToolUse(NamedTuple):
+    """각주에 실을 도구 한 건 — 도구명과 성공 여부.
+
+    ``ok``는 원장의 ``DataToolRecord.ok``를 그대로 옮긴 값이다(오류 응답이 아님).
+    성공 여부를 함께 싣는 이유: 이름만 보내면 소비자가 실패한 호출까지 "확인한
+    자료"로 표시하게 되고, 사용자는 답변이 그 데이터에 근거했다고 읽는다. 실제로는
+    아니므로, 근거를 보여준다는 이 기능의 목적과 정반대의 오독이 된다.
+    """
+
+    name: str
+    ok: bool
+
+
 @dataclass
 class ReasoningTrace:
     """한 요청에서 코드가 관측한 추론 경로 — 어느 브랜치로 갔고 어떤 도구가 실행됐는지.
@@ -96,7 +109,7 @@ class ReasoningTrace:
 
     - ``routed_agent`` — supervisor의 ``_choose_branch``가 반환한 브랜치명. 브랜치
       허용 목록으로 정규화된 값이므로 임의 문자열이 들어올 수 없다.
-    - ``tools_used`` — 도구 강제 원장(:class:`DataToolLedger`)에 기록된 도구명.
+    - ``tools_used`` — 도구 강제 원장(:class:`DataToolLedger`)에 기록된 도구.
       모든 Fin-Us 도구가 ``_record_to_ledger``를 거치므로 "실제로 실행된 도구"다.
 
     LLM 출력 텍스트를 파싱해서 채우지 않는다. 파싱으로 만들면 "실행된 도구"가 아니라
@@ -109,22 +122,31 @@ class ReasoningTrace:
     """
 
     routed_agent: str | None = None
-    tools_used: list[str] = field(default_factory=list)
+    tools_used: list[ToolUse] = field(default_factory=list)
 
     def record_route(self, branch_name: str) -> None:
         """supervisor가 고른 브랜치명을 기록한다 (마지막 라우팅이 최종 값)."""
         self.routed_agent = branch_name
 
     def record_ledger_tools(self, ledger: "DataToolLedger") -> None:
-        """*ledger*에 기록된 도구명을 호출 순서대로 병합한다 (중복 제거).
+        """*ledger*의 도구를 첫 호출 순서대로 병합한다 (도구명 기준 중복 제거).
 
         게이트 재시도(``_run_with_gate``의 2차 시도)는 원장을 새로 만들므로 이
         메서드가 여러 번 호출된다. 중복 제거는 "한 번이라도 실행된 도구" 집합을
         순서를 유지한 채 만든다.
+
+        같은 도구를 여러 번 호출해 **한 번이라도 성공**했다면 ``ok=True``로 올린다 —
+        결국 그 데이터를 얻었다는 뜻이고, 실제로 재시도 루프에서 흔한 경로다.
         """
         for record in ledger.records:
-            if record.tool_name not in self.tools_used:
-                self.tools_used.append(record.tool_name)
+            for index, seen in enumerate(self.tools_used):
+                if seen.name != record.tool_name:
+                    continue
+                if record.ok and not seen.ok:
+                    self.tools_used[index] = ToolUse(seen.name, True)
+                break
+            else:
+                self.tools_used.append(ToolUse(record.tool_name, record.ok))
 
 
 REASONING_TRACE: ContextVar["ReasoningTrace | None"] = ContextVar(

--- a/finus_nat/tests/test_reasoning_trace.py
+++ b/finus_nat/tests/test_reasoning_trace.py
@@ -188,6 +188,118 @@ def test_repeated_failure_stays_not_ok():
 
 
 # ---------------------------------------------------------------------------
+# 빈 결과(ok=True, empty=True) — 성공과도 실패와도 다른 세 번째 상태 (PR #263 리뷰)
+# ---------------------------------------------------------------------------
+
+def test_empty_result_is_carried_as_its_own_state():
+    """ok=True지만 0행인 호출을 데이터를 얻은 호출과 구분해 싣는다 (#209).
+
+    구분하지 않으면 게이트가 only_empty_reads()로 돌려주는 '[조회 결과 없음]' 답변에도
+    각주가 "확인한 자료: 뉴스 검색"이라고 적혀, 본문과 각주가 정면으로 충돌한다.
+    답변은 그 데이터에 근거하지 않았다 — ok=False에 대해 세운 논리가 그대로 성립한다.
+    """
+    ledger = DataToolLedger()
+    ledger.record("finus_market_news", ok=True, produced_rows=False, empty=True)
+    trace = ReasoningTrace()
+
+    trace.record_ledger_tools(ledger)
+
+    assert trace.tools_used == [ToolUse("finus_market_news", ok=True, empty=True)]
+
+
+def test_a_failed_call_is_never_marked_empty():
+    """오류 응답은 결과 집합이 비었는지를 말하지 않는다 — 두 필드가 모순되지 않게 눕힌다."""
+    ledger = DataToolLedger()
+    ledger.record("finus_market_news", ok=False, produced_rows=False, empty=True)
+    trace = ReasoningTrace()
+
+    trace.record_ledger_tools(ledger)
+
+    assert trace.tools_used == [ToolUse("finus_market_news", ok=False, empty=False)]
+
+
+def test_data_result_upgrades_an_earlier_empty_result():
+    """재시도에서 데이터를 얻었으면 결국 얻은 것이다 — 각주도 그렇게 말해야 한다."""
+    ledger = DataToolLedger()
+    ledger.record("finus_market_news", ok=True, produced_rows=False, empty=True)
+    ledger.record("finus_market_news", ok=True, produced_rows=True, empty=False)
+    trace = ReasoningTrace()
+
+    trace.record_ledger_tools(ledger)
+
+    assert trace.tools_used == [ToolUse("finus_market_news", ok=True, empty=False)]
+
+
+def test_empty_result_upgrades_an_earlier_failure():
+    """실패 < 빈 결과 — 오류로 끝난 게 아니라 조회에는 성공했다는 정보가 더 정확하다."""
+    ledger = DataToolLedger()
+    ledger.record("finus_market_news", ok=False, produced_rows=False)
+    ledger.record("finus_market_news", ok=True, produced_rows=False, empty=True)
+    trace = ReasoningTrace()
+
+    trace.record_ledger_tools(ledger)
+
+    assert trace.tools_used == [ToolUse("finus_market_news", ok=True, empty=True)]
+
+
+def test_a_later_empty_result_does_not_downgrade_obtained_data():
+    """한 번 얻은 데이터는 뒤 호출의 빈 결과·실패로 사라지지 않는다."""
+    ledger = DataToolLedger()
+    ledger.record("finus_market_news", ok=True, produced_rows=True, empty=False)
+    ledger.record("finus_market_news", ok=True, produced_rows=False, empty=True)
+    ledger.record("finus_market_news", ok=False, produced_rows=False)
+    trace = ReasoningTrace()
+
+    trace.record_ledger_tools(ledger)
+
+    assert trace.tools_used == [ToolUse("finus_market_news", ok=True, empty=False)]
+
+
+def test_successful_write_tool_is_not_reported_as_empty():
+    """쓰기 도구는 produced_rows=False여도 '실제로 저장했다'는 뜻이다 — 빈 결과가 아니다."""
+    ledger = DataToolLedger()
+    ledger.record("finus_save_diary", ok=True, produced_rows=False, empty=False)
+    trace = ReasoningTrace()
+
+    trace.record_ledger_tools(ledger)
+
+    assert trace.tools_used == [ToolUse("finus_save_diary", ok=True, empty=False)]
+
+
+@pytest.mark.asyncio
+async def test_empty_read_path_reports_empty_not_success():
+    """게이트의 빈 결과 경로 전체를 통과시켜 상태가 각주까지 살아 오는지 본다.
+
+    only_empty_reads()가 True면 게이트는 재시도 없이 _EMPTY_RESULT_REJECTION을
+    돌려준다. 그 답변에 붙는 각주의 근거가 이 tools_used다.
+    """
+
+    async def ainvoke(_request):
+        # mcp-news가 결과 없음일 때 내는 리터럴 (_EMPTY_RESULT_LITERALS).
+        _record_to_ledger("finus_market_news", "'삼성전자'에 대한 뉴스를 찾지 못했습니다.")
+        # 수치 주장이 있어야 게이트가 트립한다(_check_tool_enforcement).
+        return ChatResponse.from_string("삼성전자는 74,200원입니다.", usage=Usage())
+
+    inner = MagicMock()
+    inner.ainvoke = AsyncMock(side_effect=ainvoke)
+
+    trace = ReasoningTrace()
+    token = REASONING_TRACE.set(trace)
+    try:
+        answer = await _run_with_gate(
+            inner=inner,
+            query="삼성전자 뉴스 알려줘",
+            chat_request=_simple_req(),
+            inner_name="news_agent",
+        )
+    finally:
+        REASONING_TRACE.reset(token)
+
+    assert answer.startswith("[조회 결과 없음]"), "빈 결과 경로를 타는 시나리오여야 한다"
+    assert trace.tools_used == [ToolUse("finus_market_news", ok=True, empty=True)]
+
+
+# ---------------------------------------------------------------------------
 # 라우팅 → routed_agent
 # ---------------------------------------------------------------------------
 
@@ -218,6 +330,7 @@ def test_with_reasoning_trace_adds_fields_without_touching_existing_ones():
         routed_agent="news_agent",
         tools_used=[
             ToolUse("finus_market_news", ok=True),
+            ToolUse("finus_earnings_report", ok=True, empty=True),
             ToolUse("finus_account_balance", ok=False),
         ],
     )
@@ -227,8 +340,9 @@ def test_with_reasoning_trace_adds_fields_without_touching_existing_ones():
 
     assert dumped["routed_agent"] == "news_agent"
     assert dumped["tools_used"] == [
-        {"name": "finus_market_news", "ok": True},
-        {"name": "finus_account_balance", "ok": False},
+        {"name": "finus_market_news", "ok": True, "empty": False},
+        {"name": "finus_earnings_report", "ok": True, "empty": True},
+        {"name": "finus_account_balance", "ok": False, "empty": False},
     ]
     # 기존 필드 전부 불변 — 백엔드 파서와 scheduler가 이 필드들만 읽는다.
     for field_name in ("id", "object", "model", "created", "choices", "usage"):
@@ -255,6 +369,47 @@ def test_with_reasoning_trace_adds_nothing_when_nothing_observed():
 
     assert "routed_agent" not in dumped
     assert "tools_used" not in dumped
+
+
+def test_extra_fields_survive_the_fastapi_response_model_boundary():
+    """두 필드가 실제 HTTP 응답 본문까지 나가는지 고정한다 (PR #263 리뷰 🔵6).
+
+    model_dump()가 필드를 담는다고 HTTP 응답에 나간다는 보장은 없다. FastAPI는
+    response_model로 반환값을 한 번 더 검증·직렬화하는데, 그 경로에서 extra 필드가
+    떨어지면 backend는 필드가 없는 것으로 보고 각주를 **조용히** 생략한다 — 양 끝
+    (model_dump / backend 파싱)만 덮여 있고 그 사이가 비어 있던 구간이다.
+
+    response_model은 vendor 라우트와 같은 형태를 쓴다:
+      nat/front_ends/fastapi/routes/v1_chat_completions.py:158
+        response_model=ChatResponse | ChatResponseChunk
+    vendor가 이 시그니처를 바꾸면 이 테스트는 더 이상 그 경계를 대변하지 않는다.
+    """
+    fastapi = pytest.importorskip("fastapi")
+    from fastapi.testclient import TestClient
+    from nat.data_models.api_server import ChatResponseChunk
+
+    tagged = with_reasoning_trace(
+        ChatResponse.from_string("답변 본문", usage=Usage()),
+        ReasoningTrace(
+            routed_agent="news_agent",
+            tools_used=[ToolUse("finus_market_news", ok=True, empty=True)],
+        ),
+    )
+
+    app = fastapi.FastAPI()
+
+    @app.post("/v1/chat/completions", response_model=ChatResponse | ChatResponseChunk)
+    async def _endpoint():
+        return tagged
+
+    body = TestClient(app).post("/v1/chat/completions").json()
+
+    assert body["routed_agent"] == "news_agent"
+    assert body["tools_used"] == [
+        {"name": "finus_market_news", "ok": True, "empty": True}
+    ]
+    # 기존 필드도 그대로 나간다 — backend의 _nat_message_from_payload가 이걸 읽는다.
+    assert body["choices"][0]["message"]["content"] == "답변 본문"
 
 
 # ---------------------------------------------------------------------------
@@ -301,7 +456,7 @@ async def test_transcript_agent_attaches_trace_to_response(tmp_path):
     dumped = result.model_dump()
 
     assert dumped["routed_agent"] == "news_agent"
-    assert dumped["tools_used"] == [{"name": "finus_market_news", "ok": True}]
+    assert dumped["tools_used"] == [{"name": "finus_market_news", "ok": True, "empty": False}]
     assert dumped["choices"][0]["message"]["content"] == "삼성전자 뉴스입니다."
 
 

--- a/finus_nat/tests/test_reasoning_trace.py
+++ b/finus_nat/tests/test_reasoning_trace.py
@@ -35,6 +35,7 @@ from nat_finus_nat.finus_api import (
     REASONING_TRACE,
     DataToolLedger,
     ReasoningTrace,
+    ToolUse,
     _record_to_ledger,
 )
 
@@ -81,7 +82,10 @@ async def test_gate_records_executed_tools_into_trace_in_call_order():
     finally:
         REASONING_TRACE.reset(token)
 
-    assert trace.tools_used == ["finus_account_balance", "finus_market_news"]
+    assert trace.tools_used == [
+        ToolUse("finus_account_balance", ok=True),
+        ToolUse("finus_market_news", ok=True),
+    ]
 
 
 @pytest.mark.asyncio
@@ -119,7 +123,8 @@ async def test_trace_deduplicates_tools_across_gate_retry():
         REASONING_TRACE.reset(token)
 
     assert call_count["n"] == 2, "재시도가 일어나는 시나리오여야 한다"
-    assert trace.tools_used == ["finus_market_news"]
+    # 1차 실패 + 2차 성공 → 한 항목으로 접히고, 결국 데이터를 얻었으므로 ok=True.
+    assert trace.tools_used == [ToolUse("finus_market_news", ok=True)]
 
 
 @pytest.mark.asyncio
@@ -155,11 +160,11 @@ async def test_gate_does_not_fail_without_trace_box():
     assert answer == "정리했습니다."
 
 
-def test_ledger_merge_ignores_nothing_recorded_by_code():
-    """ReasoningTrace는 원장 레코드만 병합한다 — 오류 응답 기록도 '실행된 도구'다.
+def test_failed_tool_is_kept_but_marked_not_ok():
+    """실패한 호출도 목록에 남기되 ok=False로 구분한다.
 
-    도구를 호출했지만 오류가 났다면 그 사실 자체가 사용자가 알아야 할 근거다.
-    ok 여부로 거르면 각주가 "확인한 자료 없음"이 되어 시도조차 안 한 것처럼 보인다.
+    빼면 시도조차 안 한 것처럼 보이고, ok 없이 이름만 실으면 소비자가 실패한 호출까지
+    "확인한 자료"로 표시해 사용자가 답변의 근거를 오독한다.
     """
     ledger = DataToolLedger()
     ledger.record("finus_account_balance", ok=False, produced_rows=False)
@@ -167,7 +172,19 @@ def test_ledger_merge_ignores_nothing_recorded_by_code():
 
     trace.record_ledger_tools(ledger)
 
-    assert trace.tools_used == ["finus_account_balance"]
+    assert trace.tools_used == [ToolUse("finus_account_balance", ok=False)]
+
+
+def test_repeated_failure_stays_not_ok():
+    """같은 도구가 계속 실패하면 ok=False를 유지한다."""
+    ledger = DataToolLedger()
+    ledger.record("finus_account_balance", ok=False, produced_rows=False)
+    ledger.record("finus_account_balance", ok=False, produced_rows=False)
+    trace = ReasoningTrace()
+
+    trace.record_ledger_tools(ledger)
+
+    assert trace.tools_used == [ToolUse("finus_account_balance", ok=False)]
 
 
 # ---------------------------------------------------------------------------
@@ -199,14 +216,20 @@ def test_with_reasoning_trace_adds_fields_without_touching_existing_ones():
     original = ChatResponse.from_string("답변 본문", usage=Usage())
     trace = ReasoningTrace(
         routed_agent="news_agent",
-        tools_used=["finus_market_news", "finus_account_balance"],
+        tools_used=[
+            ToolUse("finus_market_news", ok=True),
+            ToolUse("finus_account_balance", ok=False),
+        ],
     )
 
     updated = with_reasoning_trace(original, trace)
     dumped = updated.model_dump()
 
     assert dumped["routed_agent"] == "news_agent"
-    assert dumped["tools_used"] == ["finus_market_news", "finus_account_balance"]
+    assert dumped["tools_used"] == [
+        {"name": "finus_market_news", "ok": True},
+        {"name": "finus_account_balance", "ok": False},
+    ]
     # 기존 필드 전부 불변 — 백엔드 파서와 scheduler가 이 필드들만 읽는다.
     for field_name in ("id", "object", "model", "created", "choices", "usage"):
         assert dumped[field_name] == original.model_dump()[field_name]
@@ -278,7 +301,7 @@ async def test_transcript_agent_attaches_trace_to_response(tmp_path):
     dumped = result.model_dump()
 
     assert dumped["routed_agent"] == "news_agent"
-    assert dumped["tools_used"] == ["finus_market_news"]
+    assert dumped["tools_used"] == [{"name": "finus_market_news", "ok": True}]
     assert dumped["choices"][0]["message"]["content"] == "삼성전자 뉴스입니다."
 
 

--- a/finus_nat/tests/test_reasoning_trace.py
+++ b/finus_nat/tests/test_reasoning_trace.py
@@ -1,0 +1,304 @@
+"""#260: 추론 메타데이터(routed_agent / tools_used) 동작 고정 테스트.
+
+핵심 계약 세 가지를 고정한다.
+
+1. 두 필드는 **코드 기록**에서만 만들어진다 — supervisor의 분기 선택 결과와 도구 강제
+   원장(:class:`DataToolLedger`). 모델 출력 텍스트를 파싱하지 않는다 (#129와 같은 원칙).
+2. 기존 응답 필드(``choices``/``usage``/``model`` 등)는 불변이다 — 추가만 한다.
+3. 원장이 비면 ``tools_used``는 빈 목록이다.
+
+실 KIS·OpenAI 연결 없이 동작한다.
+"""
+
+import pytest
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+from nat.data_models.api_server import (
+    ChatRequest,
+    ChatRequestOrMessage,
+    ChatResponse,
+    Message,
+    Usage,
+    UserMessageContentRoleType,
+)
+
+from nat_finus_nat.agents import (
+    FinusSqliteTranscriptAgentConfig,
+    _run_with_gate,
+    _trace_route,
+    finus_sqlite_transcript_agent,
+    with_reasoning_trace,
+)
+from nat_finus_nat.finus_api import (
+    DATA_TOOL_LEDGER,
+    REASONING_TRACE,
+    DataToolLedger,
+    ReasoningTrace,
+    _record_to_ledger,
+)
+
+
+# ---------------------------------------------------------------------------
+# 헬퍼
+# ---------------------------------------------------------------------------
+
+def _simple_req(text: str = "삼성전자 뉴스 알려줘") -> ChatRequest:
+    return ChatRequest(
+        messages=[Message(role=UserMessageContentRoleType.USER, content=text)]
+    )
+
+
+def _inner_calling_tools(*tool_names: str, answer: str = "정리했습니다.") -> MagicMock:
+    """호출될 때마다 *tool_names*를 순서대로 원장에 기록하는 가짜 내부 에이전트."""
+
+    async def ainvoke(_request):
+        for name in tool_names:
+            _record_to_ledger(name, "조회 결과 있음")
+        return ChatResponse.from_string(answer, usage=Usage())
+
+    inner = MagicMock()
+    inner.ainvoke = AsyncMock(side_effect=ainvoke)
+    return inner
+
+
+# ---------------------------------------------------------------------------
+# 원장 → tools_used
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_gate_records_executed_tools_into_trace_in_call_order():
+    """게이트를 통과한 호출에서 실행된 도구가 호출 순서대로 기록된다."""
+    trace = ReasoningTrace()
+    token = REASONING_TRACE.set(trace)
+    try:
+        await _run_with_gate(
+            inner=_inner_calling_tools("finus_account_balance", "finus_market_news"),
+            query="삼성전자 뉴스 알려줘",
+            chat_request=_simple_req(),
+            inner_name="news_agent",
+        )
+    finally:
+        REASONING_TRACE.reset(token)
+
+    assert trace.tools_used == ["finus_account_balance", "finus_market_news"]
+
+
+@pytest.mark.asyncio
+async def test_trace_deduplicates_tools_across_gate_retry():
+    """게이트 재시도로 같은 도구가 다시 실행돼도 tools_used에는 한 번만 남는다.
+
+    재시도는 원장을 새로 만들기 때문에 병합이 두 번 일어난다. 중복 제거가 없으면
+    각주에 "뉴스 검색, 뉴스 검색"처럼 같은 자료가 반복 노출된다.
+    """
+    call_count = {"n": 0}
+
+    async def ainvoke(_request):
+        call_count["n"] += 1
+        # 1차: 오류 응답만 기록 → 수치 주장과 함께 게이트 트립 → 재시도
+        # 2차: 성공 기록 → 통과
+        if call_count["n"] == 1:
+            _record_to_ledger("finus_market_news", '{"error": "일시 장애"}')
+            return ChatResponse.from_string("잔고는 5,000,000원입니다.", usage=Usage())
+        _record_to_ledger("finus_market_news", "뉴스 3건")
+        return ChatResponse.from_string("뉴스를 정리했습니다.", usage=Usage())
+
+    inner = MagicMock()
+    inner.ainvoke = AsyncMock(side_effect=ainvoke)
+
+    trace = ReasoningTrace()
+    token = REASONING_TRACE.set(trace)
+    try:
+        await _run_with_gate(
+            inner=inner,
+            query="잔고 알려줘",
+            chat_request=_simple_req("잔고 알려줘"),
+            inner_name="news_agent",
+        )
+    finally:
+        REASONING_TRACE.reset(token)
+
+    assert call_count["n"] == 2, "재시도가 일어나는 시나리오여야 한다"
+    assert trace.tools_used == ["finus_market_news"]
+
+
+@pytest.mark.asyncio
+async def test_trace_is_empty_when_no_tool_ran():
+    """도구를 하나도 호출하지 않으면 tools_used는 빈 목록이다."""
+    trace = ReasoningTrace()
+    token = REASONING_TRACE.set(trace)
+    try:
+        await _run_with_gate(
+            inner=_inner_calling_tools(answer="일반 지식으로 답합니다."),
+            query="투자란 무엇인가?",
+            chat_request=_simple_req("투자란 무엇인가?"),
+            inner_name="strategy_agent",
+        )
+    finally:
+        REASONING_TRACE.reset(token)
+
+    assert trace.tools_used == []
+
+
+@pytest.mark.asyncio
+async def test_gate_does_not_fail_without_trace_box():
+    """추론 기록 박스가 없어도(설치하지 않는 config·CLI 경로) 게이트는 그대로 동작한다."""
+    assert REASONING_TRACE.get() is None
+
+    answer = await _run_with_gate(
+        inner=_inner_calling_tools("finus_market_news", answer="정리했습니다."),
+        query="삼성전자 뉴스 알려줘",
+        chat_request=_simple_req(),
+        inner_name="news_agent",
+    )
+
+    assert answer == "정리했습니다."
+
+
+def test_ledger_merge_ignores_nothing_recorded_by_code():
+    """ReasoningTrace는 원장 레코드만 병합한다 — 오류 응답 기록도 '실행된 도구'다.
+
+    도구를 호출했지만 오류가 났다면 그 사실 자체가 사용자가 알아야 할 근거다.
+    ok 여부로 거르면 각주가 "확인한 자료 없음"이 되어 시도조차 안 한 것처럼 보인다.
+    """
+    ledger = DataToolLedger()
+    ledger.record("finus_account_balance", ok=False, produced_rows=False)
+    trace = ReasoningTrace()
+
+    trace.record_ledger_tools(ledger)
+
+    assert trace.tools_used == ["finus_account_balance"]
+
+
+# ---------------------------------------------------------------------------
+# 라우팅 → routed_agent
+# ---------------------------------------------------------------------------
+
+def test_trace_route_records_selected_branch():
+    trace = ReasoningTrace()
+    token = REASONING_TRACE.set(trace)
+    try:
+        _trace_route("news_agent")
+    finally:
+        REASONING_TRACE.reset(token)
+
+    assert trace.routed_agent == "news_agent"
+
+
+def test_trace_route_is_noop_without_box():
+    """박스가 없으면 조용히 no-op한다 — 각주 부재가 답변 경로를 막지 않는다."""
+    assert REASONING_TRACE.get() is None
+    _trace_route("news_agent")  # 예외 없이 통과해야 한다
+
+
+# ---------------------------------------------------------------------------
+# 응답 부착 — 기존 필드 불변
+# ---------------------------------------------------------------------------
+
+def test_with_reasoning_trace_adds_fields_without_touching_existing_ones():
+    original = ChatResponse.from_string("답변 본문", usage=Usage())
+    trace = ReasoningTrace(
+        routed_agent="news_agent",
+        tools_used=["finus_market_news", "finus_account_balance"],
+    )
+
+    updated = with_reasoning_trace(original, trace)
+    dumped = updated.model_dump()
+
+    assert dumped["routed_agent"] == "news_agent"
+    assert dumped["tools_used"] == ["finus_market_news", "finus_account_balance"]
+    # 기존 필드 전부 불변 — 백엔드 파서와 scheduler가 이 필드들만 읽는다.
+    for field_name in ("id", "object", "model", "created", "choices", "usage"):
+        assert dumped[field_name] == original.model_dump()[field_name]
+    assert updated.choices[0].message.content == "답변 본문"
+
+
+def test_with_reasoning_trace_emits_empty_tools_when_ledger_was_empty():
+    """라우팅은 됐는데 도구가 하나도 실행되지 않은 경우는 빈 목록으로 드러낸다."""
+    response = ChatResponse.from_string("답변", usage=Usage())
+    trace = ReasoningTrace(routed_agent="strategy_agent")
+
+    dumped = with_reasoning_trace(response, trace).model_dump()
+
+    assert dumped["routed_agent"] == "strategy_agent"
+    assert dumped["tools_used"] == []
+
+
+def test_with_reasoning_trace_adds_nothing_when_nothing_observed():
+    """관측된 것이 전혀 없으면 필드를 붙이지 않는다 — 백엔드는 각주를 생략한다."""
+    response = ChatResponse.from_string("답변", usage=Usage())
+
+    dumped = with_reasoning_trace(response, ReasoningTrace()).model_dump()
+
+    assert "routed_agent" not in dumped
+    assert "tools_used" not in dumped
+
+
+# ---------------------------------------------------------------------------
+# workflow 최상단 통합 — 실제 응답에 실리는지
+# ---------------------------------------------------------------------------
+
+@asynccontextmanager
+async def _transcript_agent_fn(tmp_path, inner_response_fn):
+    """finus_sqlite_transcript_agent를 만들어 내부 호출 함수를 넘긴다."""
+    inner = MagicMock()
+    inner.ainvoke = AsyncMock(side_effect=inner_response_fn)
+
+    builder = MagicMock()
+    builder.get_function = AsyncMock(return_value=inner)
+
+    config = FinusSqliteTranscriptAgentConfig(
+        inner_agent_name="router_supervisor_agent",
+        db_path=str(tmp_path / "conversations.sqlite3"),
+    )
+    async with finus_sqlite_transcript_agent(config, builder) as function_info:
+        yield function_info.single_fn
+
+
+@pytest.mark.asyncio
+async def test_transcript_agent_attaches_trace_to_response(tmp_path):
+    """최상단이 심은 박스에 안쪽이 기록하고, 그 결과가 응답에 실린다."""
+
+    async def inner_response(_request):
+        # supervisor와 브랜치가 하는 일을 그대로 흉내낸다 — 박스를 mutate한다.
+        _trace_route("news_agent")
+        ledger = DataToolLedger()
+        ledger_token = DATA_TOOL_LEDGER.set(ledger)
+        try:
+            _record_to_ledger("finus_market_news", "뉴스 3건")
+        finally:
+            DATA_TOOL_LEDGER.reset(ledger_token)
+        REASONING_TRACE.get().record_ledger_tools(ledger)
+        return ChatResponse.from_string("삼성전자 뉴스입니다.", usage=Usage())
+
+    async with _transcript_agent_fn(tmp_path, inner_response) as response_fn:
+        result = await response_fn(
+            ChatRequestOrMessage(messages=[{"role": "user", "content": "삼성전자 뉴스"}])
+        )
+    dumped = result.model_dump()
+
+    assert dumped["routed_agent"] == "news_agent"
+    assert dumped["tools_used"] == ["finus_market_news"]
+    assert dumped["choices"][0]["message"]["content"] == "삼성전자 뉴스입니다."
+
+
+@pytest.mark.asyncio
+async def test_transcript_agent_does_not_leak_trace_between_requests(tmp_path):
+    """앞선 요청의 라우팅·도구가 다음 요청의 각주로 새지 않는다."""
+    routes = ["news_agent", "trading_agent"]
+
+    async def inner_response(_request):
+        _trace_route(routes.pop(0))
+        return ChatResponse.from_string("답변", usage=Usage())
+
+    async with _transcript_agent_fn(tmp_path, inner_response) as response_fn:
+        first = await response_fn(
+            ChatRequestOrMessage(messages=[{"role": "user", "content": "뉴스"}])
+        )
+        second = await response_fn(
+            ChatRequestOrMessage(messages=[{"role": "user", "content": "잔고"}])
+        )
+
+    assert first.model_dump()["routed_agent"] == "news_agent"
+    assert second.model_dump()["routed_agent"] == "trading_agent"
+    assert second.model_dump()["tools_used"] == []


### PR DESCRIPTION
## 📝 개요

자연어 질의 시 봇이 **최종 답만** 보내서 응답까지 수십 초 동안 아무 표시가 없고, 답변이 도착해도 **어느 에이전트가 무슨 자료를 보고 답했는지** 알 수 없었습니다.

추론 과정을 두 축으로 노출합니다.

1. **진행 상태 메시지** — 질의 접수 즉시 `⏳ 분석 중입니다...` 전송, 응답이 오면 그 메시지를 치우고 답변을 새 메시지로 전송
2. **응답 근거 각주** — 답변 하단에 담당 에이전트와 실제로 실행된 도구 목록 표시

**핵심 원칙(#129와 동일):** 각주 데이터는 **코드가 기록한 것에서만** 만듭니다 — supervisor의 분기 선택 결과와 #152의 도구 강제 원장(`DataToolLedger`)입니다. 모델 출력 텍스트를 파싱하지 않습니다. 파싱으로 만들면 "실제로 호출한 도구"가 아니라 "모델이 호출했다고 주장하는 도구"가 되어, 근거로 보여주는 각주가 오히려 환각을 사실처럼 전달하는 표면이 됩니다.

## 🚀 변경 사항

**finus_nat — 응답에 추론 메타데이터 추가 (기존 필드 불변, 추가만)**
- `ReasoningTrace`(mutable box) + `REASONING_TRACE` ContextVar 신설. `DataToolLedger`와 같은 이유로 mutable box입니다 — `ContextVar.set()`은 LangGraph가 만드는 `copy_context()` 경계를 넘어 바깥으로 전파되지 않습니다. 최상단에서 박스를 심고 안쪽은 mutate만 합니다.
- workflow 최상단(`finus_sqlite_transcript_agent`)이 박스를 심고, supervisor가 라우팅 결과를, `_run_with_gate`(1·2차 시도)와 뉴스 직행 경로가 원장의 도구를 기록합니다.
- `ChatResponse`에 `routed_agent` / `tools_used`를 **추가**합니다(`model_config`가 `extra="allow"`). `choices`/`usage` 등 기존 필드는 그대로라 backend의 `_nat_message_from_payload`와 scheduler의 `analysis_from_nat_text`가 불변입니다.
- `tools_used`는 `[{"name": ..., "ok": ..., "empty": ...}]` — 호출 순서 유지, 도구명 기준 중복 제거. 원장이 비면 `[]`. 원장이 구분하는 세 상태(오류 / 성공했지만 0행 / 데이터 있음)를 그대로 넘기고, 표기는 소비자가 정합니다.

**backend — 진행 표시 + 각주**
- 접수 즉시 진행 메시지 전송(+ `sendChatAction(typing)`), 응답 도착 시 `deleteMessage`로 치우고 **답변은 새 메시지로** 전송. 삭제가 거부되면 `✅ 분석 완료`로 편집해 "분석 중"이 남지 않게 합니다.
- 답변 하단 각주: `🤖 뉴스 에이전트 · 📚 확인한 자료: KIS 시세·계좌 조회, 뉴스 검색`
- 도구명은 한국어 라벨(`TOOL_LABELS`)로 매핑하고, 매핑에 없으면 내부 이름을 그대로 노출합니다(조용히 감추면 각주가 실제보다 적게 보여줘 목적 자체가 무너집니다).
- 실패한 호출은 `(실패)`, 성공했지만 결과가 비었던 호출은 `(결과 없음)`을 붙여 데이터를 얻은 호출과 구분합니다.
- `routed_agent`/`tools_used`가 없으면 각주를 **조용히 생략**합니다.
- `NatAnswer`(str 서브클래스)로 메타데이터를 실어, 반환값을 문자열로 쓰는 기존 호출부(scheduler·`/earnings`)의 파급을 0으로 뒀습니다. `llm_chat`에는 `Literal` 오버로드를 달아 `"nat"` 분기만 `NatAnswer`를 반환함을 타입으로 드러냅니다.

**자가 리뷰에서 잡아 이 PR 안에서 고친 것**
- **답변 푸시 알림 소실(높음)** — 텔레그램은 메시지 편집에 푸시 알림을 보내지 않습니다. 최초 구현대로 진행 메시지를 답변으로 편집하면 "분석 중"만 알림이 울리고 정작 답변에는 알림이 없어, 체감 응답성을 높이려던 기능이 알림 가치를 뒤집습니다. 답변을 새 메시지로 되돌렸습니다. **이슈 #260 본문의 "editMessageText로 수정"에서 의도적으로 벗어난 부분입니다.**
- **실패한 도구가 "확인한 자료"로 표시(중간)** — 원장의 `ok`를 버리고 이름만 실어, KIS 조회가 오류로 끝나도 각주는 "확인한 자료: KIS 시세·계좌 조회"라고 말했습니다. 사용자는 답변이 그 데이터에 근거했다고 읽지만 실제로는 아닙니다. `ok`를 함께 싣고 `(실패)`로 표시합니다. 목록에서 빼지는 않습니다 — 빼면 시도조차 안 한 것처럼 보입니다.
- **각주 길이 상한 부재(낮음)** — `tools_used`는 다른 서비스가 보내는 값이라 개수·길이가 backend에서 보장되지 않습니다. 파싱 단계 `NAT_MAX_TOOLS_USED=16`, 각주 전체 `REASONING_FOOTNOTE_MAX_CHARS=300`, `_telegram_text` 슬라이스에 `max(0, ...)` 가드를 넣었습니다.
- **Mem0 모드에서 각주가 조용히 사라짐(높음)** — 아래 "관련 이슈" 참고. 이번엔 문서화까지만 했습니다.
- `TELEGRAM_MESSAGE_LIMIT`을 `telegram_notifier`로 옮겨 `[:4000]` 리터럴 4곳을 제거했습니다.

**1차 리뷰(@katalsye) 반영 — 커밋 `10a2932`**

- **🟡1 `NatAnswer`가 `llm_chat` 경계를 넘어 살아남는지 고정** — `NatAnswer`는 `str` 서브클래스라 문자열 연산 한 번이면 메타데이터가 소실됩니다. #254(PII 마스킹)의 `unmask_pii`는 mapping이 비었을 때만 원본을 그대로 돌려주므로, 합쳐지면 **PII가 포함된 질의에서만** 각주가 사라집니다 — 설계상 조용히 생략되어 로그도 남지 않습니다. 회귀 테스트 한 건과 `NatAnswer.with_text()` 헬퍼를 추가했습니다. 어느 쪽이 나중에 머지되든 CI가 잡습니다.
- **🟡2 빈 결과(`ok=True, empty=True`)를 성공과 구분** — `ok=False`에 대해 세운 논리가 그대로 성립하는 세 번째 상태입니다. 게이트가 `only_empty_reads()`로 `[조회 결과 없음] ...`을 본문으로 돌려주는 경로(#209)에서 각주만 "확인한 자료: 뉴스 검색"이라고 말해 본문과 정면으로 충돌했습니다. `ToolUse`/`NatToolUse`에 `empty`를 싣고(기본값 `False` — 구버전 호환), 병합을 순위 기반(**실패 < 빈 결과 < 데이터 있음**)으로 바꿨습니다. 각주에는 `(결과 없음)`으로 표시하고 목록에서 빼지는 않습니다.
- **🟡3 진행 메시지의 비멱등성** — 리뷰가 최소선으로 제시한 (b), 즉 `_handle_one_update` 도크스트링의 비멱등 경로 목록에 이 경로를 추가하는 것만 했습니다. **동작은 그대로입니다.** 구조적 해결은 #275로 분리했습니다.
- **🔵1** `_send_progress_message`가 실제로 전송 실패를 삼키도록 고쳤습니다 — 도크스트링은 삼킨다고 했지만 삼키는 주체는 notifier였고, notifier는 주입 가능합니다.
- **🔵2** 지적된 뮤테이션 생존 3건(진행 문구 상수, `edit_message_text` 절단, `ok` 검사)을 전부 차단했습니다. 재실행해 각각 red를 확인했습니다.
- **🔵4** `_post_message` 반환 타입을 `Any` → `httpx.Response`로 좁혔습니다.
- **🔵5** 본문 테스트 수치를 다시 측정해 정정했습니다.
- **🔵6 (리뷰어가 미실행으로 남긴 항목)** NAT의 FastAPI `response_model` 경계를 **실측했습니다.** vendor 라우트와 같은 `response_model=ChatResponse | ChatResponseChunk`로 앱을 구성해 실제 HTTP 본문을 확인했고, 두 extra 필드가 그대로 나갑니다. 수동 확인으로 남기지 않고 `test_extra_fields_survive_the_fastapi_response_model_boundary`로 고정했습니다.
- **🔵3 (이번 PR에서 하지 않음)** `TOOL_LABELS`/`AGENT_LABELS` 드리프트 CI 검사는 리뷰 의견대로 범위 밖이라 #282로 분리했습니다.

**테스트**
- `finus_nat/tests/test_reasoning_trace.py` 신규 **21건** — 원장→`tools_used` 순서·재시도 병합(실패<빈 결과<데이터)·빈 원장·**기존 응답 필드 불변**·요청 간 미누출·**FastAPI `response_model` 경계**
- backend 신규 **44건** — NAT 페이로드 파싱, 진행 메시지 전송→정리→답변 전송, 삭제 실패 폴백, 각주 생략, 실패·빈 결과 표시, 길이 가드, **`llm_chat` 경계에서 `NatAnswer` 생존**
- 전체: **backend 506 passed, 2 skipped / finus_nat 244 passed, 1 skipped** (기존 테스트 전부 통과, 특히 `test_tool_enforcement`와 NAT 응답 파싱)
- 1차 리뷰의 🔵5 지적대로 이전 본문의 수치(14건 / 236 passed)가 실제와 달랐습니다. 위 수치는 이번에 로컬에서 다시 측정한 값입니다.

**충돌 회피**
- `backend/telegram_commands.py`의 `TelegramCommandPoller` 클래스는 한 줄도 건드리지 않았습니다 (PR #241 리뷰 중).

**병합·배포 시 유의 (낮음)**
- `tools_used` 스키마가 이 PR 내부에서 `list[str]`(d86a97a) → `list[dict]`(5b20d35) → `empty` 추가(10a2932)로 바뀌었습니다. 마지막 변경은 필드 **추가**라 구버전 NAT가 `empty`를 빼고 보내도 backend가 `False`로 읽어 각주 문구만 예전과 같아집니다 — 아래 문제는 첫 변경(`list[str]`→`list[dict]`)에만 해당합니다. 구형 `list[str]`을 보내는 NAT와 신형 backend가 붙으면 backend 파서가 dict 아닌 항목을 건너뛰어 각주가 "확인한 자료: 없음"이 됩니다 — 생략이 아니라 사실과 다른 진술입니다.
- 다만 그 중간 형태는 **이 PR 내부 커밋에만** 존재하므로, **squash merge**하거나 두 서비스를 같은 커밋으로 배포하면 발생하지 않습니다. #260 이전 NAT와 붙는 경우는 필드 자체가 없어 각주가 조용히 생략되므로 문제없습니다.

## 🔗 관련 이슈
- Closes #260
- Related to #152 — 도구 강제 게이트. `tools_used`의 출처인 `DataToolLedger`를 제공합니다.
- Related to #129 — LLM 출력 provenance 주입 차단. 각주 데이터 출처 원칙이 같습니다.

**후속 이슈 (등록 완료):**
- #273 — `configs/router.yml`(Mem0 모드)에서 추론 각주가 표시되지 않습니다. 최상위 workflow인 vendor `auto_memory_agent`의 `_response_fn` 시그니처가 `(input_message: str) -> str`이라, 안쪽 `finus_sqlite_transcript_agent`가 `ChatResponse`에 붙인 두 필드가 래퍼를 통과하면서 버려집니다(래퍼가 str을 넘기므로 안쪽이 `is_string` 경로로 들어가 애초에 부착도 되지 않습니다). backend는 필드가 없으면 각주를 생략하도록 설계돼 있어 **경고 없이 기능만 사라집니다.** 기본값은 `router_nomemory.yml`이라 평소엔 동작하지만 `--memory`는 문서화된 지원 모드입니다. 이번 PR에서는 `router.yml`과 `finus_nat/README.md`에 제약을 명시했습니다.
- #275 — 자연어 경로의 진행 메시지가 폴러 재시도 예산만큼 중복 전송됩니다(1차 리뷰 🟡3). 이번 PR에서는 도크스트링 기재까지만 했습니다.
- #282 — `TOOL_LABELS`/`AGENT_LABELS`의 finus_nat 식별자 드리프트를 CI로 잡습니다(1차 리뷰 🔵3).

## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [x] 변경 사항에 대한 문서(README 등)를 업데이트했나요?

## 📸 스크린샷 (선택 사항)

실제 텔레그램 메시지 흐름입니다.

**1단계 — 질의 접수 직후 (새 메시지 → 알림 O)**
```
⏳ 분석 중입니다...
```

**2단계 — 응답 도착: 위 메시지를 삭제하고 답변을 새 메시지로 전송 (알림 O)**
```
삼성전자는 현재 74,200원에 거래되고 있습니다. 전일 대비 1.2% 상승했습니다.
최근 뉴스에서는 HBM 공급 확대 기대가 반복적으로 언급되고 있습니다.

─────
🤖 뉴스 에이전트 · 📚 확인한 자료: KIS 시세·계좌 조회, 뉴스 검색
```

**도구 호출이 실패한 경우 — 성공과 구분해 표시**
```
잔고를 확인하지 못했습니다. 잠시 후 다시 시도해 주세요.

─────
🤖 트레이딩 에이전트 · 📚 확인한 자료: KIS 시세·계좌 조회(실패)
```

**조회는 성공했지만 결과가 비어 있던 경우 — 본문과 각주가 어긋나지 않게**
```
[조회 결과 없음] 요청하신 조건으로 조회했으나 데이터가 없습니다. 조회 기간이나 종목을 바꿔 다시 질문해 주세요.

─────
🤖 뉴스 에이전트 · 📚 확인한 자료: 뉴스 검색(결과 없음)
```

**도구를 하나도 쓰지 않은 답변 — 그 사실 자체가 근거**
```
분산투자는 ...

─────
🤖 전략 에이전트 · 📚 확인한 자료: 없음
```

**메타데이터가 없는 응답(구버전 NAT) — 각주 조용히 생략**
```
예전 방식 답변
```


