### PR TITLE
refactor: state_store·pending_order_store의 duck typing을 Protocol로 좁힌다 (#271)

### DIFF
--- a/backend/redis_state.py
+++ b/backend/redis_state.py
@@ -196,8 +196,11 @@ class TelegramPollerState:
 class TelegramPollerStore(Protocol):
     """TelegramCommandPoller가 상태 저장소에 요구하는 전부 (#271).
 
-    구조적 타이핑이라 구현체가 이 클래스를 상속할 필요는 없다. 프로덕션
-    (RedisTelegramPollerStore)·인메모리·테스트 더블이 주입 지점에서 함께 검증된다.
+    구조적 타이핑이라 구현체가 이 클래스를 상속할 필요는 없다. 대신 적합성은 타입 체커를
+    돌려야 드러나는데, 이 레포의 CI에는 타입 체크 잡이 없다 — 여기서 어긋난 스토어가
+    주입돼도 폴러의 except Exception이 TypeError를 삼켜 "영속화 없음"으로 조용히 degrade한다
+    (#248이 닫으려던 중복 실행 창이 그대로 열린다). 그래서 이름·인자 모양만큼은
+    test_redis_state.test_store_matches_protocol_shape가 CI에서 고정한다.
 
     두 값을 한 덩어리(TelegramPollerState)로 주고받는 이유는 그 dataclass의 독스트링에 있다.
     """
@@ -372,6 +375,9 @@ class PendingOrderStore(Protocol):
 
     InMemoryPendingOrderStore의 동기 dict 인터페이스(__getitem__ 등)도 계약이 아니다.
     프로덕션 구현이 제공할 수 없는 테스트 편의이므로 그 클래스에만 있다.
+
+    적합성 검증은 TelegramPollerStore와 같다 — 정적으로는 체커가 있어야 보이고, CI에서는
+    test_redis_state.test_store_matches_protocol_shape가 이름·인자 모양을 고정한다.
     """
 
     async def get(self, chat_id: str) -> "PendingOrder | None": ...
@@ -423,8 +429,8 @@ class InMemoryPendingOrderStore:
         self._store[chat_id] = order
         return True
 
-    # 동기 dict 인터페이스: 기존 테스트의 handler.pending_orders[...] 접근용
-    def __getitem__(self, chat_id: str) -> Any:
+    # 동기 dict 인터페이스: 테스트의 store[...] 접근용
+    def __getitem__(self, chat_id: str) -> "PendingOrder":
         return self._store[chat_id]
 
     def __contains__(self, chat_id: object) -> bool:

--- a/backend/redis_state.py
+++ b/backend/redis_state.py
@@ -5,8 +5,13 @@ import re
 from contextlib import asynccontextmanager
 from dataclasses import asdict, dataclass
 from datetime import datetime
-from typing import Any, AsyncIterator
+from typing import TYPE_CHECKING, Any, AsyncIterator, Protocol
 from uuid import uuid4
+
+if TYPE_CHECKING:
+    # 런타임 import는 _deserialize 안에 그대로 둔다. 여기서 끌어오는 것은 타입뿐이라
+    # import 시점을 바꾸지 않는다.
+    from .trading_orders import PendingOrder
 
 logger = logging.getLogger(__name__)
 
@@ -188,6 +193,20 @@ class TelegramPollerState:
     handled_ahead: frozenset[int] = frozenset()
 
 
+class TelegramPollerStore(Protocol):
+    """TelegramCommandPoller가 상태 저장소에 요구하는 전부 (#271).
+
+    구조적 타이핑이라 구현체가 이 클래스를 상속할 필요는 없다. 프로덕션
+    (RedisTelegramPollerStore)·인메모리·테스트 더블이 주입 지점에서 함께 검증된다.
+
+    두 값을 한 덩어리(TelegramPollerState)로 주고받는 이유는 그 dataclass의 독스트링에 있다.
+    """
+
+    async def load(self) -> TelegramPollerState: ...
+
+    async def save(self, state: TelegramPollerState) -> None: ...
+
+
 class InMemoryTelegramPollerStore:
     """테스트 전용 인메모리 폴러 상태 저장소.
 
@@ -344,25 +363,47 @@ class RedisTelegramPollerStore:
         )
 
 
+class PendingOrderStore(Protocol):
+    """TelegramCommandHandler가 pending_order 저장소에 요구하는 전부 (#271).
+
+    set()은 일부러 뺐다. 핸들러는 경합하는 /buy의 승자를 하나로 고정해야 해서 항상
+    set_if_absent를 쓴다 — 여기에 set을 올리면 무조건 덮어쓰는 경로가 계약이 되어,
+    그 구분이 흐려진다. 두 구현체는 여전히 set을 제공하고 저장소 단위 테스트가 쓴다.
+
+    InMemoryPendingOrderStore의 동기 dict 인터페이스(__getitem__ 등)도 계약이 아니다.
+    프로덕션 구현이 제공할 수 없는 테스트 편의이므로 그 클래스에만 있다.
+    """
+
+    async def get(self, chat_id: str) -> "PendingOrder | None": ...
+
+    async def claim(self, chat_id: str) -> "PendingOrder | None": ...
+
+    async def set_if_absent(self, chat_id: str, order: "PendingOrder") -> bool: ...
+
+    async def delete(self, chat_id: str) -> None: ...
+
+    async def has(self, chat_id: str) -> bool: ...
+
+
 class InMemoryPendingOrderStore:
     """테스트 전용 인메모리 pending_order 저장소.
 
-    async 메서드(get/set/delete/has)와 동기 dict 인터페이스(__getitem__,
-    __contains__, __eq__)를 동시에 제공해, 기존 테스트 코드의
-    ``handler.pending_orders['123']``, ``handler.pending_orders == {}`` 등을
-    수정 없이 유지할 수 있게 한다.
+    PendingOrderStore를 만족하는 async 메서드에 더해 동기 dict 인터페이스(__getitem__,
+    __contains__, __eq__)를 제공해, 테스트가 ``store['123']``·``store == {}``로
+    상태를 단언할 수 있게 한다. 이쪽은 프로토콜 밖이라 이 클래스에만 있고,
+    핸들러를 거쳐 쓰는 테스트는 test_telegram_commands._orders로 내려온다 (#271).
 
     멀티워커 프로덕션 환경에서는 사용하지 말 것.
     프로세스 간 격리로 이슈 #63의 주문 유실 버그가 재현된다.
     """
 
     def __init__(self) -> None:
-        self._store: dict[str, Any] = {}
+        self._store: dict[str, "PendingOrder"] = {}
 
-    async def get(self, chat_id: str) -> Any:
+    async def get(self, chat_id: str) -> "PendingOrder | None":
         return self._store.get(chat_id)
 
-    async def set(self, chat_id: str, order: Any) -> None:
+    async def set(self, chat_id: str, order: "PendingOrder") -> None:
         self._store[chat_id] = order
 
     async def delete(self, chat_id: str) -> None:
@@ -371,11 +412,11 @@ class InMemoryPendingOrderStore:
     async def has(self, chat_id: str) -> bool:
         return chat_id in self._store
 
-    async def claim(self, chat_id: str) -> Any:
+    async def claim(self, chat_id: str) -> "PendingOrder | None":
         """주문을 원자적으로 꺼내며 삭제한다. 재전송 update의 중복 체결을 방지한다."""
         return self._store.pop(chat_id, None)
 
-    async def set_if_absent(self, chat_id: str, order: Any) -> bool:
+    async def set_if_absent(self, chat_id: str, order: "PendingOrder") -> bool:
         """이미 대기 주문이 있으면 False. 경합하는 /buy 요청 중 승자를 하나로 고정한다."""
         if chat_id in self._store:
             return False
@@ -428,13 +469,13 @@ class RedisPendingOrderStore:
         self.ttl_sec = ttl_sec
         self._keys = keys or RedisKeys()
 
-    def _serialize(self, order: Any) -> str:
+    def _serialize(self, order: "PendingOrder") -> str:
         """PendingOrder → JSON 문자열. set/set_if_absent가 공유한다."""
         data = asdict(order)
         data["created_at"] = data["created_at"].isoformat()
         return json.dumps(data, ensure_ascii=False)
 
-    def _deserialize(self, raw: str | bytes) -> Any:
+    def _deserialize(self, raw: str | bytes) -> "PendingOrder":
         """raw JSON → PendingOrder. ValueError/TypeError/KeyError는 호출자가 처리한다."""
         from .trading_orders import PendingOrder
 
@@ -442,7 +483,7 @@ class RedisPendingOrderStore:
         data["created_at"] = datetime.fromisoformat(data["created_at"])
         return PendingOrder(**data)
 
-    async def get(self, chat_id: str) -> Any:
+    async def get(self, chat_id: str) -> "PendingOrder | None":
         """PendingOrder를 반환하거나, 없으면(TTL 만료 포함) None을 반환한다.
 
         역직렬화 오류(스키마 변경·손상 키)는 해당 키를 삭제하고 None을 반환한다.
@@ -459,7 +500,7 @@ class RedisPendingOrderStore:
             await self.delete(chat_id)
             return None
 
-    async def claim(self, chat_id: str) -> Any:
+    async def claim(self, chat_id: str) -> "PendingOrder | None":
         """주문을 원자적으로 읽으며 삭제한다(GETDEL). 재전송된 Telegram update가
         같은 주문을 두 번 체결하는 것을 방지한다. 경합하는 두 호출 중 정확히 하나만
         order를 받고, 나머지는 None을 받는다.
@@ -474,7 +515,7 @@ class RedisPendingOrderStore:
             logger.error("pending_order 역직렬화 실패 (claim): %s", exc)
             return None
 
-    async def set(self, chat_id: str, order: Any) -> None:
+    async def set(self, chat_id: str, order: "PendingOrder") -> None:
         """PendingOrder를 JSON 직렬화하여 TTL과 함께 저장한다."""
         await self.redis.set(
             self._keys.pending_order(chat_id),
@@ -482,7 +523,7 @@ class RedisPendingOrderStore:
             ex=self.ttl_sec,
         )
 
-    async def set_if_absent(self, chat_id: str, order: Any) -> bool:
+    async def set_if_absent(self, chat_id: str, order: "PendingOrder") -> bool:
         """이미 대기 주문이 있으면 False. 경합하는 /buy 요청 중 승자를 하나로 고정한다.
         RedisSchedulerState.acquire_*_lock과 같은 NX 관용구를 따른다.
         """

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -384,19 +384,23 @@ def _create_trade_recorder() -> TradeRecorder:
     return TradeRecorder(lambda: Session(engine))
 
 
-def _create_pending_order_store() -> RedisPendingOrderStore:
+def _create_pending_order_store() -> PendingOrderStore:
     """프로덕션 Redis pending_order 저장소를 생성한다.
 
     단일 Redis 클라이언트 인스턴스를 생성해 커넥션 풀을 재사용한다.
     핸들러 인스턴스당 한 번만 호출되므로 클라이언트 누적 없음.
+
+    반환 타입은 구체 클래스가 아니라 Protocol이다. 유일한 호출부인 주입 지점이 계약 밖의
+    것을 집어들지 못하게 막아, 구현체 교체가 그 지점으로 번지지 않게 한다 (PR #287 리뷰).
     """
     return RedisPendingOrderStore(create_redis_client())
 
 
-def _create_poller_state_store() -> RedisTelegramPollerStore:
+def _create_poller_state_store() -> TelegramPollerStore:
     """프로덕션 폴러 상태 저장소를 생성한다 (#248).
 
-    _create_pending_order_store와 같은 이유로 클라이언트를 하나만 만들어 풀을 재사용한다.
+    _create_pending_order_store와 같은 이유로 클라이언트를 하나만 만들어 풀을 재사용하고,
+    같은 이유로 반환 타입을 Protocol로 좁힌다.
     """
     return RedisTelegramPollerStore(create_redis_client())
 

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -26,10 +26,12 @@ from .catalyst_repo import SqliteCatalystEventRepo
 from .database import engine
 from .redis_state import (
     InMemoryPendingOrderStore,
+    PendingOrderStore,
     RedisSchedulerState,
     RedisPendingOrderStore,
     RedisTelegramPollerStore,
     TelegramPollerState,
+    TelegramPollerStore,
     create_redis_client,
     redis_state,
 )
@@ -304,7 +306,7 @@ class TelegramCommandHandler:
         trade_recorder: Any | None = None,
         now_factory: Callable[[], datetime] | None = None,
         visualization_url: str = VISUALIZATION_URL,
-        pending_order_store: Any | None = None,
+        pending_order_store: PendingOrderStore | None = None,
     ):
         self.notifier = notifier
         self.state_factory = state_factory
