### PR TITLE
feat: fetchAllPaged에 페이지 간 지연 인자(pageDelayMs) 경로 추가 (#210)

### DIFF
--- a/mcp-trading/balance.js
+++ b/mcp-trading/balance.js
@@ -52,6 +52,8 @@ export function buildBalanceParams(accountNo, { ctxAreaFk100 = "", ctxAreaNk100 
  * @param {number}   options.timeBudgetMs  전체 시간 예산 ms (필수; 루프마다 다름)
  * @param {Function} [options.now]         현재 시각 반환 함수 (테스트 주입용, 기본 Date.now)
  * @param {string}   [options.label]       오류 로그 접두사 (기본 "연속조회")
+ * @param {number}   [options.pageDelayMs] 페이지 사이 대기 시간 ms (기본 0 = 대기 없음; 이슈 #210)
+ * @param {Function} [options.sleep]       대기 함수 (테스트 주입용, 기본 setTimeout 기반 실제 대기)
  * @returns {Promise<{ rows, summary, pages, truncated }>}
  *   truncated: null | "max_pages" | "time_budget" | "no_cursor" | "repeated_cursor" | "error"
  */
@@ -60,6 +62,8 @@ export async function fetchAllPaged(fetchPage, {
   timeBudgetMs,
   now = () => Date.now(),
   label = "연속조회",
+  pageDelayMs = 0,
+  sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
 } = {}) {
   const rows = [];
   let summary = null;
@@ -82,6 +86,23 @@ export async function fetchAllPaged(fetchPage, {
     if (pages > 0 && now() - startedAt >= timeBudgetMs) {
       truncated = "time_budget";
       break;
+    }
+
+    // 페이지 사이에만 대기한다. `pages > 0`이므로 첫 페이지 요청 전에는 대기가 없고,
+    // 위 두 break(max_pages/time_budget)나 아래쪽의 no_cursor/repeated_cursor/정상
+    // 종료 break는 모두 이 지점을 다시 지나기 전에 루프를 빠져나가므로 마지막 페이지
+    // 이후에도 대기가 붙지 않는다.
+    //
+    // 대기 시간을 시간 예산 소진에서 일부러 빼지 않는다: 이 함수의 상위 호출자는
+    // 내부 시간 예산과 무관하게 실제 벽시계 시간으로 잘린다 — backend/services.py의
+    // run_mcp_tool 30초 하드컷(get_balance), diary_agent.yml의 timeout_sec: 120
+    // (fetchAllDailyOrderCcld/fetchAllBalanceRlzPl). 대기 시간을 예산 계산에서
+    // 제외하면 내부적으로는 예산 안에 있다고 판단해도 실제 총 소요 시간이 이 상위
+    // 하드컷을 넘어설 수 있다. now/sleep 모두 기본값이 실제 시각(Date.now)·실제
+    // 대기(setTimeout)이므로 별도 처리 없이 두면 대기 시간이 자연히 다음 반복의
+    // `now() - startedAt`에 반영된다 — 이것이 의도한 동작이다.
+    if (pageDelayMs > 0 && pages > 0) {
+      await sleep(pageDelayMs);
     }
 
     let body;
@@ -165,6 +186,11 @@ export async function fetchAllPaged(fetchPage, {
  *
  * 반환: { rows, summary, pages, truncated }
  *   - truncated: null | "max_pages" | "time_budget" | "no_cursor" | "repeated_cursor" | "error"
+ *
+ * 이슈 #210: fetchAllPaged에 pageDelayMs를 의도적으로 넘기지 않는다(기본값 0 유지).
+ * 이 함수의 관측 가능한 동작이 전부 불변이어야 한다는 것이 PR #200의 수용 기준이었고,
+ * 이슈 #210도 이를 그대로 이어받는다 — 페이지 간 지연은 daily-ccld/balance-rlz-pl
+ * 두 루프(index.js)에만 옵션으로 열어두고, 이 함수는 대상이 아니다.
  */
 export async function fetchAllBalance(fetchPage, {
   maxPages = BALANCE_MAX_PAGES,

--- a/mcp-trading/index.js
+++ b/mcp-trading/index.js
@@ -57,6 +57,11 @@ const DAILY_CCLD_MAX_PAGES = 50;
 // 100 < 120이므로 상한 안에 안전하게 들어온다. 90초 초과가 이상 상황이라고 판단하기에
 // 충분하다고 본다. 실제 페이지당 지연 측정치가 확보되면 이 값을 재조정해야 한다.
 const DAILY_CCLD_TIME_BUDGET_MS = 90_000;
+// 이슈 #210: 페이지 간 대기(fetchAllPaged의 pageDelayMs). 값을 0으로 비워둔다 — KIS
+// 유량 제한의 실제 임계(초당 호출 수)를 아직 측정하지 못했다. backend/telegram_commands.py의
+// `/watch list`가 종목당 1.1초를 쓰지만 그 값의 근거도 확인되지 않았고, 애초에 다른 TR이라
+// 그대로 가져다 쓸 근거가 안 된다. 측정치가 나오면 이 값을 채운다(이슈 #210 조사 항목).
+const DAILY_CCLD_PAGE_DELAY_MS = 0;
 const BALANCE_RLZ_PL_PATH = "/uapi/domestic-stock/v1/trading/inquire-balance-rlz-pl";
 const BALANCE_RLZ_PL_TR_ID = (() => {
   const override = (process.env.KIS_TR_ID_BALANCE_RLZ_PL || process.env.FINUS_KIS_TR_ID_BALANCE_RLZ_PL || "").trim();
@@ -67,6 +72,8 @@ const BALANCE_RLZ_PL_MAX_PAGES = 50;
 // inquire-balance-rlz-pl 연속조회 전체 시간 예산. DAILY_CCLD_TIME_BUDGET_MS와 같은 근거.
 // 두 TR의 호출자·상한·요청당 타임아웃이 동일하므로 동일한 값을 쓴다.
 const BALANCE_RLZ_PL_TIME_BUDGET_MS = 90_000;
+// 이슈 #210: DAILY_CCLD_PAGE_DELAY_MS와 같은 이유로 0. 실측 전까지 비워둔다.
+const BALANCE_RLZ_PL_PAGE_DELAY_MS = 0;
 const TOKEN_TTL_MARGIN_MS = 60_000;
 const TOKEN_CACHE_PATH = process.env.KIS_TOKEN_CACHE_PATH || path.join(
   os.tmpdir(),
@@ -381,6 +388,7 @@ async function fetchAllDailyOrderCcld({
       maxPages: DAILY_CCLD_MAX_PAGES,
       timeBudgetMs: DAILY_CCLD_TIME_BUDGET_MS,
       label: "일별 주문체결 연속조회",
+      pageDelayMs: DAILY_CCLD_PAGE_DELAY_MS,
     },
   );
 
@@ -498,6 +506,7 @@ async function fetchAllBalanceRlzPl() {
       maxPages: BALANCE_RLZ_PL_MAX_PAGES,
       timeBudgetMs: BALANCE_RLZ_PL_TIME_BUDGET_MS,
       label: "실현손익 연속조회",
+      pageDelayMs: BALANCE_RLZ_PL_PAGE_DELAY_MS,
     },
   );
 

--- a/mcp-trading/tests/balance.test.js
+++ b/mcp-trading/tests/balance.test.js
@@ -88,6 +88,40 @@ test("fetchAllBalance concatenates holdings across multiple continuation pages",
   assert.deepEqual(calls[1], { ctxAreaFk100: "FK1", ctxAreaNk100: "NK1", trCont: "N" });
 });
 
+// 이슈 #210: fetchAllPaged에 pageDelayMs 옵션이 생겼지만 fetchAllBalance는 이를 넘기지
+// 않는다(기본값 0 유지) — PR #200의 수용 기준("fetchAllBalance의 관측 가능한 동작이
+// 전부 불변일 것")을 이어받는 이 작업의 핵심 조건. fetchAllBalance는 pageDelayMs/sleep을
+// 주입받을 방법이 없으므로 직접 스파이할 수 없고, 대신 여러 페이지를 지연 없이
+// 실행했을 때 실제 벽시계 시간이 거의 걸리지 않는지로 회귀를 방어한다 — 만약 나중에
+// 누군가 실수로 fetchAllBalance에 pageDelayMs를 하드코딩해 넣으면 이 테스트가 느려져 실패한다.
+test("fetchAllBalance runs across multiple pages with no page-to-page delay (regression guard for issue #210)", async () => {
+  const totalPages = 5;
+  let calls = 0;
+  const fetchPage = async () => {
+    calls += 1;
+    return {
+      body: {
+        output1: [{ prdt_name: `종목${calls}`, pdno: String(calls).padStart(6, "0") }],
+        output2: calls === 1 ? [{ tot_evlu_amt: "1" }] : [],
+        ctx_area_fk100: calls < totalPages ? `FK${calls}` : "",
+        ctx_area_nk100: calls < totalPages ? `NK${calls}` : "",
+      },
+      trCont: "F",
+    };
+  };
+
+  const startedAt = Date.now();
+  const result = await fetchAllBalance(fetchPage, { maxPages: 20, timeBudgetMs: 60_000 });
+  const elapsedMs = Date.now() - startedAt;
+
+  assert.equal(calls, totalPages);
+  assert.equal(result.pages, totalPages);
+  assert.equal(result.truncated, "no_cursor");
+  // 페이지 간 지연이 없다면 5페이지 모두 수 ms 안에 끝난다. 지연이 하나라도 붙으면
+  // (예: 실수로 pageDelayMs를 하드코딩) 이 여유(500ms)를 넘긴다.
+  assert.ok(elapsedMs < 500, `elapsedMs(${elapsedMs})가 500ms 미만이어야 함 — 페이지 간 지연이 없어야 한다`);
+});
+
 test("fetchAllBalance stops and reports truncation when the page cap is hit", async () => {
   let calls = 0;
   const fetchPage = async () => {

--- a/mcp-trading/tests/fetch-all-paged.test.js
+++ b/mcp-trading/tests/fetch-all-paged.test.js
@@ -256,3 +256,105 @@ test("fetchAllPaged: rows가 없어도 truncated 값이 반환돼 호출자가 �
   assert.notEqual(result.truncated, null);
   assert.equal(result.truncated, "time_budget");
 });
+
+// ─── 이슈 #210: pageDelayMs ──────────────────────────────────────────────────
+
+test("fetchAllPaged: pageDelayMs를 넘기지 않으면 대기 없이 기존과 동일하게 동작한다 (기본값 0)", async () => {
+  let callCount = 0;
+  const sleepCalls = [];
+  const sleep = async (ms) => {
+    sleepCalls.push(ms);
+  };
+  const fetchPage = async () => {
+    callCount += 1;
+    return {
+      body: {
+        output1: [{ pdno: String(callCount).padStart(6, "0") }],
+        output2: callCount === 1 ? [{ tot: "1" }] : [],
+        ctx_area_fk100: callCount < 3 ? `FK${callCount}` : "",
+        ctx_area_nk100: callCount < 3 ? `NK${callCount}` : "",
+      },
+      trCont: "F",
+    };
+  };
+
+  const result = await fetchAllPaged(fetchPage, {
+    maxPages: MAX_PAGES,
+    timeBudgetMs: TIME_BUDGET_MS,
+    sleep, // pageDelayMs를 안 넘겼으니 호출되지 않아야 함
+  });
+
+  assert.equal(callCount, 3);
+  assert.equal(result.pages, 3);
+  assert.equal(result.truncated, "no_cursor");
+  assert.deepEqual(sleepCalls, []);
+});
+
+test("fetchAllPaged: pageDelayMs > 0이면 페이지 사이에만 대기하고, 첫 요청 전·마지막 이후에는 대기하지 않는다", async () => {
+  const pageOrder = [];
+  let callCount = 0;
+  const sleepCalls = [];
+  const sleep = async (ms) => {
+    sleepCalls.push({ ms, beforeCall: callCount + 1 });
+  };
+  const fetchPage = async () => {
+    callCount += 1;
+    pageOrder.push(callCount);
+    return {
+      body: {
+        output1: [{ pdno: String(callCount).padStart(6, "0") }],
+        output2: callCount === 1 ? [{ tot: "1" }] : [],
+        // 3번째 응답에서 커서가 끊겨 루프가 끝난다 (총 3회 호출)
+        ctx_area_fk100: callCount < 3 ? `FK${callCount}` : "",
+        ctx_area_nk100: callCount < 3 ? `NK${callCount}` : "",
+      },
+      trCont: "F",
+    };
+  };
+
+  const result = await fetchAllPaged(fetchPage, {
+    maxPages: MAX_PAGES,
+    timeBudgetMs: TIME_BUDGET_MS,
+    pageDelayMs: 250,
+    sleep,
+  });
+
+  assert.equal(callCount, 3);
+  assert.equal(result.truncated, "no_cursor");
+  // 대기는 페이지 사이(2번째 호출 전, 3번째 호출 전)에만 발생해야 한다.
+  // 1번째 호출(첫 페이지) 전에는 대기가 없고, 3번째(마지막) 호출 이후에도 대기가 없다.
+  assert.deepEqual(sleepCalls, [
+    { ms: 250, beforeCall: 2 },
+    { ms: 250, beforeCall: 3 },
+  ]);
+});
+
+test("fetchAllPaged: pageDelayMs가 0이면 sleep을 주입해도 호출되지 않는다", async () => {
+  let callCount = 0;
+  let sleepCallCount = 0;
+  const sleep = async () => {
+    sleepCallCount += 1;
+  };
+  const fetchPage = async () => {
+    callCount += 1;
+    return {
+      body: {
+        output1: [{ pdno: String(callCount).padStart(6, "0") }],
+        output2: callCount === 1 ? [{ tot: "1" }] : [],
+        ctx_area_fk100: "",
+        ctx_area_nk100: "",
+      },
+      trCont: "F",
+    };
+  };
+
+  const result = await fetchAllPaged(fetchPage, {
+    maxPages: MAX_PAGES,
+    timeBudgetMs: TIME_BUDGET_MS,
+    pageDelayMs: 0,
+    sleep,
+  });
+
+  assert.equal(result.truncated, "no_cursor");
+  assert.equal(sleepCallCount, 0);
+});


### PR DESCRIPTION
## 이 PR이 하는 것

`fetchAllPaged`(mcp-trading/balance.js)에 `pageDelayMs`/`sleep` 옵션을 추가해, 페이지 간 지연을 **루프별 인자**로 열어둔다.

- `pageDelayMs` 기본값은 **0** — 아무 옵션도 안 넘기면 기존 동작과 완전히 동일하다.
- `pageDelayMs > 0`일 때만 **페이지 사이에만** 대기한다. 첫 페이지 요청 전, 마지막 페이지 이후에는 대기가 붙지 않는다. (`pages > 0` 가드로 구현, 위쪽 max_pages/time_budget break와 아래쪽 no_cursor/repeated_cursor/정상종료 break가 모두 대기 지점을 다시 지나기 전에 루프를 빠져나간다.)
- `sleep`은 `now`와 같은 패턴으로 테스트 주입 가능(기본은 실제 `setTimeout`).
- `index.js`의 두 호출부(daily-ccld L373 부근, balance-rlz-pl L490 부근)에 `DAILY_CCLD_PAGE_DELAY_MS` / `BALANCE_RLZ_PL_PAGE_DELAY_MS` 상수를 추가해 인자 경로를 뚫었다.

## 이 PR이 하지 않는 것

**실제 지연 값을 정하지 않았다.** 두 상수 모두 `0`으로 두었다 — 즉 현재 동작은 이 PR 이전과 완전히 동일하다. KIS 유량 제한의 실제 임계(초당 호출 수)를 아직 측정하지 못했기 때문이다. `backend/telegram_commands.py`의 `/watch list`가 종목당 1.1초를 쓰지만, 그 값의 근거 자체가 확인되지 않았고 다른 TR이라 그대로 가져다 쓸 근거도 없다. 이슈 #210의 "조사가 먼저 필요한 것" 항목(KIS 유량 제한 실측, 세 루프의 실제 페이지당 지연 측정치)은 이 PR의 범위 밖이며 후속 작업으로 남는다. 따라서 `Closes #210`이 아니라 `Refs #210`을 쓴다 — 실측이 남아 이슈가 완결되지 않는다.

## `fetchAllBalance` 동작 불변을 어떻게 보장했는가

PR #200의 수용 기준("`fetchAllBalance`의 관측 가능한 동작이 전부 불변일 것")을 그대로 승계하는 게 이 작업의 핵심 조건이다.

- `fetchAllBalance`는 `pageDelayMs`/`sleep`을 받지도, `fetchAllPaged`에 넘기지도 않는다 — 기본값 0 유지.
- `fetchAllBalance`는 pageDelayMs를 주입받을 방법이 없어 직접 스파이할 수 없으므로, 대신 5페이지를 지연 없이 돌렸을 때 실제 벽시계 시간이 500ms를 넘지 않는지로 회귀를 방어하는 테스트를 추가했다(`tests/balance.test.js`: "fetchAllBalance runs across multiple pages with no page-to-page delay"). 나중에 누군가 실수로 `fetchAllBalance`에 `pageDelayMs`를 하드코딩해 넣으면 이 테스트가 느려져 실패한다.
- 기존 balance 테스트(호출 횟수·반환값·truncated 플래그를 검증하는 것들) 전부 그대로 통과했다.

## 시간 예산과 지연의 상호작용을 어떻게 결정했는가

**대기 시간을 시간 예산(`timeBudgetMs`) 소진에서 일부러 빼지 않는다.** 이 함수의 상위 호출자는 내부 시간 예산과 무관하게 실제 벽시계 시간으로 잘린다 — `backend/services.py`의 `run_mcp_tool` 30초 하드컷(`get_balance`), `diary_agent.yml`의 `timeout_sec: 120`(daily-ccld/balance-rlz-pl 루프). 대기 시간을 예산 계산에서 제외하면 내부적으로는 예산 안에 있다고 판단해도 실제 총 소요 시간이 이 상위 하드컷을 넘어설 수 있다. `now`/`sleep` 모두 기본값이 실제 시각(`Date.now`)·실제 대기(`setTimeout`)라 별도 처리 없이 두면 대기 시간이 자연히 다음 반복의 `now() - startedAt`에 반영된다 — 이것이 의도한 동작이며, `balance.js`의 코드 주석에 근거와 함께 남겼다.

커서 가드(no_cursor/repeated_cursor)와의 상호작용: 대기는 루프 최상단, 다음 페이지를 요청하기 직전에만 발생한다. 두 가드는 페이지 응답을 받은 뒤 다음 요청으로 넘어가기 전에 `break`하므로, 가드가 발동한 이후에는 대기 지점을 다시 지나지 않는다 — 즉 잘림이 확정된 마지막 페이지 이후에는 대기가 붙지 않는다.

## 실행한 검증 명령과 결과

워크트리에 `node_modules`가 없어 먼저 설치:

```
cd mcp-trading && npm install
```

전체 테스트:

```
cd mcp-trading && npm test
```

결과: **142 passed, 0 failed** (기존 138 + 신규 4). 신규 테스트:
- `tests/fetch-all-paged.test.js`: pageDelayMs 미지정 시 무동작(회귀 방어), pageDelayMs > 0일 때 페이지 사이에만 대기(첫 요청 전·마지막 이후 무대기 확인), pageDelayMs=0이면 sleep 미호출 — 모두 주입 가능한 `sleep` 스파이로 검증, 실제 벽시계 대기 없음.
- `tests/balance.test.js`: `fetchAllBalance`가 5페이지를 지연 없이(500ms 미만) 처리하는 회귀 방어 테스트.

기존 balance 관련 테스트(`balance.test.js`, `balance-rlz-pl-report.test.js`, `fetch-all-paged.test.js`의 기존 케이스) 전부 통과.

Refs #210