### PR TITLE
test: CI에 redis 서비스 컨테이너를 붙여 실 redis 통합 테스트를 켠다 (#267)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,25 @@ jobs:
   backend-test:
     name: Backend pytest
     runs-on: ubuntu-latest
+
+    # backend/tests/test_redis_integration.py는 REDIS_INTEGRATION_URL이 없으면 전부
+    # skip한다. 이 변수가 CI에 없던 동안 실 redis 커버리지는 0이었고, redis를 지나는
+    # 코드는 전부 테스트 안 FakeRedis만 통과했다 — 즉 FakeRedis와 실제 redis-py의
+    # 반환 규약(특히 set(..., nx=True, ex=...))이 어디에서도 대조되지 않았다(#267).
+    # 락 획득 여부를 그 반환값으로 판정하므로, 어긋나면 테스트는 초록불인 채
+    # 프로덕션 락만 깨진다. 서비스 컨테이너를 붙여 실제 서버와 대조한다.
+    services:
+      redis:
+        image: redis:7-alpine
+        ports: ['6379:6379']
+        # 서비스가 뜨자마자 스텝이 시작되면 접속이 거부돼 테스트가 skip으로 새 나간다.
+        # health check가 통과할 때까지 잡을 붙잡아 둔다.
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@v4
 
@@ -31,6 +50,9 @@ jobs:
         run: uv sync --project backend
 
       - name: backend 테스트 실행
+        # 서비스 컨테이너는 잡 컨테이너가 아닌 러너 호스트에 포트를 매핑하므로 localhost로 닿는다.
+        env:
+          REDIS_INTEGRATION_URL: redis://localhost:6379/0
         run: uv run --project backend pytest backend/tests/
 
   nat-test:

--- a/backend/tests/test_redis_integration.py
+++ b/backend/tests/test_redis_integration.py
@@ -31,7 +31,11 @@ async def _redis_client():
         await client.ping()
     except Exception as exc:
         await client.aclose()
-        pytest.skip(f"Redis integration server unavailable: {exc}")
+        # 접속 실패를 skip으로 넘기면, CI에서 서비스 컨테이너가 죽거나 주소가 어긋난
+        # 순간 이 파일 전체가 조용히 사라지고 잡은 초록불로 끝난다 — #267이 없애려는
+        # "실 redis 커버리지 0" 상태로 아무 신호 없이 되돌아간다. URL을 준 것은
+        # "여기 redis가 있다"는 선언이므로, 없으면 skip이 아니라 실패다.
+        pytest.fail(f"REDIS_INTEGRATION_URL={url} 에 접속하지 못했습니다: {exc}")
     return client
 
 

--- a/backend/tests/test_redis_integration.py
+++ b/backend/tests/test_redis_integration.py
@@ -35,7 +35,12 @@ async def _redis_client():
         # 순간 이 파일 전체가 조용히 사라지고 잡은 초록불로 끝난다 — #267이 없애려는
         # "실 redis 커버리지 0" 상태로 아무 신호 없이 되돌아간다. URL을 준 것은
         # "여기 redis가 있다"는 선언이므로, 없으면 skip이 아니라 실패다.
-        pytest.fail(f"REDIS_INTEGRATION_URL={url} 에 접속하지 못했습니다: {exc}")
+        #
+        # URL 값 자체는 찍지 않는다. redis://user:pass@host 형태면 credential이 그대로
+        # 나가는데 이 레포는 public이라 Actions 로그가 공개다. 지금 CI 값에는
+        # credential이 없지만 나중에 관리형 redis를 secret으로 물리는 순간 샌다.
+        # 진단에 필요한 host:port는 redis-py 예외 메시지가 이미 갖고 있어 잃는 것도 없다.
+        pytest.fail(f"REDIS_INTEGRATION_URL 로 지정한 redis에 접속하지 못했습니다: {exc}")
     return client
 
 


### PR DESCRIPTION
## 📝 개요

CI에 redis 서비스 컨테이너를 붙여, 지금까지 한 번도 실행된 적 없는 실 redis 통합 테스트 3건을 켠다. 접속 실패가 조용한 skip으로 새 나가던 경로도 함께 막는다.

범위 밖: `REDIS_INTEGRATION_URL`을 언급한 문서가 레포에 없어 로컬에서는 skip 3건만 보이고 켜는 법을 알 수 없다. 백엔드 테스트 실행법을 적어둔 문서 자체가 없어 넣을 자리가 마땅치 않으므로, 그 문서를 신설하는 이슈를 따로 등록하겠다.

## 🔍 발견된 문제

1. 실 redis 통합 테스트는 `REDIS_INTEGRATION_URL`이 없으면 전부 skip하는데 CI에 그 변수가 없었다. 즉 레포의 실 redis 커버리지가 CI에서 0이었고, redis를 지나는 코드는 전부 테스트 안의 인메모리 더블만 통과했다.
2. 그래서 더블과 실제 redis 클라이언트의 반환 규약이 어디에서도 대조되지 않았다. 락 획득 여부를 그 반환값으로 판정하므로, 둘이 어긋나면 테스트는 초록불인 채 프로덕션 락만 깨진다.
3. 접속 실패가 skip이라, 변수를 넣더라도 컨테이너가 죽거나 주소가 어긋나는 순간 통합 테스트 전체가 아무 신호 없이 사라지고 잡은 초록불로 끝난다.

## 🔧 문제 해결 방법

1. backend 잡에 redis 서비스 컨테이너를 붙이고(헬스체크 포함) 테스트 스텝에 `REDIS_INTEGRATION_URL`을 준다. 이슈 #267이 제안한 구성 그대로다.
2. 별도 조치는 없다. 1번으로 통합 테스트가 실제로 돌기 시작하면서 대조가 성립한다 — 아래 검증의 뮤테이션 실험이 그 대조가 실효하는지 확인한 것이다.
3. 접속 실패를 skip에서 실패로 바꾼다. 변수를 준 것은 "여기 redis가 있다"는 선언이므로 없으면 실패가 맞다. 변수 미설정 시의 skip(로컬 기본 경로)은 그대로 둔다.

## ✅ 검증

로컬에서 `redis:7-alpine` 컨테이너를 띄워 실측했다. 아래는 모두 CI 체크에 뜨지 않는 것이다.

- 뮤테이션으로 대조 실효 확인: `acquire_analysis_lock`의 `return token if acquired else None`을 `return None if acquired is False else token`으로 바꿨다. 실제 클라이언트는 NX 실패에 `None`을, 테스트 더블은 `False`를 돌려주므로 이 코드는 더블 아래서만 옳다. 변수 없이 돌리면 `514 passed, 3 skipped`로 초록불이고, 변수를 주면 통합 테스트 2건만 FAILED가 된다. 확인 후 되돌렸다.
- 변수는 있는데 접속 불가(`redis://localhost:6399/0`): skip이 아니라 3건 FAILED.
- 실패 메시지에 접속 URL 값을 넣지 않는다. 이 레포는 public이라 Actions 로그가 공개인데 `redis://user:pass@host` 형태면 credential이 그대로 나간다. `redis://default:sup3rs3cr3t@localhost:1/0`으로 실패시켜 비밀번호가 출력에 없고 `Error 22 connecting to localhost:1`은 남는 것을 확인했다.
- `ci.yml`을 YAML 파서로 읽어 `services.redis`와 스텝 수준 `env`가 의도한 구조로 들어갔는지 확인했다.

## 🔗 관련 이슈

- Closes #267
- 관련: #248, #251