@@ -316,16 +318,16 @@ class TelegramCommandHandler:
         self.trade_recorder = trade_recorder
         self.now_factory = now_factory or (lambda: datetime.now(KST))
         self.visualization_url = visualization_url.strip()
-        # pending_orders: 기존 테스트 코드(handler.pending_orders['123'] 등)와
-        # 호환되도록 InMemoryPendingOrderStore가 동기 dict 인터페이스를 제공한다.
         # 프로덕션에서는 TelegramCommandPoller가 RedisPendingOrderStore를 주입한다.
+        # 미주입 시의 InMemoryPendingOrderStore는 동기 dict 인터페이스도 함께 제공하지만
+        # 그건 PendingOrderStore 계약 밖이라, 여기서는 프로토콜이 보장하는 것만 쓴다.
         if pending_order_store is None:
             logger.warning(
                 "pending_order_store 미주입 — InMemoryPendingOrderStore 사용. "
                 "멀티워커 환경에서는 주문이 프로세스 간 격리된다(#63)."
             )
             pending_order_store = InMemoryPendingOrderStore()
-        self.pending_orders: Any = pending_order_store
+        self.pending_orders: PendingOrderStore = pending_order_store
         self.market_callbacks: dict[str, tuple[str, str]] = {}
 
     async def handle_update(self, update: dict[str, Any]) -> None:
