### PR TITLE
refactor: 봇 토큰 리댁션을 로거 allowlist에서 발생 지점 차단으로 전환 (#257)

### DIFF
--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -1978,7 +1978,11 @@ class TelegramCommandPoller:
         # 아래 run()의 "polling failed" 로그로 흘러간다 — 실제로 그랬다 (PR #253 2차 리뷰).
         # call_telegram_api가 URL 없는 TelegramApiError로 바꿔 던진다 (#257).
         body = await call_telegram_api(
-            self.notifier.bot_token, "getUpdates", payload=payload, timeout=30.0
+            self.notifier.bot_token,
+            "getUpdates",
+            payload=payload,
+            timeout=30.0,
+            expect_body=True,
         )
         if body.get("ok") is not True:
             return []

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -37,7 +37,7 @@ from .watchlist_repo import SqliteWatchlistRepo
 from .telegram_notifier import (
     TELEGRAM_ALERT_MODES,
     TelegramNotifier,
-    call_telegram_api,
+    fetch_telegram_api,
     telegram_notifier,
 )
 from .timeutil import KST
@@ -1976,13 +1976,9 @@ class TelegramCommandPoller:
 
         # URL을 직접 만들지 않는다. 여기서 만들면 raise_for_status의 예외에 토큰이 실려
         # 아래 run()의 "polling failed" 로그로 흘러간다 — 실제로 그랬다 (PR #253 2차 리뷰).
-        # call_telegram_api가 URL 없는 TelegramApiError로 바꿔 던진다 (#257).
-        body = await call_telegram_api(
-            self.notifier.bot_token,
-            "getUpdates",
-            payload=payload,
-            timeout=30.0,
-            expect_body=True,
+        # fetch_telegram_api가 URL 없는 TelegramApiError로 바꿔 던진다 (#257).
+        body = await fetch_telegram_api(
+            self.notifier.bot_token, "getUpdates", payload=payload, timeout=30.0
         )
         if body.get("ok") is not True:
             return []

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -10,7 +10,6 @@ from datetime import datetime, timedelta
 from typing import Any, Callable
 from urllib.parse import quote as _url_quote
 
-import httpx
 from fastapi import HTTPException
 from sqlmodel import Session
 
@@ -35,7 +34,12 @@ from .redis_state import (
 )
 from .services import llm_chat, run_mcp_tool
 from .watchlist_repo import SqliteWatchlistRepo
-from .telegram_notifier import TELEGRAM_ALERT_MODES, TelegramNotifier, telegram_notifier
+from .telegram_notifier import (
+    TELEGRAM_ALERT_MODES,
+    TelegramNotifier,
+    call_telegram_api,
+    telegram_notifier,
+)
 from .timeutil import KST
 from .trading_orders import (
     McpTradingOrderGateway,
@@ -1966,15 +1970,16 @@ class TelegramCommandPoller:
                 logger.error("Telegram bot command menu setup failed: %s", exc)
 
     async def _get_updates(self) -> list[dict[str, Any]]:
-        url = f"https://api.telegram.org/bot{self.notifier.bot_token}/getUpdates"
         payload: dict[str, Any] = {"timeout": 25, "limit": GET_UPDATES_LIMIT}
         if self.offset is not None:
             payload["offset"] = self.offset
 
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.post(url, json=payload)
-            response.raise_for_status()
-            body = response.json()
+        # URL을 직접 만들지 않는다. 여기서 만들면 raise_for_status의 예외에 토큰이 실려
+        # 아래 run()의 "polling failed" 로그로 흘러간다 — 실제로 그랬다 (PR #253 2차 리뷰).
+        # call_telegram_api가 URL 없는 TelegramApiError로 바꿔 던진다 (#257).
+        body = await call_telegram_api(
+            self.notifier.bot_token, "getUpdates", payload=payload, timeout=30.0
+        )
         if body.get("ok") is not True:
             return []
         return body.get("result") or []

--- a/backend/telegram_notifier.py
+++ b/backend/telegram_notifier.py
@@ -18,18 +18,107 @@ def _redact_telegram_bot_token(value: str) -> str:
     return _TELEGRAM_BOT_URL_RE.sub(r"\1<redacted>", value)
 
 
+class TelegramApiError(Exception):
+    """텔레그램 API 호출 실패. str()에 요청 URL이 — 따라서 봇 토큰이 — 들어가지 않는다 (#257).
+
+    httpx가 만드는 예외, 특히 raise_for_status의 HTTPStatusError는 메시지에 요청 URL을
+    그대로 담는다. 텔레그램 URL은 경로에 봇 토큰이 있으므로 그 예외를 호출부까지 올려
+    보내면 "이 예외를 %s로 찍는 모든 로거"에 리댁션을 걸어야 한다. 그 로거 이름 목록은
+    두 번 뚫렸다 (PR #253 1차 리뷰: 이 모듈, 2차 리뷰: telegram_commands 폴러).
+
+    발생 지점에서 URL 없는 예외로 바꿔 던지면 목록을 유지할 이유 자체가 없어진다.
+    대신 httpx 예외 타입이 소비자에게 도달하지 않으므로, 429 판정에 필요한
+    status_code와 본문은 이 예외가 직접 들고 다닌다.
+    """
+
+    def __init__(
+        self,
+        method: str,
+        *,
+        status_code: int | None = None,
+        body: dict[str, Any] | None = None,
+        reason: str = "",
+    ) -> None:
+        self.method = method
+        self.status_code = status_code
+        self.body = body
+
+        # 텔레그램은 실패 본문에 사람이 읽을 수 있는 description을 준다
+        # ("Too Many Requests: retry after 42"). URL이 빠진 만큼 이쪽을 남겨야
+        # 진단 정보가 오히려 줄지 않는다.
+        description = (body or {}).get("description")
+        if isinstance(description, str) and description.strip():
+            reason = description.strip()
+
+        details = []
+        if status_code is not None:
+            details.append(f"HTTP {status_code}")
+        if reason:
+            # reason은 httpx 예외 메시지에서 오기도 한다. UnsupportedProtocol처럼 URL을
+            # 담는 타입이 있어 여기서 한 번 더 거른다 — 이 클래스의 계약은 "str()에
+            # 토큰 없음"이고, 그 계약이 리댁션 목록을 대신한다.
+            details.append(_redact_telegram_bot_token(reason))
+        super().__init__(
+            f"telegram {method} failed: {', '.join(details) or 'unknown error'}"
+        )
+
+
+def _response_body(response: httpx.Response) -> dict[str, Any] | None:
+    try:
+        body = response.json()
+    except Exception:
+        return None
+    return body if isinstance(body, dict) else None
+
+
+async def call_telegram_api(
+    bot_token: str,
+    method: str,
+    *,
+    payload: dict[str, Any] | None = None,
+    timeout: float = 10.0,
+) -> dict[str, Any]:
+    """텔레그램 API를 한 번 호출하고 응답 본문을 돌려준다.
+
+    봇 토큰이 URL에 실리는 지점이 이 함수 하나뿐이고, 여기서 나가는 실패는 전부
+    TelegramApiError다. httpx 예외는 이 경계를 넘지 않는다 (#257).
+    """
+    url = f"https://api.telegram.org/bot{bot_token}/{method}"
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            if payload is None:
+                response = await client.post(url)
+            else:
+                response = await client.post(url, json=payload)
+            response.raise_for_status()
+            body = response.json()
+    except httpx.HTTPStatusError as exc:
+        raise TelegramApiError(
+            method,
+            status_code=exc.response.status_code,
+            body=_response_body(exc.response),
+            reason=exc.response.reason_phrase,
+        ) from None
+    except Exception as exc:
+        # 네트워크 오류, 본문 파싱 실패 등. from None으로 예외 체인을 끊는다 —
+        # 원본 메시지에 URL이 들어 있을 수 있고, 체인이 남으면 exc_info 로깅이나
+        # 처리되지 않은 트레이스백이 그 원본을 그대로 찍는다.
+        raise TelegramApiError(method, reason=f"{type(exc).__name__}: {exc}") from None
+    return body if isinstance(body, dict) else {}
+
+
 def _retry_after_seconds(exc: Exception) -> int | None:
     """429 응답의 parameters.retry_after. 429가 아니거나 본문이 없으면 None.
 
     send_text가 bool만 돌려주는 탓에 호출부는 이 값을 볼 수 없다. 최소한 로그에는
     남겨 두어야 재시도 간격 가정이 실제 ban 길이와 맞는지 판단할 수 있다.
     """
-    if not isinstance(exc, httpx.HTTPStatusError) or exc.response.status_code != 429:
+    if not isinstance(exc, TelegramApiError) or exc.status_code != 429:
         return None
-    try:
-        retry_after = exc.response.json()["parameters"]["retry_after"]
-    except Exception:
+    parameters = (exc.body or {}).get("parameters")
+    if not isinstance(parameters, dict):
         return None
+    retry_after = parameters.get("retry_after")
     # bool은 int의 서브클래스라 isinstance만으로는 True/False가 통과한다 (PR #253 리뷰).
     if isinstance(retry_after, bool) or not isinstance(retry_after, int):
         return None
@@ -57,18 +146,18 @@ class _TelegramTokenRedactionFilter(logging.Filter):
 
 
 def _install_telegram_token_redaction_filter() -> None:
-    # raise_for_status가 만드는 str(HTTPStatusError)에는 요청 URL이 그대로 들어 있고,
-    # telegram URL에는 봇 토큰이 들어 있다. 그 예외를 %s로 찍는 모듈이 전부 여기 있어야 한다.
+    # 애플리케이션 코드가 만드는 예외에는 더 이상 URL이 없다 — telegram 호출이 전부
+    # call_telegram_api를 지나고, 거기서 나오는 TelegramApiError는 str()에 URL을 담지
+    # 않는다 (#257). 그래서 backend.* 로거는 이 목록에 없어도 된다. 예전에는 있어야 했고,
+    # 빠뜨려서 두 번 뚫렸다 (PR #253 1·2차 리뷰).
     #
-    # __name__(backend.telegram_notifier) — send_text 등 5곳 (PR #253 리뷰)
-    # backend.telegram_commands — 폴러의 _get_updates가 같은 형태로 URL을 만들고
-    #   "Telegram command polling failed: %s"로 찍는다. 401·409(인스턴스 중복)·429·5xx에서
-    #   폴링 루프가 5초마다 재시도하며 매 회 기록하므로 전송 경로보다 트리거가 잦다.
-    #   전송 경로만 막고 이쪽을 놓쳤었다 (PR #253 2차 리뷰).
+    # httpx/httpcore는 남는다. 이쪽은 예외 경로가 아니라 자신의 정상 로깅이 문제다 —
+    # httpx는 요청마다 INFO로 'HTTP Request: POST <full-url>'을 찍고, 그 URL에 토큰이
+    # 들어 있다. 우리 코드를 어떻게 고치든 이 로그는 라이브러리가 직접 만든다.
     #
-    # 이 목록은 로거 이름 allowlist라 구조적으로 취약하다 — telegram 예외를 로깅하는 모듈이
-    # 새로 생기면 같은 누출이 다시 열린다. 실제로 이미 한 번 그랬다. 근본 대응은 #257.
-    for logger_name in (__name__, "backend.telegram_commands", "httpx", "httpcore"):
+    # 이 두 이름은 서드파티 라이브러리 로거라 애플리케이션 모듈이 늘어도 따라 늘지 않는다.
+    # allowlist가 계속 자라던 원인이 backend.* 쪽이었다.
+    for logger_name in ("httpx", "httpcore"):
         target_logger = logging.getLogger(logger_name)
         if any(
             isinstance(filter_, _TelegramTokenRedactionFilter)
@@ -238,14 +327,13 @@ class TelegramNotifier:
         if not self.enabled:
             return False
 
-        url = f"https://api.telegram.org/bot{self.bot_token}/answerCallbackQuery"
         payload = {"callback_query_id": callback_query_id}
         if text:
             payload["text"] = text
         try:
-            async with httpx.AsyncClient(timeout=10.0) as client:
-                response = await client.post(url, json=payload)
-                response.raise_for_status()
+            await call_telegram_api(
+                self.bot_token, "answerCallbackQuery", payload=payload
+            )
             return True
         except Exception as exc:
             logger.error("Telegram callback answer failed: %s", exc)
@@ -255,14 +343,12 @@ class TelegramNotifier:
         if not self.enabled:
             return False
 
-        url = f"https://api.telegram.org/bot{self.bot_token}/sendChatAction"
         try:
-            async with httpx.AsyncClient(timeout=10.0) as client:
-                response = await client.post(
-                    url,
-                    json={"chat_id": self.chat_id, "action": action},
-                )
-                response.raise_for_status()
+            await call_telegram_api(
+                self.bot_token,
+                "sendChatAction",
+                payload={"chat_id": self.chat_id, "action": action},
+            )
             return True
         except Exception as exc:
             logger.error("Telegram chat action send failed: %s", exc)
@@ -272,11 +358,10 @@ class TelegramNotifier:
         if not self.enabled:
             return False
 
-        url = f"https://api.telegram.org/bot{self.bot_token}/setMyCommands"
         try:
-            async with httpx.AsyncClient(timeout=10.0) as client:
-                response = await client.post(url, json={"commands": commands})
-                response.raise_for_status()
+            await call_telegram_api(
+                self.bot_token, "setMyCommands", payload={"commands": commands}
+            )
             return True
         except Exception as exc:
             logger.error("Telegram bot command menu setup failed: %s", exc)
@@ -288,12 +373,8 @@ class TelegramNotifier:
         if self.bot_username:
             return self.bot_username
 
-        url = f"https://api.telegram.org/bot{self.bot_token}/getMe"
         try:
-            async with httpx.AsyncClient(timeout=10.0) as client:
-                response = await client.post(url)
-                response.raise_for_status()
-                body = response.json()
+            body = await call_telegram_api(self.bot_token, "getMe")
             result = body.get("result") or {}
             username = str(result.get("username") or "").strip().lstrip("@")
             self.bot_username = username.lower()
@@ -308,7 +389,6 @@ class TelegramNotifier:
         *,
         reply_markup: dict[str, Any] | None = None,
     ) -> None:
-        url = f"https://api.telegram.org/bot{self.bot_token}/sendMessage"
         payload = {
             "chat_id": self.chat_id,
             "text": text,
@@ -316,9 +396,7 @@ class TelegramNotifier:
         }
         if reply_markup is not None:
             payload["reply_markup"] = reply_markup
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            response = await client.post(url, json=payload)
-            response.raise_for_status()
+        await call_telegram_api(self.bot_token, "sendMessage", payload=payload)
 
 
 telegram_notifier = TelegramNotifier()

--- a/backend/telegram_notifier.py
+++ b/backend/telegram_notifier.py
@@ -77,17 +77,48 @@ async def call_telegram_api(
     *,
     payload: dict[str, Any] | None = None,
     timeout: float = 10.0,
-    expect_body: bool = False,
+) -> None:
+    """텔레그램 API를 호출하고 성공 여부만 본다. 응답 본문은 읽지 않는다.
+
+    본문이 필요하면 fetch_telegram_api를 쓴다. 플래그 하나로 합치지 않고 함수를 나눈
+    이유는, 합치면 "본문을 읽어야 하는데 플래그를 빠뜨린" 호출부가 조용히 빈 dict를
+    받기 때문이다 — getUpdates라면 로그도 백오프도 없이 "update 없음"으로 계속 돌고,
+    getMe라면 username이 ""로 퇴화한다. 나뉘어 있으면 잘못 고른 쪽이 None을 돌려주므로
+    첫 실행에서 깨진다 (#257 자가리뷰).
+    """
+    await _request_telegram_api(
+        bot_token, method, payload=payload, timeout=timeout, parse_body=False
+    )
+
+
+async def fetch_telegram_api(
+    bot_token: str,
+    method: str,
+    *,
+    payload: dict[str, Any] | None = None,
+    timeout: float = 10.0,
 ) -> dict[str, Any]:
-    """텔레그램 API를 한 번 호출한다.
+    """텔레그램 API를 호출하고 응답 본문을 파싱해 돌려준다.
 
-    봇 토큰이 URL에 실리는 지점이 이 함수 하나뿐이고, 여기서 나가는 실패는 전부
-    TelegramApiError다. httpx 예외는 이 경계를 넘지 않는다 (#257).
+    파싱 실패는 TelegramApiError다. 조용히 {}로 넘기면 폴러가 "update 없음"으로 읽고
+    로그도 백오프도 없이 다음 폴링으로 넘어간다.
+    """
+    return await _request_telegram_api(
+        bot_token, method, payload=payload, timeout=timeout, parse_body=True
+    )
 
-    expect_body는 응답 본문을 파싱할지 정한다. 본문을 읽는 호출은 getMe와 getUpdates
-    둘뿐이고, 나머지 넷은 성공 여부만 본다. 무조건 파싱하면 200에 비-JSON이 온 경우
-    본문을 쓰지도 않는 호출까지 실패하게 되는데, 이는 이 리팩터링 전에 없던 동작이다.
-    파싱하지 않을 때는 빈 dict를 돌려준다.
+
+async def _request_telegram_api(
+    bot_token: str,
+    method: str,
+    *,
+    payload: dict[str, Any] | None,
+    timeout: float,
+    parse_body: bool,
+) -> dict[str, Any]:
+    """봇 토큰이 URL에 실리는 유일한 지점.
+
+    여기서 나가는 실패는 전부 TelegramApiError다. httpx 예외는 이 경계를 넘지 않는다 (#257).
     """
     url = f"https://api.telegram.org/bot{bot_token}/{method}"
     try:
@@ -97,10 +128,10 @@ async def call_telegram_api(
             else:
                 response = await client.post(url, json=payload)
             response.raise_for_status()
-            # 본문을 쓰는 호출에서는 파싱 실패도 실패로 남긴다 — 이 역시 리팩터링 전
-            # 동작이다. 조용히 {}로 넘기면 폴러가 "update 없음"으로 읽고 로그도 없이
-            # 다음 폴링으로 넘어간다.
-            body = response.json() if expect_body else {}
+            # 본문을 쓰지 않는 호출은 파싱하지 않는다. 무조건 파싱하면 200에 비-JSON이
+            # 온 경우 본문을 읽지도 않는 sendMessage까지 실패하는데, 이는 이 리팩터링
+            # 전에 없던 동작이다 (#257 자가리뷰).
+            body = response.json() if parse_body else {}
     except httpx.HTTPStatusError as exc:
         raise TelegramApiError(
             method,
@@ -396,7 +427,7 @@ class TelegramNotifier:
             return self.bot_username
 
         try:
-            body = await call_telegram_api(self.bot_token, "getMe", expect_body=True)
+            body = await fetch_telegram_api(self.bot_token, "getMe")
             result = body.get("result") or {}
             username = str(result.get("username") or "").strip().lstrip("@")
             self.bot_username = username.lower()

--- a/backend/telegram_notifier.py
+++ b/backend/telegram_notifier.py
@@ -193,9 +193,10 @@ class _TelegramTokenRedactionFilter(logging.Filter):
 
 def _install_telegram_token_redaction_filter() -> None:
     # 애플리케이션 코드가 만드는 예외에는 더 이상 URL이 없다 — telegram 호출이 전부
-    # call_telegram_api를 지나고, 거기서 나오는 TelegramApiError는 str()에 URL을 담지
-    # 않는다 (#257). 그래서 backend.* 로거는 이 목록에 없어도 된다. 예전에는 있어야 했고,
-    # 빠뜨려서 두 번 뚫렸다 (PR #253 1·2차 리뷰).
+    # _request_telegram_api를 지나고(call_telegram_api와 fetch_telegram_api 둘 다 그리로
+    # 모인다), 거기서 나오는 TelegramApiError는 str()에 URL을 담지 않는다 (#257).
+    # 그래서 backend.* 로거는 이 목록에 없어도 된다. 예전에는 있어야 했고, 빠뜨려서
+    # 두 번 뚫렸다 (PR #253 1·2차 리뷰).
     #
     # httpx만 남는다. 이쪽은 예외 경로가 아니라 라이브러리 자신의 정상 로깅이 문제다 —
     # 요청마다 INFO로 'HTTP Request: %s %s ...'를 request.url과 함께 찍고, 그 URL에

--- a/backend/telegram_notifier.py
+++ b/backend/telegram_notifier.py
@@ -77,11 +77,17 @@ async def call_telegram_api(
     *,
     payload: dict[str, Any] | None = None,
     timeout: float = 10.0,
+    expect_body: bool = False,
 ) -> dict[str, Any]:
-    """텔레그램 API를 한 번 호출하고 응답 본문을 돌려준다.
+    """텔레그램 API를 한 번 호출한다.
 
     봇 토큰이 URL에 실리는 지점이 이 함수 하나뿐이고, 여기서 나가는 실패는 전부
     TelegramApiError다. httpx 예외는 이 경계를 넘지 않는다 (#257).
+
+    expect_body는 응답 본문을 파싱할지 정한다. 본문을 읽는 호출은 getMe와 getUpdates
+    둘뿐이고, 나머지 넷은 성공 여부만 본다. 무조건 파싱하면 200에 비-JSON이 온 경우
+    본문을 쓰지도 않는 호출까지 실패하게 되는데, 이는 이 리팩터링 전에 없던 동작이다.
+    파싱하지 않을 때는 빈 dict를 돌려준다.
     """
     url = f"https://api.telegram.org/bot{bot_token}/{method}"
     try:
@@ -91,7 +97,10 @@ async def call_telegram_api(
             else:
                 response = await client.post(url, json=payload)
             response.raise_for_status()
-            body = response.json()
+            # 본문을 쓰는 호출에서는 파싱 실패도 실패로 남긴다 — 이 역시 리팩터링 전
+            # 동작이다. 조용히 {}로 넘기면 폴러가 "update 없음"으로 읽고 로그도 없이
+            # 다음 폴링으로 넘어간다.
+            body = response.json() if expect_body else {}
     except httpx.HTTPStatusError as exc:
         raise TelegramApiError(
             method,
@@ -103,6 +112,12 @@ async def call_telegram_api(
         # 네트워크 오류, 본문 파싱 실패 등. from None으로 예외 체인을 끊는다 —
         # 원본 메시지에 URL이 들어 있을 수 있고, 체인이 남으면 exc_info 로깅이나
         # 처리되지 않은 트레이스백이 그 원본을 그대로 찍는다.
+        #
+        # 감수한 비용: except Exception이라 우리 쪽 버그(직렬화 불가한 payload로 나는
+        # TypeError 같은 것)도 한 줄로 뭉개지고 발생 위치를 잃는다. 그럼에도 넓게 잡는
+        # 이유는, 타입을 모르는 예외야말로 메시지에 URL이 없다고 가정할 수 없기
+        # 때문이다. 좁히려면 "URL을 담지 않는다고 확인된 타입"의 목록이 필요한데,
+        # 그건 이 이슈가 없애려는 allowlist와 같은 종류의 물건이다.
         raise TelegramApiError(method, reason=f"{type(exc).__name__}: {exc}") from None
     return body if isinstance(body, dict) else {}
 
@@ -151,13 +166,20 @@ def _install_telegram_token_redaction_filter() -> None:
     # 않는다 (#257). 그래서 backend.* 로거는 이 목록에 없어도 된다. 예전에는 있어야 했고,
     # 빠뜨려서 두 번 뚫렸다 (PR #253 1·2차 리뷰).
     #
-    # httpx/httpcore는 남는다. 이쪽은 예외 경로가 아니라 자신의 정상 로깅이 문제다 —
-    # httpx는 요청마다 INFO로 'HTTP Request: POST <full-url>'을 찍고, 그 URL에 토큰이
-    # 들어 있다. 우리 코드를 어떻게 고치든 이 로그는 라이브러리가 직접 만든다.
+    # httpx만 남는다. 이쪽은 예외 경로가 아니라 라이브러리 자신의 정상 로깅이 문제다 —
+    # 요청마다 INFO로 'HTTP Request: %s %s ...'를 request.url과 함께 찍고, 그 URL에
+    # 토큰이 들어 있다. 우리 코드를 어떻게 고치든 이 로그는 httpx가 직접 만든다.
     #
-    # 이 두 이름은 서드파티 라이브러리 로거라 애플리케이션 모듈이 늘어도 따라 늘지 않는다.
-    # allowlist가 계속 자라던 원인이 backend.* 쪽이었다.
-    for logger_name in ("httpx", "httpcore"):
+    # httpcore는 뺐다. 여기 있었지만 한 번도 동작한 적이 없다 — 필터는 그 로거가 직접
+    # 만든 레코드에만 걸리고 자식에서 전파된 레코드는 타지 않는데, httpcore가 맨
+    # "httpcore"로 찍는 곳은 없다(전부 httpcore.connection/.http11/.http2/.proxy/.socks).
+    # 애초에 걸 이유도 없었다: httpcore의 trace 로그는 request=%r로 찍고 그 repr이
+    # <Request [b'POST']>라 URL을 담지 않는다. httpx.Request의 repr과 달리 안전하다.
+    #
+    # 남은 항목이 하나라 해도 "httpx가 로거 이름을 바꾸면 조용히 무력화된다"는 성질은
+    # 그대로다. 그래서 test_httpx_request_logging_is_redacted_end_to_end가 실제 httpx
+    # 요청을 태워 이 결합을 검사한다 — 이름이 바뀌면 조용히가 아니라 빨갛게 깨진다.
+    for logger_name in ("httpx",):
         target_logger = logging.getLogger(logger_name)
         if any(
             isinstance(filter_, _TelegramTokenRedactionFilter)
@@ -374,7 +396,7 @@ class TelegramNotifier:
             return self.bot_username
 
         try:
-            body = await call_telegram_api(self.bot_token, "getMe")
+            body = await call_telegram_api(self.bot_token, "getMe", expect_body=True)
             result = body.get("result") or {}
             username = str(result.get("username") or "").strip().lstrip("@")
             self.bot_username = username.lower()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,49 @@
+import httpx
 import pytest
 
 from backend import services, stock_code
+
+
+@pytest.fixture
+def failing_telegram_client():
+    """텔레그램 호출을 상태 오류로 실패시키는 가짜 httpx 클라이언트 팩토리 (#257).
+
+    호출부가 만든 URL을 그대로 받아 httpx 응답을 세우고 raise_for_status를 태운다.
+    URL을 테스트가 지어내지 않는 것이 핵심이다 — 토큰이 실제로 URL에 실려 나가고
+    예외 메시지에 들어앉는 경로를 그대로 통과시켜야 리댁션을 검증한 것이 된다.
+
+    전송(telegram_notifier)과 폴링(telegram_commands) 양쪽이 같은 팩토리를 쓴다.
+    """
+
+    def _factory(status_code, body):
+        class FakeResponse:
+            def __init__(self, url):
+                self._inner = httpx.Response(
+                    status_code, json=body, request=httpx.Request("POST", url)
+                )
+
+            def raise_for_status(self):
+                self._inner.raise_for_status()
+
+            def json(self):
+                return body
+
+        class FakeAsyncClient:
+            def __init__(self, *, timeout):
+                self.timeout = timeout
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, traceback):
+                return None
+
+            async def post(self, url, **kwargs):
+                return FakeResponse(url)
+
+        return FakeAsyncClient
+
+    return _factory
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -46,6 +46,10 @@ def _make_poller(notifier, handler, *, state_store=None):
     )
 
 
+async def _noop(*args, **kwargs):
+    return None
+
+
 class FakeState:
     def __init__(self):
         self.mode = "urgent"
@@ -1874,6 +1878,48 @@ async def test_alerts_command_ignores_other_chats():
     assert notifier.messages == []
 
 
+@pytest.mark.asyncio
+async def test_polling_failure_log_has_no_bot_token(
+    monkeypatch, caplog, failing_telegram_client
+):
+    """폴러의 getUpdates 실패 로그에 봇 토큰이 남지 않아야 한다 (PR #253 2차 리뷰, #257).
+
+    401(토큰 폐기)·409(인스턴스 중복 또는 웹훅 병행)·429·5xx에서 폴링 루프가 5초마다
+    재시도하며 매 회 기록하므로, 전송 경로보다 트리거가 잦다.
+
+    예전에는 backend.telegram_commands가 리댁션 목록에 들어 있어야만 막혔다. 지금은
+    _get_updates가 URL을 직접 만들지 않고 call_telegram_api에 맡겨서 막힌다 — 이 테스트는
+    목록이 아니라 그 위임을 지킨다. _get_updates에 URL 조립이 되돌아오면 여기서 깨진다.
+    """
+    token = "8666951614:SECRET"
+    notifier = FakeNotifier()
+    notifier.enabled = True
+    notifier.bot_token = token
+    poller = _make_poller(notifier, handler=TelegramCommandHandler(notifier=notifier))
+
+    monkeypatch.setattr(
+        "backend.telegram_notifier.httpx.AsyncClient",
+        failing_telegram_client(409, {"ok": False, "description": "Conflict"}),
+    )
+
+    async def stop_after_first_failure(delay):
+        raise pytest.fail.Exception("stop after first failed polling iteration")
+
+    monkeypatch.setattr(poller, "_sleep", stop_after_first_failure)
+    monkeypatch.setattr(poller, "_setup_bot_profile", _noop)
+    monkeypatch.setattr(poller, "_restore_state", _noop)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(pytest.fail.Exception):
+            await poller.run()
+
+    assert "Telegram command polling failed" in caplog.text
+    assert token not in caplog.text
+    assert "api.telegram.org" not in caplog.text
+    # 진단 정보는 남아야 한다 — 409는 인스턴스 중복이라 상태 코드 없이는 원인을 못 좁힌다.
+    assert "409" in caplog.text
+
+
 def test_poller_default_handler_uses_order_gateway_and_trade_recorder_factories(monkeypatch):
     gateway = object()
     recorder = object()
@@ -3608,8 +3654,10 @@ async def test_get_updates_sends_the_batch_limit(monkeypatch):
                 json=lambda: {"ok": True, "result": []},
             )
 
+    # HTTP 호출은 telegram_notifier.call_telegram_api로 옮겨갔다 (#257). 패치 지점도
+    # 따라 옮긴다 — 여기서 검사하는 것은 폴러가 싣는 payload이지 호출 위치가 아니다.
     monkeypatch.setattr(
-        telegram_commands.httpx, "AsyncClient", lambda **kwargs: FakeClient()
+        "backend.telegram_notifier.httpx.AsyncClient", lambda **kwargs: FakeClient()
     )
     notifier = FakeNotifier()
     notifier.bot_token = "token"

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -1888,7 +1888,7 @@ async def test_polling_failure_log_has_no_bot_token(
     재시도하며 매 회 기록하므로, 전송 경로보다 트리거가 잦다.
 
     예전에는 backend.telegram_commands가 리댁션 목록에 들어 있어야만 막혔다. 지금은
-    _get_updates가 URL을 직접 만들지 않고 call_telegram_api에 맡겨서 막힌다 — 이 테스트는
+    _get_updates가 URL을 직접 만들지 않고 fetch_telegram_api에 맡겨서 막힌다 — 이 테스트는
     목록이 아니라 그 위임을 지킨다. _get_updates에 URL 조립이 되돌아오면 여기서 깨진다.
     """
     token = "8666951614:SECRET"
@@ -3654,7 +3654,7 @@ async def test_get_updates_sends_the_batch_limit(monkeypatch):
                 json=lambda: {"ok": True, "result": []},
             )
 
-    # HTTP 호출은 telegram_notifier.call_telegram_api로 옮겨갔다 (#257). 패치 지점도
+    # HTTP 호출은 telegram_notifier.fetch_telegram_api로 옮겨갔다 (#257). 패치 지점도
     # 따라 옮긴다 — 여기서 검사하는 것은 폴러가 싣는 payload이지 호출 위치가 아니다.
     monkeypatch.setattr(
         "backend.telegram_notifier.httpx.AsyncClient", lambda **kwargs: FakeClient()

--- a/backend/tests/test_telegram_notifier.py
+++ b/backend/tests/test_telegram_notifier.py
@@ -608,7 +608,20 @@ def test_no_module_builds_a_telegram_url_outside_the_gateway():
 
     offenders = []
     for path in sorted(backend_dir.rglob("*.py")):
-        if "tests" in path.parts:
+        # 우리 소스만 본다. CI는 backend/ 안에 가상환경을 만들고, 거기 설치된 서드파티
+        # 패키지에도 텔레그램 URL 문자열이 있다(실제로 이 가드가 처음 그걸로 깨졌다).
+        # 가상환경 이름은 .venv일 수도 venv일 수도 있어 이름으로 거르지 않고, 서드파티
+        # 코드가 반드시 들어가는 site-packages/dist-packages로 거른다.
+        #
+        # 판정은 반드시 backend_dir 기준 상대 경로로 한다. 절대 경로의 부분을 보면
+        # 체크아웃 위치에 점으로 시작하는 디렉토리가 하나만 있어도(worktree가 .claude/
+        # 아래 있는 경우처럼) 전부 걸러져 가드가 조용히 무력해진다 — 실측으로 확인했다.
+        relative = path.relative_to(backend_dir)
+        if any(
+            part.startswith(".")
+            or part in {"__pycache__", "site-packages", "dist-packages", "tests"}
+            for part in relative.parts
+        ):
             continue
         source = path.read_text(encoding="utf-8")
         for number, line in enumerate(source.splitlines(), 1):
@@ -617,7 +630,8 @@ def test_no_module_builds_a_telegram_url_outside_the_gateway():
             # 관문 안의 그 한 줄만 허용한다.
             if path.name == "telegram_notifier.py" and line in gateway_source:
                 continue
-            offenders.append(f"{path.name}:{number}: {line.strip()}")
+            # 상대 경로로 남긴다 — 파일명만 찍으면 어느 트리의 파일인지 알 수 없다.
+            offenders.append(f"{relative}:{number}: {line.strip()}")
 
     assert offenders == [], (
         "텔레그램 URL을 직접 만드는 곳이 생겼다. call_telegram_api / fetch_telegram_api를 "

--- a/backend/tests/test_telegram_notifier.py
+++ b/backend/tests/test_telegram_notifier.py
@@ -4,8 +4,10 @@ import httpx
 import pytest
 
 from backend.telegram_notifier import (
+    TelegramApiError,
     TelegramNotifier,
     _retry_after_seconds,
+    call_telegram_api,
     should_send_telegram_alert,
 )
 
@@ -170,6 +172,9 @@ async def test_send_text_posts_reply_markup(monkeypatch):
         def raise_for_status(self):
             return None
 
+        def json(self):
+            return {"ok": True}
+
     class FakeAsyncClient:
         def __init__(self, *, timeout):
             self.timeout = timeout
@@ -213,6 +218,9 @@ async def test_answer_callback_query_posts_payload(monkeypatch):
         def raise_for_status(self):
             return None
 
+        def json(self):
+            return {"ok": True}
+
     class FakeAsyncClient:
         def __init__(self, *, timeout):
             self.timeout = timeout
@@ -249,6 +257,9 @@ async def test_send_chat_action_posts_typing_payload(monkeypatch):
         def raise_for_status(self):
             return None
 
+        def json(self):
+            return {"ok": True}
+
     class FakeAsyncClient:
         def __init__(self, *, timeout):
             self.timeout = timeout
@@ -281,6 +292,9 @@ async def test_set_bot_commands_posts_command_menu_payload(monkeypatch):
     class FakeResponse:
         def raise_for_status(self):
             return None
+
+        def json(self):
+            return {"ok": True}
 
     class FakeAsyncClient:
         def __init__(self, *, timeout):
@@ -344,10 +358,13 @@ async def test_load_bot_username_fetches_and_caches_get_me(monkeypatch):
     assert calls == [("https://api.telegram.org/bottoken/getMe", {})]
 
 
-def _http_status_error(status_code, body):
-    request = httpx.Request("POST", "https://api.telegram.org/bottoken/sendMessage")
-    response = httpx.Response(status_code, json=body, request=request)
-    return httpx.HTTPStatusError("error", request=request, response=response)
+def _api_error(status_code, body, *, method="sendMessage"):
+    """call_telegram_api가 상태 오류에서 만드는 것과 같은 예외.
+
+    실제 생성 경로(raise_for_status → TelegramApiError)는
+    test_call_telegram_api_raises_error_without_token이 따로 검증한다.
+    """
+    return TelegramApiError(method, status_code=status_code, body=body)
 
 
 def test_retry_after_seconds_reads_429_parameters():
@@ -356,21 +373,21 @@ def test_retry_after_seconds_reads_429_parameters():
     send_text가 bool만 돌려주는 탓에 호출부의 재시도 간격은 고정 추측값이다.
     실제 ban 길이가 그 가정과 맞는지 판단할 근거가 로그에 있어야 한다.
     """
-    exc = _http_status_error(429, {"ok": False, "parameters": {"retry_after": 37}})
+    exc = _api_error(429, {"ok": False, "parameters": {"retry_after": 37}})
     assert _retry_after_seconds(exc) == 37
 
 
 def test_retry_after_seconds_returns_none_for_non_429_or_malformed_body():
-    assert _retry_after_seconds(_http_status_error(500, {"ok": False})) is None
-    assert _retry_after_seconds(_http_status_error(429, {"ok": False})) is None
-    assert _retry_after_seconds(_http_status_error(429, {"parameters": {}})) is None
+    assert _retry_after_seconds(_api_error(500, {"ok": False})) is None
+    assert _retry_after_seconds(_api_error(429, {"ok": False})) is None
+    assert _retry_after_seconds(_api_error(429, {"parameters": {}})) is None
     assert (
-        _retry_after_seconds(_http_status_error(429, {"parameters": {"retry_after": "30"}}))
+        _retry_after_seconds(_api_error(429, {"parameters": {"retry_after": "30"}}))
         is None
     )
     # bool은 int의 서브클래스라 가드가 없으면 True가 1로 통과한다 (PR #253 리뷰).
     assert (
-        _retry_after_seconds(_http_status_error(429, {"parameters": {"retry_after": True}}))
+        _retry_after_seconds(_api_error(429, {"parameters": {"retry_after": True}}))
         is None
     )
     assert _retry_after_seconds(httpx.ConnectError("boom")) is None
@@ -379,7 +396,7 @@ def test_retry_after_seconds_returns_none_for_non_429_or_malformed_body():
 @pytest.mark.asyncio
 async def test_send_text_logs_retry_after_on_429(monkeypatch, caplog):
     async def raise_429(text, *, reply_markup=None):
-        raise _http_status_error(429, {"ok": False, "parameters": {"retry_after": 42}})
+        raise _api_error(429, {"ok": False, "parameters": {"retry_after": 42}})
 
     notifier = TelegramNotifier("token", "123")
     monkeypatch.setattr(notifier, "_post_message", raise_429)
@@ -391,54 +408,104 @@ async def test_send_text_logs_retry_after_on_429(monkeypatch, caplog):
 
 
 @pytest.mark.asyncio
-async def test_send_text_failure_log_redacts_bot_token(monkeypatch, caplog):
-    """전송 실패 로그에 봇 토큰이 평문으로 남지 않아야 한다 (PR #253 리뷰).
+async def test_call_telegram_api_raises_error_without_token(
+    monkeypatch, failing_telegram_client
+):
+    """상태 오류를 URL 없는 예외로 바꿔 던진다 — allowlist를 없앨 수 있는 근거다 (#257).
 
-    raise_for_status가 만드는 str(HTTPStatusError)에는 요청 URL이 들어 있고, 그 URL에
-    토큰이 포함된다. 리댁션 필터가 httpx/httpcore 로거에만 걸려 있어 이 모듈 자신의
-    로거로 찍는 경로는 걸러지지 않았다.
+    httpx의 HTTPStatusError는 메시지에 요청 URL을 담고, 텔레그램 URL의 경로가 곧 봇
+    토큰이다. 그 예외가 이 경계를 넘으면 "이걸 %s로 찍는 모든 로거"에 리댁션을 걸어야
+    하고, 그 목록은 두 번 뚫렸다 (PR #253 1·2차 리뷰).
     """
-    token = "SECRET-BOT-TOKEN-123"
-    request = httpx.Request("POST", f"https://api.telegram.org/bot{token}/sendMessage")
-    response = httpx.Response(
-        429, json={"ok": False, "parameters": {"retry_after": 42}}, request=request
+    token = "8666951614:SECRET"
+    monkeypatch.setattr(
+        "backend.telegram_notifier.httpx.AsyncClient",
+        failing_telegram_client(
+            429,
+            {
+                "ok": False,
+                "description": "Too Many Requests: retry after 42",
+                "parameters": {"retry_after": 42},
+            },
+        ),
     )
 
-    async def raise_for_status(text, *, reply_markup=None):
-        response.raise_for_status()
+    with pytest.raises(TelegramApiError) as excinfo:
+        await call_telegram_api(token, "sendMessage", payload={})
 
+    exc = excinfo.value
+    assert token not in str(exc)
+    assert "api.telegram.org" not in str(exc)
+    # 예외 체인도 끊겨 있어야 한다. 남으면 exc_info 로깅이나 처리되지 않은 트레이스백이
+    # 원본 HTTPStatusError를 — 따라서 URL을 — 그대로 찍는다.
+    assert exc.__cause__ is None
+    assert exc.__suppress_context__ is True
+    # URL이 빠진 만큼 진단 정보는 오히려 늘어야 한다.
+    assert exc.status_code == 429
+    assert "HTTP 429" in str(exc)
+    assert "Too Many Requests: retry after 42" in str(exc)
+
+
+@pytest.mark.asyncio
+async def test_call_telegram_api_redacts_token_from_transport_error_message(monkeypatch):
+    """상태 오류가 아닌 실패도 토큰을 흘리지 않아야 한다 (#257).
+
+    httpx의 전송 계층 예외는 대개 URL을 담지 않지만 전부는 아니다 — UnsupportedProtocol,
+    InvalidURL처럼 메시지에 URL을 넣는 타입이 있다. 그 메시지를 그대로 reason에 실으면
+    상태 오류 경로만 막고 이쪽으로 새는 것이라, 예외를 만들 때 한 번 더 거른다.
+    """
+    token = "8666951614:SECRET"
+
+    class ExplodingAsyncClient:
+        def __init__(self, *, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return None
+
+        async def post(self, url, **kwargs):
+            raise httpx.UnsupportedProtocol(f"Request URL has an unsupported protocol: {url}")
+
+    monkeypatch.setattr(
+        "backend.telegram_notifier.httpx.AsyncClient", ExplodingAsyncClient
+    )
+
+    with pytest.raises(TelegramApiError) as excinfo:
+        await call_telegram_api(token, "getUpdates", payload={})
+
+    assert token not in str(excinfo.value)
+    assert "bot<redacted>" in str(excinfo.value)
+    # 어떤 종류의 실패였는지는 남아야 한다.
+    assert "UnsupportedProtocol" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_send_text_failure_log_redacts_bot_token(
+    monkeypatch, caplog, failing_telegram_client
+):
+    """전송 실패 로그에 봇 토큰이 평문으로 남지 않아야 한다 (PR #253 1차 리뷰, #257).
+
+    _post_message가 실제로 URL을 만들고 raise_for_status가 도는 경로를 그대로 태운다.
+    예전에는 이 모듈 로거가 리댁션 목록에 들어 있어야 통과했고, 지금은 예외에 URL이
+    없어야 통과한다 — 즉 목록을 지워도 이 테스트가 남는다.
+    """
+    token = "SECRET-BOT-TOKEN-123"
+    monkeypatch.setattr(
+        "backend.telegram_notifier.httpx.AsyncClient",
+        failing_telegram_client(429, {"ok": False, "parameters": {"retry_after": 42}}),
+    )
     notifier = TelegramNotifier(token, "123")
-    monkeypatch.setattr(notifier, "_post_message", raise_for_status)
 
     with caplog.at_level(logging.ERROR):
         assert await notifier.send_text("안녕") is False
 
     assert token not in caplog.text
-    assert "bot<redacted>" in caplog.text
+    assert "api.telegram.org" not in caplog.text
     # 진단에 필요한 정보는 남아 있어야 한다.
     assert "retry_after=42s" in caplog.text
-
-
-def test_polling_error_log_redacts_bot_token(caplog):
-    """폴러의 getUpdates 실패 로그에도 리댁션이 걸린다 (PR #253 3차 리뷰).
-
-    _get_updates가 URL에 토큰을 넣고 raise_for_status를 호출하며, 401·409(인스턴스 중복)·
-    429·5xx에서 폴링 루프가 5초마다 재시도하므로 전송 경로보다 트리거가 잦다.
-
-    기존 test_telegram_error_log_redacts_bot_token도 getUpdates URL을 쓰지만 로거가
-    httpx라 이 항목을 검증하지 않는다. allowlist에서 backend.telegram_commands만 빼도
-    스위트 전체가 초록이었다 — 자격증명 누출은 조용히 되돌아가면 알 방법이 없다.
-    """
-    token = "8666951614:SECRET"
-    url = f"https://api.telegram.org/bot{token}/getUpdates"
-
-    with caplog.at_level(logging.ERROR, logger="backend.telegram_commands"):
-        logging.getLogger("backend.telegram_commands").error(
-            "Telegram command polling failed: %s", httpx.HTTPError(url)
-        )
-
-    assert token not in caplog.text
-    assert "https://api.telegram.org/bot<redacted>/getUpdates" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -452,7 +519,7 @@ async def test_send_text_publishes_and_clears_retry_after(monkeypatch):
     notifier = TelegramNotifier("token", "123")
 
     async def fail(text, *, reply_markup=None):
-        raise _http_status_error(429, {"ok": False, "parameters": {"retry_after": 42}})
+        raise _api_error(429, {"ok": False, "parameters": {"retry_after": 42}})
 
     monkeypatch.setattr(notifier, "_post_message", fail)
     assert await notifier.send_text("안녕") is False
@@ -460,7 +527,7 @@ async def test_send_text_publishes_and_clears_retry_after(monkeypatch):
 
     # 429가 아닌 실패는 값을 남기지 않는다 — 이월되면 다음 재시도가 엉뚱한 값을 기다린다.
     async def fail_500(text, *, reply_markup=None):
-        raise _http_status_error(500, {"ok": False})
+        raise _api_error(500, {"ok": False})
 
     monkeypatch.setattr(notifier, "_post_message", fail_500)
     assert await notifier.send_text("안녕") is False

--- a/backend/tests/test_telegram_notifier.py
+++ b/backend/tests/test_telegram_notifier.py
@@ -8,6 +8,7 @@ from backend.telegram_notifier import (
     TelegramNotifier,
     _retry_after_seconds,
     call_telegram_api,
+    fetch_telegram_api,
     should_send_telegram_alert,
 )
 
@@ -464,9 +465,9 @@ async def test_call_telegram_api_raises_error_without_token(
 async def test_send_text_succeeds_when_200_body_is_not_json(monkeypatch):
     """본문을 쓰지 않는 호출은 200의 본문이 JSON이 아니어도 성공해야 한다 (#257 자가리뷰).
 
-    call_telegram_api가 무조건 response.json()을 부르면, 본문을 읽지도 않는 sendMessage가
-    파싱 실패로 실패한다 — 리팩터링 전에는 없던 동작이고, send_text가 False를 돌려주면
-    _send_text_settled가 최대 4회 재시도한다. expect_body가 그 비대칭을 막는다.
+    무조건 response.json()을 부르면 본문을 읽지도 않는 sendMessage가 파싱 실패로 실패한다 —
+    리팩터링 전에는 없던 동작이고, send_text가 False를 돌려주면 _send_text_settled가
+    최대 4회 재시도한다. call_telegram_api/fetch_telegram_api 분리가 그 비대칭을 막는다.
     """
 
     class FakeResponse:
@@ -497,7 +498,45 @@ async def test_send_text_succeeds_when_200_body_is_not_json(monkeypatch):
     # 반대로 본문을 읽는 호출은 파싱 실패를 실패로 남긴다. 조용히 {}로 넘기면 폴러가
     # "update 없음"으로 읽고 로그도 백오프도 없이 다음 폴링으로 넘어간다.
     with pytest.raises(TelegramApiError):
-        await call_telegram_api("token", "getUpdates", payload={}, expect_body=True)
+        await fetch_telegram_api("token", "getUpdates", payload={})
+
+
+@pytest.mark.asyncio
+async def test_call_telegram_api_returns_none_so_body_readers_cannot_use_it(monkeypatch):
+    """본문이 필요한 호출부가 call_telegram_api를 고르면 조용히가 아니라 즉시 깨져야 한다.
+
+    플래그 하나짜리 API였다면 빠뜨린 호출부가 빈 dict를 받아 getUpdates는 "update 없음",
+    getMe는 username ""으로 조용히 퇴화한다. 반환형을 나눠 그 실수를 불가능하게 만든
+    것이 이 분리의 목적이다 (#257 자가리뷰).
+    """
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"ok": True, "result": [{"update_id": 1}]}
+
+    class FakeAsyncClient:
+        def __init__(self, *, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return None
+
+        async def post(self, url, **kwargs):
+            return FakeResponse()
+
+    monkeypatch.setattr("backend.telegram_notifier.httpx.AsyncClient", FakeAsyncClient)
+
+    assert await call_telegram_api("token", "getUpdates", payload={}) is None
+    assert await fetch_telegram_api("token", "getUpdates", payload={}) == {
+        "ok": True,
+        "result": [{"update_id": 1}],
+    }
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_telegram_notifier.py
+++ b/backend/tests/test_telegram_notifier.py
@@ -154,6 +154,32 @@ def test_httpx_telegram_bot_token_is_redacted_from_logs(caplog):
     assert "https://api.telegram.org/bot<redacted>/sendMessage" in caplog.text
 
 
+@pytest.mark.asyncio
+async def test_httpx_request_logging_is_redacted_end_to_end(caplog):
+    """httpx가 스스로 찍는 요청 로그에 토큰이 남지 않아야 한다 (#257).
+
+    이것만은 발생 지점 차단으로 못 막는다. 예외가 아니라 라이브러리의 정상 INFO 로그라
+    우리 코드를 어떻게 고쳐도 httpx가 request.url을 직접 찍는다. 그래서 리댁션 필터의
+    로거 이름 목록에 "httpx" 한 항목이 남아 있다.
+
+    로거 이름을 문자열로 비교하는 대신 실제 요청을 태워 잡는다 — httpx가 로거를
+    httpx._client 같은 이름으로 옮기면 필터는 조용히 무력화되는데(필터는 전파된
+    레코드에 걸리지 않는다), 이 테스트는 그때 빨갛게 깨진다. 목록에 기댄 리댁션이
+    조용히 되돌아가는 것이 이 이슈의 출발점이었다.
+    """
+    token = "8666951614:SECRET"
+    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    transport = httpx.MockTransport(lambda request: httpx.Response(200, json={"ok": True}))
+
+    with caplog.at_level(logging.INFO):
+        async with httpx.AsyncClient(transport=transport) as client:
+            await client.post(url, json={"text": "안녕"})
+
+    assert "HTTP Request" in caplog.text
+    assert token not in caplog.text
+    assert "bot<redacted>" in caplog.text
+
+
 def test_telegram_error_log_redacts_bot_token(caplog):
     telegram_url = "https://api.telegram.org/bot8666951614:SECRET/getUpdates"
 
@@ -171,9 +197,6 @@ async def test_send_text_posts_reply_markup(monkeypatch):
     class FakeResponse:
         def raise_for_status(self):
             return None
-
-        def json(self):
-            return {"ok": True}
 
     class FakeAsyncClient:
         def __init__(self, *, timeout):
@@ -218,9 +241,6 @@ async def test_answer_callback_query_posts_payload(monkeypatch):
         def raise_for_status(self):
             return None
 
-        def json(self):
-            return {"ok": True}
-
     class FakeAsyncClient:
         def __init__(self, *, timeout):
             self.timeout = timeout
@@ -257,9 +277,6 @@ async def test_send_chat_action_posts_typing_payload(monkeypatch):
         def raise_for_status(self):
             return None
 
-        def json(self):
-            return {"ok": True}
-
     class FakeAsyncClient:
         def __init__(self, *, timeout):
             self.timeout = timeout
@@ -292,9 +309,6 @@ async def test_set_bot_commands_posts_command_menu_payload(monkeypatch):
     class FakeResponse:
         def raise_for_status(self):
             return None
-
-        def json(self):
-            return {"ok": True}
 
     class FakeAsyncClient:
         def __init__(self, *, timeout):
@@ -444,6 +458,46 @@ async def test_call_telegram_api_raises_error_without_token(
     assert exc.status_code == 429
     assert "HTTP 429" in str(exc)
     assert "Too Many Requests: retry after 42" in str(exc)
+
+
+@pytest.mark.asyncio
+async def test_send_text_succeeds_when_200_body_is_not_json(monkeypatch):
+    """본문을 쓰지 않는 호출은 200의 본문이 JSON이 아니어도 성공해야 한다 (#257 자가리뷰).
+
+    call_telegram_api가 무조건 response.json()을 부르면, 본문을 읽지도 않는 sendMessage가
+    파싱 실패로 실패한다 — 리팩터링 전에는 없던 동작이고, send_text가 False를 돌려주면
+    _send_text_settled가 최대 4회 재시도한다. expect_body가 그 비대칭을 막는다.
+    """
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            raise ValueError("Expecting value: line 1 column 1 (char 0)")
+
+    class FakeAsyncClient:
+        def __init__(self, *, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return None
+
+        async def post(self, url, **kwargs):
+            return FakeResponse()
+
+    monkeypatch.setattr("backend.telegram_notifier.httpx.AsyncClient", FakeAsyncClient)
+    notifier = TelegramNotifier("token", "123")
+
+    assert await notifier.send_text("안녕") is True
+
+    # 반대로 본문을 읽는 호출은 파싱 실패를 실패로 남긴다. 조용히 {}로 넘기면 폴러가
+    # "update 없음"으로 읽고 로그도 백오프도 없이 다음 폴링으로 넘어간다.
+    with pytest.raises(TelegramApiError):
+        await call_telegram_api("token", "getUpdates", payload={}, expect_body=True)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 📝 개요

봇 토큰이 로그에 평문으로 남는 것을 막는 방식을 "로거 이름 목록에 리댁션 필터를 건다"에서 "예외에 URL을 아예 담지 않는다"로 바꿨다. 목록에 의존하던 재발 경로가 없어진다.

- 한계: 라이브러리가 스스로 찍는 요청 로그는 발생 지점 차단으로 도달할 수 없어 리댁션 항목 1개가 남는다. 종단 테스트로 묶어 조용히 뚫리지 않게 했다.
- 범위 밖: 그 서드파티 표면을 목록 없이 덮는 방향(출력 시점 일괄 세탁)은 이번에 택하지 않았다. 리뷰 승인 후 별도 이슈로 등록하겠다.

## 🔍 발견된 문제
1. 봇 토큰이 로그에 평문으로 남을 수 있었다. 리댁션이 "어느 로거로 찍는가" 목록에 기대고 있어서, 목록 밖에서 텔레그램 오류를 기록하면 토큰이 그대로 남는다. 가정이 아니라 실제로 두 번 열렸고, 그중 폴링 경로는 5초마다 재시도하며 매 회 기록한다.
2. 그 목록의 항목 하나는 한 번도 동작한 적이 없었다. 커버되고 있는 것처럼 읽히지만 실제로 걸러낸 레코드가 없다.
3. 목록에 남는 항목은 서드파티가 로거 이름을 바꾸면 조용히 무력화된다. 기존 테스트는 우리 목록만 고정할 뿐 그 상황을 잡지 못했다.

## 🔧 문제 해결 방법
1. 로그 시점이 아니라 발생 시점을 고쳤다. 텔레그램 API 호출을 관문 하나로 모으고 거기서 나가는 예외가 요청 URL을 담지 않게 해서, 어디서 로깅하든 샐 것이 없게 만들었다. 진단 정보는 상태 코드와 API가 주는 설명 문구로 대체해 오히려 늘렸다.
2. 동작하지 않던 항목을 제거했다. 해당 라이브러리는 애초에 URL을 로그에 담지 않는다는 것도 함께 확인했다.
3. 남은 항목을 실제 요청을 태우는 종단 테스트로 묶었다. 로거 이름이 바뀌면 조용히가 아니라 빨갛게 깨진다.

## ✅ 검증
<!-- CI가 잡지 않는 것만. 수동 재현, 실측 수치, 로컬에서만 확인한 것. -->
- 필터 전파 실측: 로깅 필터는 자식 로거에서 전파된 레코드를 타지 않는다. 같은 URL을 부모 이름으로 찍으면 리댁션되고 자식 이름으로 찍으면 그대로 통과하는 것을 확인해, 문제 2가 실재함을 확정했다.
- 서드파티 로거 이름 변경 시뮬레이션: 라이브러리가 자기 로거를 옮긴 상황을 재현하니 새 종단 테스트 1건만 실패하고 기존 리댁션 테스트 4건은 초록이었다. 문제 3의 사각이 이 테스트로 덮인다는 뜻이다.
- 뮤테이션 8건: 각 수정을 되돌렸을 때 의도한 테스트가 실제로 실패하는 것을 하나씩 확인했다. 어느 수정에 어느 테스트가 대응하는지는 각 커밋 메시지에 적었다.
- 동작 보존 확인: 리팩터링으로 응답 본문 처리가 바뀌면서 200 응답에 비-JSON이 왔을 때의 결과가 달라지는 것을 발견해, 호출 6곳 모두 이전 동작으로 되돌렸다.

## 🔗 관련 이슈
- Closes #257