@@ -1651,7 +1653,7 @@ class TelegramCommandPoller:
         *,
         notifier: TelegramNotifier = telegram_notifier,
         handler: TelegramCommandHandler | None = None,
-        state_store: Any | None = None,
+        state_store: TelegramPollerStore | None = None,
     ):
         self.notifier = notifier
         if handler is None:
@@ -1675,7 +1677,9 @@ class TelegramCommandPoller:
         # 경로를 탄다. 근거는 확률이 아니라 비용 대비다: _handled_ahead는 Telegram이 원리적으로
         # 보호해줄 수 없는 유일한 상태인데(서버는 미확정 update만 알 뿐 무엇을 이미 실행했는지
         # 모른다) 영속화 비용은 이미 쓰는 키에 필드 하나다 (PR #251 리뷰).
-        self.state_store = state_store if state_store is not None else _create_poller_state_store()
+        self.state_store: TelegramPollerStore = (
+            state_store if state_store is not None else _create_poller_state_store()
+        )
         self.offset: int | None = None
         # update_id -> 재시도 예산. 유실돼도 poison 폐기가 미뤄질 뿐 중복 실행으로 이어지지
         # 않으므로 영속화하지 않는다. 매 update 쓰기에 얹을 값이 아니다 (#248).

--- a/backend/tests/test_pending_order_store.py
+++ b/backend/tests/test_pending_order_store.py
@@ -651,6 +651,7 @@ async def test_memory_store_set_if_absent_returns_false_and_preserves_original()
     assert result is False
     # 원래 주문(A)이 B로 덮어쓰이지 않아야 한다
     stored = await store.get("123")
+    assert stored is not None
     assert stored is _ORDER_A
     assert stored.callback_token == "tok-a"
 

--- a/backend/tests/test_redis_state.py
+++ b/backend/tests/test_redis_state.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 
 import pytest
@@ -6,9 +7,14 @@ from backend.redis_state import (
     MAX_HANDLED_AHEAD,
     SIGNAL_HASH_TTL_SEC,
     TELEGRAM_POLLER_STATE_TTL_SEC,
+    InMemoryPendingOrderStore,
+    InMemoryTelegramPollerStore,
+    PendingOrderStore,
+    RedisPendingOrderStore,
     RedisSchedulerState,
     RedisTelegramPollerStore,
     TelegramPollerState,
+    TelegramPollerStore,
     signal_hash,
     normalize_signal_text,
 )
@@ -335,3 +341,60 @@ async def test_poller_state_save_is_quiet_below_warning_threshold(caplog):
         await store.save(TelegramPollerState(offset=1, handled_ahead=frozenset(range(6_700))))
 
     assert "상한의 절반을 넘었다" not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# 저장소 프로토콜 적합성 (#271)
+# ---------------------------------------------------------------------------
+
+
+def _protocol_methods(protocol) -> dict:
+    """Protocol이 선언한 메서드만 추린다 (typing이 붙이는 내부 속성 제외)."""
+    return {
+        name: member
+        for name, member in vars(protocol).items()
+        if inspect.isfunction(member) and not name.startswith("_")
+    }
+
+
+def _shape(signature: inspect.Signature) -> list:
+    """self를 뺀 (이름, 종류, 필수 여부). 애노테이션은 타입 체커의 몫이라 보지 않는다."""
+    return [
+        (name, parameter.kind, parameter.default is inspect.Parameter.empty)
+        for name, parameter in signature.parameters.items()
+        if name != "self"
+    ]
+
+
+@pytest.mark.parametrize(
+    ("protocol", "implementation"),
+    [
+        (TelegramPollerStore, RedisTelegramPollerStore),
+        (TelegramPollerStore, InMemoryTelegramPollerStore),
+        (PendingOrderStore, RedisPendingOrderStore),
+        (PendingOrderStore, InMemoryPendingOrderStore),
+    ],
+    ids=lambda obj: obj.__name__,
+)
+def test_store_matches_protocol_shape(protocol, implementation):
+    """구현체의 메서드 이름·인자 모양이 Protocol과 어긋나지 않는다 (#271).
+
+    Protocol은 정적 검사 장치인데 이 레포의 CI에는 타입 체크 잡이 없다. 어긋남이 런타임까지
+    살아남으면 두 주입 지점 모두 그것을 조용히 삼킨다 — TelegramCommandPoller의
+    _persist_state·_restore_state에 있는 except Exception이 TypeError를 로그 한 줄로
+    흘려보내고, 폴러는 "영속화 없음"으로 degrade한다. #248이 닫으려던 중복 실행 창이
+    그대로 열리는데 예외는 어디에도 오르지 않는다.
+
+    그래서 타입 체커 없이도 CI가 잡을 수 있는 만큼(이름·인자 모양)을 여기서 고정한다.
+    타입의 적합성 자체는 여전히 체커의 몫이다.
+
+    이 테스트가 잡는 mutation: 구현체의 메서드 이름 변경(save → save_state),
+    인자 추가·삭제(save(self)), 위치 인자의 키워드 전용 전환.
+    """
+    for name, declared in _protocol_methods(protocol).items():
+        actual = getattr(implementation, name, None)
+        assert actual is not None, f"{implementation.__name__}에 {name}이 없다"
+        assert inspect.iscoroutinefunction(actual), f"{name}은 async여야 한다"
+        assert _shape(inspect.signature(actual)) == _shape(inspect.signature(declared)), (
+            f"{implementation.__name__}.{name}의 인자가 {protocol.__name__}과 다르다"
+        )

--- a/backend/tests/test_redis_state.py
+++ b/backend/tests/test_redis_state.py
@@ -349,7 +349,12 @@ async def test_poller_state_save_is_quiet_below_warning_threshold(caplog):
 
 
 def _protocol_methods(protocol) -> dict:
-    """Protocol이 선언한 메서드만 추린다 (typing이 붙이는 내부 속성 제외)."""
+    """Protocol이 선언한 메서드만 추린다 (typing이 붙이는 내부 속성 제외).
+
+    isfunction은 staticmethod·classmethod를 걸러낸다. 두 Protocol 모두 인스턴스 메서드만
+    선언하고 있어 지금은 빠지는 것이 없지만, 나중에 그런 멤버가 추가되면 이 테스트가
+    실패하는 대신 조용히 검사 대상에서 빠진다. 그때 여기를 함께 고쳐야 한다 (PR #287 리뷰).
+    """
     return {
         name: member
         for name, member in vars(protocol).items()

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -44,7 +44,8 @@ def _make_poller(notifier, handler, *, state_store: TelegramPollerStore | None =
     state_store 기본값은 redis 클라이언트라, 주입하지 않으면 테스트가 실제 연결을 시도한다.
     재시작 시나리오는 같은 state_store를 두 폴러에 넘겨 재현한다.
 
-    타입을 명시해야 여기를 지나는 테스트 더블도 TelegramPollerStore로 검증된다 (#271).
+    타입을 명시해야 타입 체커를 돌릴 때 여기를 지나는 테스트 더블까지 TelegramPollerStore로
+    검증된다. CI에는 타입 체크 잡이 없어 자동으로 강제되지는 않는다 (#271).
     """
     return TelegramCommandPoller(
         notifier=notifier,

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -27,23 +27,42 @@ from backend.telegram_commands import (
     TelegramCommandHandler,
     TelegramCommandPoller,
 )
-from backend.redis_state import InMemoryTelegramPollerStore, TelegramPollerState
+from backend.redis_state import (
+    InMemoryPendingOrderStore,
+    InMemoryTelegramPollerStore,
+    TelegramPollerState,
+    TelegramPollerStore,
+)
 from backend.trading_orders import OrderExecutionResult, PendingOrder
 
 KST = ZoneInfo("Asia/Seoul")
 
 
-def _make_poller(notifier, handler, *, state_store=None):
+def _make_poller(notifier, handler, *, state_store: TelegramPollerStore | None = None):
     """폴러 테스트용 생성기 — 상태 저장소를 인메모리로 고정한다 (#248).
 
     state_store 기본값은 redis 클라이언트라, 주입하지 않으면 테스트가 실제 연결을 시도한다.
     재시작 시나리오는 같은 state_store를 두 폴러에 넘겨 재현한다.
+
+    타입을 명시해야 여기를 지나는 테스트 더블도 TelegramPollerStore로 검증된다 (#271).
     """
     return TelegramCommandPoller(
         notifier=notifier,
         handler=handler,
         state_store=state_store if state_store is not None else InMemoryTelegramPollerStore(),
     )
+
+
+def _orders(handler: TelegramCommandHandler) -> InMemoryPendingOrderStore:
+    """미주입 기본값인 인메모리 저장소의 동기 dict 인터페이스로 내려간다 (#271).
+
+    핸들러가 약속하는 것은 PendingOrderStore(async 5종)까지다. 아래 단언들이 쓰는
+    ``[...]``·``in``·``== {}``는 인메모리 더블에만 있는 테스트 편의라, 그 사실을
+    타입으로 드러내고 다른 저장소가 주입되면 여기서 끊는다.
+    """
+    store = handler.pending_orders
+    assert isinstance(store, InMemoryPendingOrderStore)
+    return store
 
 
 class FakeState:
@@ -894,13 +913,13 @@ async def test_buy_command_creates_pending_order_and_prompts_confirmation():
                 {
                     "text": "✅ 확정",
                     "callback_data": (
-                        f"order:confirm:{handler.pending_orders['123'].callback_token}"
+                        f"order:confirm:{_orders(handler)['123'].callback_token}"
                     ),
                 },
                 {
                     "text": "❌ 취소",
                     "callback_data": (
-                        f"order:cancel:{handler.pending_orders['123'].callback_token}"
+                        f"order:cancel:{_orders(handler)['123'].callback_token}"
                     ),
                 },
             ]
@@ -908,12 +927,12 @@ async def test_buy_command_creates_pending_order_and_prompts_confirmation():
     }
     assert "현재가: 현재가" not in notifier.messages[-1]
     assert "잔고: 주문가능금액" not in notifier.messages[-1]
-    assert handler.pending_orders["123"].stock_name == "삼성전자"
-    assert handler.pending_orders["123"].stock_code == "005930"
-    assert handler.pending_orders["123"].side == "BUY"
-    assert handler.pending_orders["123"].quantity == 10
-    assert handler.pending_orders["123"].price == 75000
-    assert handler.pending_orders["123"].order_type == "LIMIT"
+    assert _orders(handler)["123"].stock_name == "삼성전자"
+    assert _orders(handler)["123"].stock_code == "005930"
+    assert _orders(handler)["123"].side == "BUY"
+    assert _orders(handler)["123"].quantity == 10
+    assert _orders(handler)["123"].price == 75000
+    assert _orders(handler)["123"].order_type == "LIMIT"
 
 
 @pytest.mark.asyncio
@@ -979,12 +998,12 @@ async def test_buy_command_without_price_creates_market_order_and_prompts_confir
     assert "주문금액:" not in notifier.messages[-1]
     assert "/confirm" in notifier.messages[-1]
     assert "/cancel" in notifier.messages[-1]
-    assert handler.pending_orders["123"].stock_name == "삼성전자"
-    assert handler.pending_orders["123"].stock_code == "005930"
-    assert handler.pending_orders["123"].side == "BUY"
-    assert handler.pending_orders["123"].quantity == 10
-    assert handler.pending_orders["123"].price == 0
-    assert handler.pending_orders["123"].order_type == "MARKET"
+    assert _orders(handler)["123"].stock_name == "삼성전자"
+    assert _orders(handler)["123"].stock_code == "005930"
+    assert _orders(handler)["123"].side == "BUY"
+    assert _orders(handler)["123"].quantity == 10
+    assert _orders(handler)["123"].price == 0
+    assert _orders(handler)["123"].order_type == "MARKET"
 
 
 @pytest.mark.asyncio
@@ -1032,23 +1051,23 @@ async def test_natural_language_market_buy_creates_pending_order_without_nat():
                 {
                     "text": "✅ 확정",
                     "callback_data": (
-                        f"order:confirm:{handler.pending_orders['123'].callback_token}"
+                        f"order:confirm:{_orders(handler)['123'].callback_token}"
                     ),
                 },
                 {
                     "text": "❌ 취소",
                     "callback_data": (
-                        f"order:cancel:{handler.pending_orders['123'].callback_token}"
+                        f"order:cancel:{_orders(handler)['123'].callback_token}"
                     ),
                 },
             ]
         ]
     }
-    assert handler.pending_orders["123"].stock_name == "삼성전자"
-    assert handler.pending_orders["123"].side == "BUY"
-    assert handler.pending_orders["123"].quantity == 1
-    assert handler.pending_orders["123"].price == 0
-    assert handler.pending_orders["123"].order_type == "MARKET"
+    assert _orders(handler)["123"].stock_name == "삼성전자"
+    assert _orders(handler)["123"].side == "BUY"
+    assert _orders(handler)["123"].quantity == 1
+    assert _orders(handler)["123"].price == 0
+    assert _orders(handler)["123"].order_type == "MARKET"
 
 
 @pytest.mark.asyncio
@@ -1091,11 +1110,11 @@ async def test_natural_language_limit_sell_creates_pending_order_without_nat():
     assert "NAVER 매도 주문 확인" in notifier.messages[-1]
     assert "주문유형: 지정가" in notifier.messages[-1]
     assert "지정가: 200,000원" in notifier.messages[-1]
-    assert handler.pending_orders["123"].stock_name == "NAVER"
-    assert handler.pending_orders["123"].side == "SELL"
-    assert handler.pending_orders["123"].quantity == 2
-    assert handler.pending_orders["123"].price == 200000
-    assert handler.pending_orders["123"].order_type == "LIMIT"
+    assert _orders(handler)["123"].stock_name == "NAVER"
+    assert _orders(handler)["123"].side == "SELL"
+    assert _orders(handler)["123"].quantity == 2
+    assert _orders(handler)["123"].price == 200000
+    assert _orders(handler)["123"].order_type == "LIMIT"
 
 
 @pytest.mark.asyncio
@@ -1121,7 +1140,7 @@ async def test_ambiguous_natural_language_order_replies_with_usage_without_nat()
     assert notifier.messages == [
         "자연어 주문을 해석할 수 없습니다. /buy 또는 /sell 형식으로 입력하세요."
     ]
-    assert handler.pending_orders == {}
+    assert _orders(handler) == {}
 
 
 @pytest.mark.asyncio
@@ -1155,10 +1174,10 @@ async def test_buy_command_accepts_stock_name_with_spaces():
         {"stock_name": "LG 화학"},
     )
     assert "LG 화학 매수 주문 확인" in notifier.messages[-1]
-    assert handler.pending_orders["123"].stock_name == "LG 화학"
-    assert handler.pending_orders["123"].quantity == 10
-    assert handler.pending_orders["123"].price == 75000
-    assert handler.pending_orders["123"].order_type == "LIMIT"
+    assert _orders(handler)["123"].stock_name == "LG 화학"
+    assert _orders(handler)["123"].quantity == 10
+    assert _orders(handler)["123"].price == 75000
+    assert _orders(handler)["123"].order_type == "LIMIT"
 
 
 @pytest.mark.asyncio
@@ -1186,7 +1205,7 @@ async def test_buy_command_rejects_unresolved_stock_code_before_quote_and_balanc
         (TRADING_MCP_PARAMS, "resolve_stock_code", {"stock_name": "알수없는종목"})
     ]
     assert notifier.messages[-1] == "주문 준비 실패: 종목코드를 확인할 수 없습니다."
-    assert handler.pending_orders == {}
+    assert _orders(handler) == {}
 
 
 def test_extract_stock_code_numeric():
@@ -1308,7 +1327,7 @@ async def test_order_command_rejects_unorderable_stock_code_before_quote_and_bal
     assert "주문을 지원하지 않습니다" in message
     # 왜 안 되는지를 설명하는 문장이 이 수정의 핵심이므로 함께 고정한다.
     assert "ETN·펀드 등 영숫자 종목코드는 아직 주문 대상이 아닙니다." in message
-    assert handler.pending_orders == {}
+    assert _orders(handler) == {}
 
 
 @pytest.mark.asyncio
@@ -1335,7 +1354,7 @@ async def test_cancel_removes_pending_order():
     await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/cancel"}})
 
     assert "대기 주문을 취소했습니다." in notifier.messages[-1]
-    assert handler.pending_orders == {}
+    assert _orders(handler) == {}
 
 
 @pytest.mark.asyncio
@@ -1372,7 +1391,7 @@ async def test_cancel_button_removes_pending_order():
 
     assert notifier.callback_answers == [("callback-1", None)]
     assert "대기 주문을 취소했습니다." in notifier.messages[-1]
-    assert handler.pending_orders == {}
+    assert _orders(handler) == {}
 
 
 @pytest.mark.asyncio
@@ -1409,8 +1428,8 @@ async def test_buy_with_stock_code_resolves_name_and_shows_no_warning():
         {"message": {"chat": {"id": 123}, "text": "/buy 005930 10"}}
     )
 
-    assert handler.pending_orders["123"].stock_name == "삼성전자"
-    assert handler.pending_orders["123"].stock_code == "005930"
+    assert _orders(handler)["123"].stock_name == "삼성전자"
+    assert _orders(handler)["123"].stock_code == "005930"
     assert "삼성전자 매수 주문 확인" in notifier.messages[-1]
     assert UNRESOLVED_STOCK_WARNING not in notifier.messages[-1]
 
@@ -1449,7 +1468,7 @@ async def test_buy_with_unresolved_echo_is_rejected(code):
         {"message": {"chat": {"id": 123}, "text": f"/buy {code} 10"}}
     )
 
-    assert handler.pending_orders == {}
+    assert _orders(handler) == {}
     assert "종목마스터에 없는 종목입니다" in notifier.messages[-1]
     assert code in notifier.messages[-1]
 
@@ -1515,7 +1534,7 @@ async def test_confirm_executes_gateway_and_records_trade():
     assert recorder.results[0].stock_code == "005930"
     assert notifier.actions == ["typing", "typing"]
     assert "주문 완료" in notifier.messages[-1]
-    assert handler.pending_orders == {}
+    assert _orders(handler) == {}
 
 
 @pytest.mark.asyncio
@@ -1558,7 +1577,7 @@ async def test_confirm_button_executes_gateway_and_records_trade():
     assert len(gateway.orders) == 1
     assert len(recorder.results) == 1
     assert "주문 완료" in notifier.messages[-1]
-    assert handler.pending_orders == {}
+    assert _orders(handler) == {}
 
 
 @pytest.mark.asyncio
@@ -1598,7 +1617,7 @@ async def test_tokenless_old_confirm_button_does_not_execute_current_pending_ord
         ("old-callback", "이전 주문 버튼입니다. 최신 주문 메시지에서 다시 선택하세요.")
     ]
     assert gateway.orders == []
-    assert "123" in handler.pending_orders
+    assert "123" in _orders(handler)
 
 
 @pytest.mark.asyncio
@@ -1633,7 +1652,7 @@ async def test_confirm_gateway_success_recorder_failure_clears_pending_order():
     assert len(recorder.results) == 1
     assert notifier.messages[-2] == "주문 완료: 주문 접수\n거래 이력 기록 실패: db commit failed"
     assert notifier.messages[-1] == "확정할 대기 주문이 없습니다."
-    assert handler.pending_orders == {}
+    assert _orders(handler) == {}
 
 
 @pytest.mark.asyncio
@@ -1660,7 +1679,7 @@ async def test_confirm_without_gateway_keeps_pending_order():
     await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/confirm"}})
 
     assert notifier.messages[-1] == "주문 실행 설정이 준비되지 않았습니다."
-    assert "123" in handler.pending_orders
+    assert "123" in _orders(handler)
 
 
 @pytest.mark.asyncio
@@ -1695,7 +1714,7 @@ async def test_confirm_gateway_ambiguous_failure_clears_pending_order_and_blocks
         "중복 주문 방지를 위해 대기 주문을 제거했습니다."
     )
     assert notifier.messages[-1] == "확정할 대기 주문이 없습니다."
-    assert handler.pending_orders == {}
+    assert _orders(handler) == {}
 
 
 @pytest.mark.asyncio
@@ -1731,7 +1750,7 @@ async def test_confirm_real_order_guard_failure_keeps_pending_order():
     assert notifier.messages[-1] == (
         "주문 실패: 실계좌 주문은 KIS_REAL_ORDER_ENABLED=true 설정이 필요합니다."
     )
-    assert "123" in handler.pending_orders
+    assert "123" in _orders(handler)
 
 
 @pytest.mark.asyncio
@@ -1754,7 +1773,7 @@ async def test_sell_command_rejects_market_closed():
     )
 
     assert notifier.messages == ["주문 불가: 현재 장 운영 시간이 아닙니다. (평일 09:00~15:30)"]
-    assert handler.pending_orders == {}
+    assert _orders(handler) == {}
     assert calls == []
 
 
@@ -1800,7 +1819,7 @@ async def test_sell_command_rejects_duplicate_pending_order():
         notifier.messages[-1]
         == "이미 대기 중인 주문이 있습니다. /confirm 또는 /cancel로 먼저 처리하세요."
     )
-    assert handler.pending_orders["123"].side == "BUY"
+    assert _orders(handler)["123"].side == "BUY"
 
 
 @pytest.mark.asyncio
@@ -2718,7 +2737,7 @@ async def test_poller_persists_state_after_each_update(monkeypatch):
             return None
 
     class RecordingStore(InMemoryTelegramPollerStore):
-        async def save(self, state):
+        async def save(self, state: TelegramPollerState) -> None:
             saved.append(state.offset)
             await super().save(state)
 
@@ -2756,10 +2775,10 @@ async def test_poller_keeps_polling_when_state_store_fails(monkeypatch, caplog):
             handled.append(update["update_id"])
 
     class BrokenStore:
-        async def load(self):
+        async def load(self) -> TelegramPollerState:
             raise RuntimeError("redis unavailable")
 
-        async def save(self, state):
+        async def save(self, state: TelegramPollerState) -> None:
             raise RuntimeError("redis unavailable")
 
     poller = _make_poller(notifier, handler=NoopHandler(), state_store=BrokenStore())
@@ -3261,7 +3280,7 @@ async def test_buy_prompt_send_failure_does_not_ask_poller_to_retry(monkeypatch)
     assert all("삼성전자 매수 주문 확인" in message for message in notifier.messages)
     # 프롬프트가 끝내 안 나갔으므로 대기 주문을 남기지 않는다. 남기면 사용자는 존재를
     # 모르는 주문 때문에 다음 /buy가 "이미 대기 중"으로 막힌다 (PR #253 2차 리뷰).
-    assert handler.pending_orders == {}
+    assert _orders(handler) == {}
 
 
 @pytest.mark.asyncio
@@ -3312,7 +3331,7 @@ async def test_confirm_result_send_failure_does_not_ask_poller_to_retry(monkeypa
     assert len(gateway.orders) == 1
     assert sleeps == list(telegram_commands.SETTLED_SEND_RETRY_BACKOFF_SECONDS)
     assert notifier.messages == ["주문 완료: 주문 접수"] * (len(sleeps) + 1)
-    assert handler.pending_orders == {}
+    assert _orders(handler) == {}
 
 
 @pytest.mark.asyncio
@@ -3348,7 +3367,7 @@ async def test_confirm_unclear_result_send_failure_does_not_ask_poller_to_retry(
         for message in notifier.messages
     )
     # 403과 달리 복원하지 않는다 — 중복 주문 방지가 우선이다.
-    assert handler.pending_orders == {}
+    assert _orders(handler) == {}
 
 
 @pytest.mark.asyncio
@@ -3374,7 +3393,7 @@ async def test_confirm_403_keeps_update_retryable_when_order_is_restored():
 
     # 인플레이스 재시도 없이 한 번만 시도하고 폴러에 넘긴다.
     assert notifier.messages == ["주문 실패: 실계좌 가드"]
-    assert handler.pending_orders["123"].stock_code == "005930"
+    assert _orders(handler)["123"].stock_code == "005930"
 
 
 @pytest.mark.asyncio
@@ -3400,7 +3419,7 @@ async def test_cancel_confirmation_send_failure_does_not_ask_poller_to_retry(mon
     await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/cancel"}})
 
     assert notifier.messages == ["대기 주문을 취소했습니다."] * (len(sleeps) + 1)
-    assert handler.pending_orders == {}
+    assert _orders(handler) == {}
 
 
 @pytest.mark.asyncio
@@ -3461,7 +3480,7 @@ async def test_order_prepare_does_not_convert_send_failure_into_user_message():
         )
 
     assert notifier.messages == ["주문 준비 실패: 종목코드를 확인할 수 없습니다."]
-    assert "123" not in handler.pending_orders
+    assert "123" not in _orders(handler)
 
 
 @pytest.mark.asyncio
@@ -3564,7 +3583,7 @@ async def test_pending_order_is_stamped_at_store_time_not_command_time():
         {"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 10"}}
     )
 
-    order = handler.pending_orders["123"]
+    order = _orders(handler)["123"]
     # 명령 수신 시각(10:00:00)이었다면 만료가 10:01:00 — 이미 지난 뒤다.
     assert order.created_at > datetime(2026, 5, 20, 10, 0, 0, tzinfo=KST)
     expires_at = order.created_at + telegram_commands.ORDER_EXPIRES_AFTER
@@ -3800,10 +3819,11 @@ async def test_poller_keeps_polling_when_state_store_hangs(monkeypatch, caplog):
             handled.append(update["update_id"])
 
     class HangingStore:
-        async def load(self):
+        async def load(self) -> TelegramPollerState:
             await asyncio.Event().wait()  # 영원히 깨어나지 않는다
+            raise AssertionError("도달하지 않는다")  # 반환 타입을 지키기 위한 종결
 
-        async def save(self, state):
+        async def save(self, state: TelegramPollerState) -> None:
             await asyncio.Event().wait()
 
     monkeypatch.setattr(telegram_commands, "STATE_STORE_TIMEOUT_SECONDS", 0.01)


### PR DESCRIPTION
## 📝 개요

주문·폴러 상태 저장소의 주입 지점 두 곳이 `Any`라 어떤 객체든 통과한다. 저장소가 실제로 요구받는 것만 담은 Protocol로 좁히고, 타입 체커가 없는 이 레포에서도 어긋남이 CI에 걸리게 한다.

- 범위 밖: 폴러가 저장소 예외를 삼키는 fail-open 자체는 그대로다. 어긋남을 감지하는 쪽으로만 대응했다.
- 범위 밖: 테스트 함수 안의 지역 클래스로 만든 더블은 import가 안 돼 적합성 테스트 대상이 아니다. 정적 검사에서만 검증된다.
- 후속: CI 타입 체크 잡 도입은 기존 오류 271건의 처리 방침이 먼저라 별도 이슈로 등록하겠다.

## 🔍 발견된 문제

1. 두 주입 지점이 `Any`여서 저장소 구현체의 시그니처가 어긋나도 그 코드 경로가 실행될 때까지 드러나지 않는다. 각 인터페이스에 구현체가 셋 이상(프로덕션·인메모리·테스트 더블)이라 어긋날 여지가 넓다.
2. 어긋난 저장소가 주입되면 폴러는 예외 대신 로그 한 줄만 남기고 "영속화 없음"으로 degrade한다. #248이 닫은 중복 실행 창이 조용히 다시 열린다.
3. Protocol을 선언하는 것만으로는 이 레포에서 아무것도 검증되지 않는다. CI는 pytest·npm·hadolint·nginx만 돌리고 dev 의존성도 pytest 둘뿐이라 타입 체커가 아예 없다.

## 🔧 문제 해결 방법

1. 폴러 상태 저장소와 주문 저장소가 요구받는 메서드만 담은 Protocol 두 개를 정의하고, 주입 파라미터와 보관 속성의 타입을 함께 좁혔다. 구조적 타이핑이라 구현체는 상속하지 않는다.
2. 계약을 실제 사용면에 맞췄다. 핸들러가 쓰지 않는 덮어쓰기 저장(`set`)과 인메모리 구현에만 있는 동기 dict 인터페이스는 계약 밖에 두고, 후자를 쓰던 테스트는 인메모리 구현으로 명시적으로 내려가게 바꿨다.
3. 타입 체커 없이도 도는 적합성 테스트를 추가해 네 구현체의 메서드 이름·인자 모양을 CI에서 고정했다. 타입 자체의 적합성은 여전히 체커의 몫이며 그 경계를 독스트링에 적었다.

## ✅ 검증

- pyright(로컬, backend/.venv 3.13.13) 변경 전후 파일별 오류 수 동일: `redis_state` 0, `test_redis_state` 0, `telegram_commands` 5, `test_telegram_commands` 154, `test_pending_order_store` 9. 전부 기존 부채이고 이 브랜치가 늘린 오류는 0이다.
- Protocol이 실제로 무는지 정적으로 3방향 확인: 프로덕션 구현의 메서드명 변경 → 폴러의 대입에서 오류, 인메모리 구현의 인자 타입 변경 → 핸들러 대입과 테스트 주입 3곳에서 오류, 테스트 더블의 반환 타입 변경 → 헬퍼 인자에서 오류.
- 새 적합성 테스트는 수정을 되돌리면 실패한다(각 1 failed): `save` → `save_state`, `save(self)`로 인자 삭제, `set_if_absent`의 `order` 키워드 전용화, `claim` → `claimed`.

## 🔗 관련 이슈

- Closes #271
