### PR TITLE
fix: 메모리 모드에서 사라지던 추론 각주 복구 (#273)

### DIFF
--- a/finus_nat/README.md
+++ b/finus_nat/README.md
@@ -30,12 +30,15 @@ router.yml과 router_nomemory.yml은 기본적으로 최근 대화 히스토리�
 무엇이 오든 — router.yml처럼 vendor `auto_memory_agent`가 끼든, router_nomemory.yml처럼
 바로 `finus_sqlite_transcript_agent`가 오든 — 부착 지점은 같습니다.
 
-**CLI 문자열 입력은 각주 없이 평문만 돌려줍니다.** `nat run --input ...`(= `run.sh`)처럼
-단일 문자열로 워크플로를 부르면 각주를 실을 응답 객체가 없으므로 본문 텍스트만
-반환합니다. 종전 `finus_sqlite_transcript_agent`는 이 경우에도 각주가 실린
-`ChatResponse`를 돌려줬으니 **동작이 바뀐 지점입니다**(#273). HTTP 경로(backend·
-scheduler)는 `messages`를 보내므로 영향받지 않습니다 — CLI에서 각주가 안 보인다면
-이것이 이유입니다.
+**단일 문자열 입력은 각주 없이 평문만 돌려줍니다.** `nat run --input ...`처럼 단일
+문자열로 워크플로를 부르면 각주를 실을 응답 객체가 없으므로 본문 텍스트만 반환합니다.
+종전 `finus_sqlite_transcript_agent`는 이 경우에도 각주가 실린 `ChatResponse`를
+돌려줬으니 **동작이 바뀐 지점입니다**(#273).
+
+`run.sh`에서 이 경로를 타는 것은 **`--once`뿐입니다.** 기본 모드는 채팅 REPL(`nat serve`
++ `finus-chat`)이고, REPL은 HTTP로 `messages`를 보내므로 각주가 그대로 나옵니다.
+backend·scheduler도 마찬가지로 영향받지 않습니다. 즉 각주가 안 보이는 경우는
+`run.sh --once`와 `nat run --input` 두 가지뿐입니다.
 
 이 지점을 vendor 바깥으로 올린 이유: `auto_memory_agent`의 `_response_fn` 시그니처가
 `(input_message: str) -> str`이라, 안쪽에서 `ChatResponse`에 붙인 두 필드가 그 래퍼를

--- a/finus_nat/README.md
+++ b/finus_nat/README.md
@@ -30,6 +30,13 @@ router.yml과 router_nomemory.yml은 기본적으로 최근 대화 히스토리�
 무엇이 오든 — router.yml처럼 vendor `auto_memory_agent`가 끼든, router_nomemory.yml처럼
 바로 `finus_sqlite_transcript_agent`가 오든 — 부착 지점은 같습니다.
 
+**CLI 문자열 입력은 각주 없이 평문만 돌려줍니다.** `nat run --input ...`(= `run.sh`)처럼
+단일 문자열로 워크플로를 부르면 각주를 실을 응답 객체가 없으므로 본문 텍스트만
+반환합니다. 종전 `finus_sqlite_transcript_agent`는 이 경우에도 각주가 실린
+`ChatResponse`를 돌려줬으니 **동작이 바뀐 지점입니다**(#273). HTTP 경로(backend·
+scheduler)는 `messages`를 보내므로 영향받지 않습니다 — CLI에서 각주가 안 보인다면
+이것이 이유입니다.
+
 이 지점을 vendor 바깥으로 올린 이유: `auto_memory_agent`의 `_response_fn` 시그니처가
 `(input_message: str) -> str`이라, 안쪽에서 `ChatResponse`에 붙인 두 필드가 그 래퍼를
 통과하면서 버려집니다. backend는 필드가 없으면 각주를 조용히 생략하므로, 예전

--- a/finus_nat/README.md
+++ b/finus_nat/README.md
@@ -25,11 +25,16 @@ router.yml과 router_nomemory.yml은 기본적으로 최근 대화 히스토리�
 넘기면 소비자가 실패·빈 결과까지 "확인한 자료"로 표시해, 답변이 근거하지 않은 데이터를
 근거로 제시하게 됩니다. 표기는 소비자가 정합니다(backend는 `(실패)`/`(결과 없음)`).
 
-**router_nomemory.yml(기본값)에서만 동작합니다.** router.yml(`--memory`)은 최상위
-workflow가 vendor `auto_memory_agent`인데, 그 `_response_fn` 시그니처가
-`(input_message: str) -> str`이라 안쪽에서 `ChatResponse`에 붙인 두 필드가 래퍼를
-통과하면서 버려집니다. backend는 필드가 없으면 각주를 조용히 생략하므로, 메모리
-모드에서는 경고 없이 각주만 사라집니다.
+**두 라우터 모두 동작합니다.** 두 config의 최상위 `workflow`는
+`finus_reasoning_trace_agent`이고, 각주는 오직 여기서만 붙습니다(#273). 그 아래에
+무엇이 오든 — router.yml처럼 vendor `auto_memory_agent`가 끼든, router_nomemory.yml처럼
+바로 `finus_sqlite_transcript_agent`가 오든 — 부착 지점은 같습니다.
+
+이 지점을 vendor 바깥으로 올린 이유: `auto_memory_agent`의 `_response_fn` 시그니처가
+`(input_message: str) -> str`이라, 안쪽에서 `ChatResponse`에 붙인 두 필드가 그 래퍼를
+통과하면서 버려집니다. backend는 필드가 없으면 각주를 조용히 생략하므로, 예전
+router.yml에서는 경고도 예외도 없이 각주만 사라졌습니다(#273). vendor를 감싸는 대신
+부착 지점을 올렸으므로 NAT 업그레이드로 vendor 시그니처가 바뀌어도 깨지지 않습니다.
 
 ## 1. Mem0 self-hosted server 설정
 

--- a/finus_nat/configs/router.yml
+++ b/finus_nat/configs/router.yml
@@ -61,18 +61,21 @@ functions:
     db_path: ${FINUS_TRANSCRIPT_DB_PATH:-.state/conversations.sqlite3}
     max_history_messages: 30
 
-# ⚠️ 이 모드에서는 추론 각주(#260)가 표시되지 않습니다.
-# 최상위 workflow인 vendor auto_memory_agent의 _response_fn 시그니처가
-# (input_message: str) -> str 이라, 안쪽 transcript_router_agent가 ChatResponse에
-# 붙인 routed_agent/tools_used가 이 래퍼를 통과하면서 버려집니다.
-# backend는 두 필드가 없으면 각주를 조용히 생략하므로 경고 없이 각주만 사라집니다.
-# router_nomemory.yml(기본값)에서는 정상 동작합니다.
-workflow: # Mem0 auto_memory_agent를 설정합니다.
-  _type: auto_memory_agent
-  inner_agent_name: transcript_router_agent
-  memory_name: router_mem0_memory
-  llm_name: router_openai_llm
-  add_params:
-    infer: false
-  verbose: true
-  description: "Fin-Us router supervisor with separate Mem0 memory"
+  memory_router_agent: # Mem0 auto_memory_agent를 설정합니다.
+    _type: auto_memory_agent
+    inner_agent_name: transcript_router_agent
+    memory_name: router_mem0_memory
+    llm_name: router_openai_llm
+    add_params:
+      infer: false
+    verbose: true
+    description: "Fin-Us router supervisor with separate Mem0 memory"
+
+# 추론 각주(#260)는 최상위 finus_reasoning_trace_agent가 붙입니다 — vendor
+# auto_memory_agent 바깥입니다(#273). vendor _response_fn 시그니처가
+# (input_message: str) -> str 이라, 안쪽에서 ChatResponse에 붙인
+# routed_agent/tools_used는 이 래퍼를 통과하면서 버려집니다. 부착 지점을 그 위로
+# 올렸으므로 router_nomemory.yml과 같은 자리에서 각주가 실립니다.
+workflow:
+  _type: finus_reasoning_trace_agent
+  inner_agent_name: memory_router_agent

--- a/finus_nat/configs/router_nomemory.yml
+++ b/finus_nat/configs/router_nomemory.yml
@@ -36,8 +36,13 @@ functions:
         function_name: diary_branch_agent
         description: "당일 거래 조회, 매매일지 초안, 거래 회고와 기록 정리."
 
+  transcript_router_agent:
+    _type: finus_sqlite_transcript_agent
+    inner_agent_name: router_supervisor_agent
+    db_path: ${FINUS_TRANSCRIPT_DB_PATH:-.state/conversations.sqlite3}
+    max_history_messages: 30
+
+# 추론 각주(#260)의 부착 지점 — router.yml과 같은 최상위 자리입니다(#273).
 workflow:
-  _type: finus_sqlite_transcript_agent
-  inner_agent_name: router_supervisor_agent
-  db_path: ${FINUS_TRANSCRIPT_DB_PATH:-.state/conversations.sqlite3}
-  max_history_messages: 30
+  _type: finus_reasoning_trace_agent
+  inner_agent_name: transcript_router_agent

--- a/finus_nat/src/nat_finus_nat/agents.py
+++ b/finus_nat/src/nat_finus_nat/agents.py
@@ -644,6 +644,13 @@ async def finus_reasoning_trace_agent(config: FinusReasoningTraceAgentConfig, bu
     vendor 래퍼를 ``ChatResponse``가 통과하도록 감싸는 대안도 있었으나, vendor
     시그니처에 의존하므로 NAT 업그레이드 때 같은 방식으로 다시 깨진다. 부착 지점을
     vendor 바깥으로 올리면 vendor가 무엇을 버리든 무관해진다.
+
+    **알려진 한계 (#273 리뷰):** vendor ``_response_fn``은 예외를 삼키고 ``str(ex)``를
+    답변으로 돌려준다(``router.yml``이 ``verbose: true``). supervisor는 브랜치를 부르기
+    **전에** ``_trace_route()``를 부르므로, 브랜치가 터지면 ``routed_agent``가 남은 채
+    에러 텍스트가 올라오고 여기서 그 텍스트에 각주가 붙는다. 메모리 모드는 여태 각주가
+    없었으니 이 PR로 새로 도달 가능해진 경로다. 막으려면 vendor의 실패 문자열을
+    알아봐야 하는데, 그게 바로 이 함수가 없애려던 결합이라 그대로 둔다.
     """
     inner_agent = await builder.get_function(config.inner_agent_name)
 
@@ -659,8 +666,14 @@ async def finus_reasoning_trace_agent(config: FinusReasoningTraceAgentConfig, bu
         finally:
             REASONING_TRACE.reset(trace_token)
 
+        # 문자열 입력(`nat run --input`)은 평문으로 돌려준다 — 각주를 실을 곳이 없다.
+        # **종전 동작과 다르다.** 옛 transcript agent는 isinstance 검사가 먼저라
+        # 문자열 입력에도 각주가 실린 ChatResponse를 돌려줬고, 그 아래 `is_string`
+        # 분기는 안쪽(supervisor)이 항상 ChatResponse를 반환하므로 도달하지 않는
+        # 죽은 코드였다 — "실을 곳이 없다"는 주석이 실행되지 않는 분기에 붙어 있었다.
+        # 여기서는 검사 순서를 뒤집어 그 의도를 실제로 실행한다. HTTP 경로(backend·
+        # scheduler)는 messages를 보내므로 영향받지 않는다.
         if chat_request_or_message.is_string:
-            # 문자열 반환 경로(`nat run --input` 등)는 각주를 실을 곳이 없다.
             return chat_response_plain_text(result)
         if isinstance(result, ChatResponse):
             return with_reasoning_trace(result, trace)

--- a/finus_nat/src/nat_finus_nat/agents.py
+++ b/finus_nat/src/nat_finus_nat/agents.py
@@ -622,6 +622,55 @@ def with_reasoning_trace(response: ChatResponse, trace: ReasoningTrace) -> ChatR
     )
 
 
+class FinusReasoningTraceAgentConfig(FunctionBaseConfig, name="finus_reasoning_trace_agent"):
+    inner_agent_name: FunctionRef = Field(..., description="Agent/workflow to invoke with a reasoning-trace box installed.")
+    description: str = Field(default="Fin-Us agent that attaches the reasoning trace footnote (#260)")
+
+
+@register_function(config_type=FinusReasoningTraceAgentConfig, framework_wrappers=[LLMFrameworkEnum.LANGCHAIN])
+async def finus_reasoning_trace_agent(config: FinusReasoningTraceAgentConfig, builder: Builder):
+    """추론 각주(#260)의 **유일한** 소유 지점 — 박스를 심고, 결과를 응답에 붙인다 (#273).
+
+    두 라우터 config가 이 함수를 최상위 ``workflow``로 쓰고, 그 아래 무엇이 오든
+    (``auto_memory_agent``가 끼든 안 끼든) 각주는 같은 자리에서 붙는다. 부착 지점이
+    config에 따라 갈리지 않는 것이 이 함수가 존재하는 이유의 전부다.
+
+    이전에는 ``finus_sqlite_transcript_agent``가 그 역할을 겸했는데, ``router.yml``에서는
+    그 위에 vendor ``auto_memory_agent``가 얹힌다. vendor ``_response_fn``의 시그니처가
+    ``(input_message: str) -> str``이라 안쪽이 ``ChatResponse``에 붙인 ``routed_agent``/
+    ``tools_used``가 래퍼를 통과하면서 사라졌다. backend는 두 필드가 없으면 각주를
+    조용히 생략하므로(#260) 메모리 모드에서는 로그도 예외도 없이 기능만 없어졌다.
+
+    vendor 래퍼를 ``ChatResponse``가 통과하도록 감싸는 대안도 있었으나, vendor
+    시그니처에 의존하므로 NAT 업그레이드 때 같은 방식으로 다시 깨진다. 부착 지점을
+    vendor 바깥으로 올리면 vendor가 무엇을 버리든 무관해진다.
+    """
+    inner_agent = await builder.get_function(config.inner_agent_name)
+
+    async def _response_fn(chat_request_or_message: ChatRequestOrMessage) -> ChatResponse | str:
+        # 박스는 여기서 한 번만 심는다. 안쪽(supervisor, _run_with_gate)은 mutate만 한다 —
+        # ContextVar.set()은 LangGraph의 copy_context() 경계를 넘어 바깥으로 전파되지
+        # 않기 때문이다(DataToolLedger와 동일). 반대 방향(바깥→안쪽)은 전파되므로
+        # vendor auto_memory_agent가 중간에 끼어 있어도 안쪽이 같은 박스를 본다.
+        trace = ReasoningTrace()
+        trace_token = REASONING_TRACE.set(trace)
+        try:
+            result = await inner_agent.ainvoke(chat_request_or_message)
+        finally:
+            REASONING_TRACE.reset(trace_token)
+
+        if chat_request_or_message.is_string:
+            # 문자열 반환 경로(`nat run --input` 등)는 각주를 실을 곳이 없다.
+            return chat_response_plain_text(result)
+        if isinstance(result, ChatResponse):
+            return with_reasoning_trace(result, trace)
+        # vendor auto_memory_agent는 str을 돌려준다 — 여기서 ChatResponse로 만들며
+        # 각주를 붙이므로, 안쪽에서 무엇이 버려졌는지와 무관하게 필드가 실린다.
+        return with_reasoning_trace(ChatResponse.from_string(str(result), usage=Usage()), trace)
+
+    yield FunctionInfo.from_fn(_response_fn, description=config.description)
+
+
 def nat_chat_extra_headers(conversation_id: str) -> dict[str, str]:
     return {
         "Content-Type": "application/json",
@@ -785,15 +834,11 @@ async def finus_sqlite_transcript_agent(config: FinusSqliteTranscriptAgentConfig
         forward_messages = history + chat_request.messages
         forward = _chat_request_with_messages(chat_request, forward_messages)
 
-        # #260: 추론 기록 박스를 workflow 최상단에서 한 번만 심는다. 안쪽(supervisor,
-        # _run_with_gate)은 박스를 mutate하기만 한다 — ContextVar.set()은 LangGraph의
-        # copy_context() 경계를 넘어 바깥으로 전파되지 않기 때문이다(DataToolLedger와 동일).
-        trace = ReasoningTrace()
-        trace_token = REASONING_TRACE.set(trace)
-        try:
-            result = await inner_agent.ainvoke(forward)
-        finally:
-            REASONING_TRACE.reset(trace_token)
+        # 추론 기록 박스(#260)는 이 에이전트가 심지 않는다 — 최상위
+        # finus_reasoning_trace_agent가 심고 붙인다(#273). 여기서 겸하면
+        # router.yml처럼 위에 vendor auto_memory_agent가 얹히는 config에서
+        # 부착 결과가 그 래퍼에 막혀 조용히 사라진다.
+        result = await inner_agent.ainvoke(forward)
         assistant = chat_response_plain_text(result)
 
         to_store: list[tuple[str, str]] = []
@@ -808,11 +853,10 @@ async def finus_sqlite_transcript_agent(config: FinusSqliteTranscriptAgentConfig
         _append_messages(db_path, conversation_id, to_store)
 
         if isinstance(result, ChatResponse):
-            return with_reasoning_trace(result, trace)
+            return result
         if chat_request_or_message.is_string:
-            # 문자열 반환 경로(chat_cli 등)는 실을 곳이 없으므로 각주 메타데이터를 붙이지 않는다.
             return str(result)
-        return with_reasoning_trace(ChatResponse.from_string(str(result), usage=Usage()), trace)
+        return ChatResponse.from_string(str(result), usage=Usage())
 
     yield FunctionInfo.from_fn(_response_fn, description=config.description)
 

--- a/finus_nat/tests/test_agent_configs.py
+++ b/finus_nat/tests/test_agent_configs.py
@@ -474,6 +474,48 @@ def test_readonly_config_accepts_asset_classes(name: str):
     assert config.trading_tool_name == name
 
 
+# ---------------------------------------------------------------------------
+# #273 회귀 가드 — 두 라우터의 최상위 workflow가 각주 부착 지점을 공유하는지
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("config_path", _ROUTER_PATHS, ids=[p.name for p in _ROUTER_PATHS])
+def test_router_workflow_is_the_reasoning_trace_agent(config_path: Path):
+    """#273: 두 라우터 모두 최상위 workflow가 finus_reasoning_trace_agent여야 한다.
+
+    각주(#260)는 이 한 지점에서만 붙는다. 위에 다른 래퍼를 얹으면 — 특히 vendor
+    ``auto_memory_agent``처럼 ``(input_message: str) -> str`` 시그니처인 래퍼를 —
+    ``routed_agent``/``tools_used``가 그 경계에서 버려지고, backend는 필드가 없으면
+    각주를 **조용히** 생략한다. 관측 형태가 "각주가 안 나온다"뿐이라 런타임에는
+    드러나지 않으므로 config 모양을 여기서 고정한다.
+    """
+    import nat_finus_nat.register  # noqa: F401 - 등록 트리거만 필요
+    from nat.runtime.loader import load_config
+    from nat_finus_nat.agents import FinusReasoningTraceAgentConfig
+
+    workflow = load_config(config_path).workflow
+    assert isinstance(workflow, FinusReasoningTraceAgentConfig), (
+        f"{config_path.name}: 최상위 workflow는 finus_reasoning_trace_agent여야 합니다. "
+        f"실제 타입: {type(workflow).__name__}"
+    )
+
+
+def test_memory_router_wraps_the_transcript_agent_below_the_trace_agent():
+    """#273: router.yml의 auto_memory_agent는 workflow가 아니라 그 아래 함수여야 한다.
+
+    체인은 finus_reasoning_trace_agent → auto_memory_agent → finus_sqlite_transcript_agent다.
+    auto_memory_agent가 다시 최상위로 올라가면 각주가 그 str 경계에서 사라진다.
+    """
+    import nat_finus_nat.register  # noqa: F401 - 등록 트리거만 필요
+    from nat.runtime.loader import load_config
+
+    config = load_config(CONFIGS_ROOT / "router.yml")
+    assert str(config.workflow.inner_agent_name) == "memory_router_agent"
+
+    memory_agent = config.functions["memory_router_agent"]
+    assert type(memory_agent).static_type() == "auto_memory_agent"
+    assert str(memory_agent.inner_agent_name) == "transcript_router_agent"
+
+
 def test_kis_agents_share_identical_system_prompt():
     """monitoring/strategy/trading 프롬프트는 의도적으로 동일하다 - 한 곳만 수정되는 드리프트를 막는다."""
     import nat_finus_nat.register  # noqa: F401 - 등록 트리거만 필요

--- a/finus_nat/tests/test_reasoning_trace.py
+++ b/finus_nat/tests/test_reasoning_trace.py
@@ -27,6 +27,7 @@ from nat.data_models.api_server import (
 from nat.utils.type_converter import GlobalTypeConverter
 
 from nat_finus_nat.agents import (
+    MEMORY_PROMPT_PREFIX,
     FinusReasoningTraceAgentConfig,
     FinusSqliteTranscriptAgentConfig,
     _run_with_gate,
@@ -502,7 +503,15 @@ def _compiled_vendor_graph(transcript_fn):
     from langgraph.graph import END, START, StateGraph
 
     async def inner_node(state: _VendorState) -> _VendorState:
-        result = await transcript_fn(ChatRequestOrMessage(input_message=state["text"]))
+        # vendor `inner_agent_node`는 안쪽을 **문자열이 아니라** `ChatRequest(messages=...)`로
+        # 부른다 — 그 앞 `memory_retrieve_node`가 회수한 기억을 `MEMORY_PROMPT_PREFIX`
+        # 시스템 메시지로 마지막 user 앞에 끼워 넣기 때문이다. 여기를 `input_message=`로
+        # 흉내내면 transcript agent가 production에서 타지 않는 문자열 분기로 들어가고,
+        # 기억 시스템 메시지를 걸러내는 경로도 안 밟힌다 (#291 자가리뷰).
+        result = await transcript_fn(ChatRequestOrMessage(messages=[
+            {"role": "system", "content": f"{MEMORY_PROMPT_PREFIX}\n사용자는 삼성전자를 보유 중이다."},
+            {"role": "user", "content": state["text"]},
+        ]))
         # vendor는 마지막 메시지의 content(str)만 상태에 남긴다 — 필드 소실 지점.
         return {"text": chat_response_plain_text(result)}
 

--- a/finus_nat/tests/test_reasoning_trace.py
+++ b/finus_nat/tests/test_reasoning_trace.py
@@ -23,10 +23,15 @@ from nat.data_models.api_server import (
     UserMessageContentRoleType,
 )
 
+from nat.utils.type_converter import GlobalTypeConverter
+
 from nat_finus_nat.agents import (
+    FinusReasoningTraceAgentConfig,
     FinusSqliteTranscriptAgentConfig,
     _run_with_gate,
     _trace_route,
+    chat_response_plain_text,
+    finus_reasoning_trace_agent,
     finus_sqlite_transcript_agent,
     with_reasoning_trace,
 )
@@ -414,42 +419,110 @@ def test_extra_fields_survive_the_fastapi_response_model_boundary():
 
 # ---------------------------------------------------------------------------
 # workflow 최상단 통합 — 실제 응답에 실리는지
+#
+# 각주는 최상위 finus_reasoning_trace_agent 한 곳에서만 붙는다(#273). 아래 두
+# 헬퍼는 두 라우터 config의 체인을 그대로 재현한다 — 부착 지점이 같으므로 같은
+# 단언이 양쪽에 걸린다.
 # ---------------------------------------------------------------------------
 
-@asynccontextmanager
-async def _transcript_agent_fn(tmp_path, inner_response_fn):
-    """finus_sqlite_transcript_agent를 만들어 내부 호출 함수를 넘긴다."""
-    inner = MagicMock()
-    inner.ainvoke = AsyncMock(side_effect=inner_response_fn)
+def _branch_recording(route: str, *tool_names: str, answer: str = "답변"):
+    """supervisor + 브랜치가 하는 일을 흉내내는 가짜 내부 에이전트 함수.
 
-    builder = MagicMock()
-    builder.get_function = AsyncMock(return_value=inner)
-
-    config = FinusSqliteTranscriptAgentConfig(
-        inner_agent_name="router_supervisor_agent",
-        db_path=str(tmp_path / "conversations.sqlite3"),
-    )
-    async with finus_sqlite_transcript_agent(config, builder) as function_info:
-        yield function_info.single_fn
-
-
-@pytest.mark.asyncio
-async def test_transcript_agent_attaches_trace_to_response(tmp_path):
-    """최상단이 심은 박스에 안쪽이 기록하고, 그 결과가 응답에 실린다."""
+    최상단이 심은 박스를 mutate하기만 한다 — 실제 _trace_route/_trace_ledger_tools와 같다.
+    """
 
     async def inner_response(_request):
-        # supervisor와 브랜치가 하는 일을 그대로 흉내낸다 — 박스를 mutate한다.
-        _trace_route("news_agent")
+        _trace_route(route)
         ledger = DataToolLedger()
         ledger_token = DATA_TOOL_LEDGER.set(ledger)
         try:
-            _record_to_ledger("finus_market_news", "뉴스 3건")
+            for name in tool_names:
+                _record_to_ledger(name, "뉴스 3건")
         finally:
             DATA_TOOL_LEDGER.reset(ledger_token)
-        REASONING_TRACE.get().record_ledger_tools(ledger)
-        return ChatResponse.from_string("삼성전자 뉴스입니다.", usage=Usage())
+        trace = REASONING_TRACE.get()
+        assert trace is not None, "최상단이 박스를 심어 안쪽까지 전파돼야 한다"
+        trace.record_ledger_tools(ledger)
+        return ChatResponse.from_string(answer, usage=Usage())
 
-    async with _transcript_agent_fn(tmp_path, inner_response) as response_fn:
+    return inner_response
+
+
+def _as_function(response_fn) -> MagicMock:
+    fn = MagicMock()
+    fn.ainvoke = AsyncMock(side_effect=response_fn)
+    return fn
+
+
+def _builder_returning(function_mock: MagicMock) -> MagicMock:
+    builder = MagicMock()
+    builder.get_function = AsyncMock(return_value=function_mock)
+    return builder
+
+
+@asynccontextmanager
+async def _nomemory_chain(tmp_path, inner_response_fn):
+    """router_nomemory.yml 체인: trace_agent → transcript_agent → 브랜치."""
+    transcript_config = FinusSqliteTranscriptAgentConfig(
+        inner_agent_name="router_supervisor_agent",
+        db_path=str(tmp_path / "conversations.sqlite3"),
+    )
+    async with finus_sqlite_transcript_agent(
+        transcript_config, _builder_returning(_as_function(inner_response_fn))
+    ) as transcript_info:
+        transcript_fn = transcript_info.single_fn
+        async with finus_reasoning_trace_agent(
+            FinusReasoningTraceAgentConfig(inner_agent_name="transcript_router_agent"),
+            _builder_returning(_as_function(transcript_fn)),
+        ) as trace_info:
+            yield trace_info.single_fn
+
+
+@asynccontextmanager
+async def _memory_chain(tmp_path, inner_response_fn):
+    """router.yml 체인: trace_agent → auto_memory_agent(vendor) → transcript_agent → 브랜치.
+
+    가운데 vendor 흉내는 실제 `_response_fn(input_message: str) -> str` 시그니처를
+    그대로 재현한다 — NAT 타입 변환이 요청을 문자열로 눕히고, 반환도 문자열이라
+    안쪽이 ChatResponse에 붙인 추가 필드는 **여기서 전부 사라진다**. #273의 원인이
+    바로 이 지점이므로, 흉내를 느슨하게 만들면 회귀 테스트가 아무것도 지키지 않는다.
+    """
+    transcript_config = FinusSqliteTranscriptAgentConfig(
+        inner_agent_name="router_supervisor_agent",
+        db_path=str(tmp_path / "conversations.sqlite3"),
+    )
+    async with finus_sqlite_transcript_agent(
+        transcript_config, _builder_returning(_as_function(inner_response_fn))
+    ) as transcript_info:
+        transcript_fn = transcript_info.single_fn
+
+        async def vendor_auto_memory(request):
+            text = GlobalTypeConverter.get().convert(request, to_type=str)
+            result = await transcript_fn(ChatRequestOrMessage(input_message=text))
+            return chat_response_plain_text(result)
+
+        async with finus_reasoning_trace_agent(
+            FinusReasoningTraceAgentConfig(inner_agent_name="memory_router_agent"),
+            _builder_returning(_as_function(vendor_auto_memory)),
+        ) as trace_info:
+            yield trace_info.single_fn
+
+
+_CHAINS = [(_nomemory_chain, "router_nomemory.yml"), (_memory_chain, "router.yml")]
+_CHAIN_IDS = [name for _, name in _CHAINS]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("chain,_config_name", _CHAINS, ids=_CHAIN_IDS)
+async def test_workflow_attaches_trace_to_response(chain, _config_name, tmp_path):
+    """최상단이 심은 박스에 안쪽이 기록하고, 그 결과가 응답에 실린다.
+
+    router.yml 파라미터가 #273의 회귀 가드다 — 부착 지점이 vendor 안쪽으로 돌아가면
+    두 필드가 str 경계에서 버려져 red가 된다.
+    """
+    async with chain(tmp_path, _branch_recording(
+        "news_agent", "finus_market_news", answer="삼성전자 뉴스입니다."
+    )) as response_fn:
         result = await response_fn(
             ChatRequestOrMessage(messages=[{"role": "user", "content": "삼성전자 뉴스"}])
         )
@@ -461,15 +534,15 @@ async def test_transcript_agent_attaches_trace_to_response(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_transcript_agent_does_not_leak_trace_between_requests(tmp_path):
+@pytest.mark.parametrize("chain,_config_name", _CHAINS, ids=_CHAIN_IDS)
+async def test_workflow_does_not_leak_trace_between_requests(chain, _config_name, tmp_path):
     """앞선 요청의 라우팅·도구가 다음 요청의 각주로 새지 않는다."""
     routes = ["news_agent", "trading_agent"]
 
-    async def inner_response(_request):
-        _trace_route(routes.pop(0))
-        return ChatResponse.from_string("답변", usage=Usage())
+    async def inner_response(request):
+        return await _branch_recording(routes.pop(0))(request)
 
-    async with _transcript_agent_fn(tmp_path, inner_response) as response_fn:
+    async with chain(tmp_path, inner_response) as response_fn:
         first = await response_fn(
             ChatRequestOrMessage(messages=[{"role": "user", "content": "뉴스"}])
         )
@@ -480,3 +553,45 @@ async def test_transcript_agent_does_not_leak_trace_between_requests(tmp_path):
     assert first.model_dump()["routed_agent"] == "news_agent"
     assert second.model_dump()["routed_agent"] == "trading_agent"
     assert second.model_dump()["tools_used"] == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("chain,_config_name", _CHAINS, ids=_CHAIN_IDS)
+async def test_workflow_returns_plain_text_for_string_input(chain, _config_name, tmp_path):
+    """`nat run --input` 같은 문자열 경로는 각주를 실을 곳이 없으므로 본문만 돌려준다."""
+    async with chain(tmp_path, _branch_recording(
+        "news_agent", "finus_market_news", answer="삼성전자 뉴스입니다."
+    )) as response_fn:
+        result = await response_fn(ChatRequestOrMessage(input_message="삼성전자 뉴스"))
+
+    assert result == "삼성전자 뉴스입니다."
+
+
+@pytest.mark.asyncio
+async def test_transcript_agent_no_longer_owns_the_trace_box(tmp_path):
+    """transcript_agent는 박스를 심지도 붙이지도 않는다 (#273).
+
+    겸하면 박스가 두 겹이 되어(안쪽 set이 바깥 박스를 가림) 최상단이 심은 박스는
+    빈 채로 남고, router.yml에서는 다시 각주가 조용히 사라진다.
+    """
+    seen: list[object] = []
+
+    async def inner_response(_request):
+        seen.append(REASONING_TRACE.get())
+        return ChatResponse.from_string("답변", usage=Usage())
+
+    transcript_config = FinusSqliteTranscriptAgentConfig(
+        inner_agent_name="router_supervisor_agent",
+        db_path=str(tmp_path / "conversations.sqlite3"),
+    )
+    async with finus_sqlite_transcript_agent(
+        transcript_config, _builder_returning(_as_function(inner_response))
+    ) as transcript_info:
+        result = await transcript_info.single_fn(
+            ChatRequestOrMessage(messages=[{"role": "user", "content": "뉴스"}])
+        )
+
+    assert seen == [None], "transcript_agent가 박스를 심으면 최상단 박스를 가린다"
+    dumped = result.model_dump()
+    assert "routed_agent" not in dumped
+    assert "tools_used" not in dumped

--- a/finus_nat/tests/test_reasoning_trace.py
+++ b/finus_nat/tests/test_reasoning_trace.py
@@ -545,12 +545,12 @@ async def _memory_chain(tmp_path, inner_response_fn):
             yield trace_info.single_fn
 
 
-_CHAINS = [(_nomemory_chain, "router_nomemory.yml"), (_memory_chain, "router.yml")]
-_CHAIN_IDS = [name for _, name in _CHAINS]
+_ROUTER_CHAINS = [(_nomemory_chain, "router_nomemory.yml"), (_memory_chain, "router.yml")]
+_ROUTER_CHAIN_IDS = [name for _, name in _ROUTER_CHAINS]
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("chain,_config_name", _CHAINS, ids=_CHAIN_IDS)
+@pytest.mark.parametrize("chain,_config_name", _ROUTER_CHAINS, ids=_ROUTER_CHAIN_IDS)
 async def test_workflow_attaches_trace_to_response(chain, _config_name, tmp_path):
     """최상단이 심은 박스에 안쪽이 기록하고, 그 결과가 응답에 실린다.
 
@@ -571,7 +571,7 @@ async def test_workflow_attaches_trace_to_response(chain, _config_name, tmp_path
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("chain,_config_name", _CHAINS, ids=_CHAIN_IDS)
+@pytest.mark.parametrize("chain,_config_name", _ROUTER_CHAINS, ids=_ROUTER_CHAIN_IDS)
 async def test_workflow_does_not_leak_trace_between_requests(chain, _config_name, tmp_path):
     """앞선 요청의 라우팅·도구가 다음 요청의 각주로 새지 않는다."""
     routes = ["news_agent", "trading_agent"]
@@ -593,7 +593,7 @@ async def test_workflow_does_not_leak_trace_between_requests(chain, _config_name
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("chain,_config_name", _CHAINS, ids=_CHAIN_IDS)
+@pytest.mark.parametrize("chain,_config_name", _ROUTER_CHAINS, ids=_ROUTER_CHAIN_IDS)
 async def test_workflow_returns_plain_text_for_string_input(chain, _config_name, tmp_path):
     """`nat run --input` 같은 문자열 경로는 각주를 실을 곳이 없으므로 본문만 돌려준다."""
     async with chain(tmp_path, _branch_recording(
@@ -610,7 +610,12 @@ async def test_transcript_agent_no_longer_owns_the_trace_box(tmp_path):
 
     겸하면 박스가 두 겹이 되어(안쪽 set이 바깥 박스를 가림) 최상단이 심은 박스는
     빈 채로 남고, router.yml에서는 다시 각주가 조용히 사라진다.
+
+    최상단 역할을 대신해 sentinel 박스를 미리 심고, 안쪽이 **그 박스 그대로**를 보는지
+    동일성으로 확인한다. ``is None``으로 확인하면 ContextVar 기본값이 바뀌는 날
+    의도와 무관한 이유로 깨진다 (#291 리뷰).
     """
+    outer_box = ReasoningTrace()
     seen: list[object] = []
 
     async def inner_response(_request):
@@ -621,14 +626,18 @@ async def test_transcript_agent_no_longer_owns_the_trace_box(tmp_path):
         inner_agent_name="router_supervisor_agent",
         db_path=str(tmp_path / "conversations.sqlite3"),
     )
-    async with finus_sqlite_transcript_agent(
-        transcript_config, _builder_returning(_as_function(inner_response))
-    ) as transcript_info:
-        result = await transcript_info.single_fn(
-            ChatRequestOrMessage(messages=[{"role": "user", "content": "뉴스"}])
-        )
+    outer_token = REASONING_TRACE.set(outer_box)
+    try:
+        async with finus_sqlite_transcript_agent(
+            transcript_config, _builder_returning(_as_function(inner_response))
+        ) as transcript_info:
+            result = await transcript_info.single_fn(
+                ChatRequestOrMessage(messages=[{"role": "user", "content": "뉴스"}])
+            )
+    finally:
+        REASONING_TRACE.reset(outer_token)
 
-    assert seen == [None], "transcript_agent가 박스를 심으면 최상단 박스를 가린다"
+    assert seen and seen[0] is outer_box, "transcript_agent가 박스를 심으면 최상단 박스를 가린다"
     dumped = result.model_dump()
     assert "routed_agent" not in dumped
     assert "tools_used" not in dumped

--- a/finus_nat/tests/test_reasoning_trace.py
+++ b/finus_nat/tests/test_reasoning_trace.py
@@ -12,6 +12,7 @@
 
 import pytest
 from contextlib import asynccontextmanager
+from typing import TypedDict
 from unittest.mock import AsyncMock, MagicMock
 
 from nat.data_models.api_server import (
@@ -478,14 +479,50 @@ async def _nomemory_chain(tmp_path, inner_response_fn):
             yield trace_info.single_fn
 
 
+class _VendorState(TypedDict):
+    """vendor AutoMemoryWrapperState 자리 — 홉을 재현하는 데 필요한 최소 필드."""
+
+    text: str
+
+
+def _compiled_vendor_graph(transcript_fn):
+    """vendor가 안쪽을 부르는 방식(CompiledStateGraph.ainvoke)까지 재현한다.
+
+    #273 수정은 두 가정 위에 서 있다.
+
+    1. vendor의 str 경계에서 ChatResponse의 추가 필드가 버려진다 — 그래서 부착
+       지점을 그 **바깥**으로 올려야 한다.
+    2. 최상단이 심은 박스가 그 경계를 **안쪽으로는** 넘어간다 — 그래서 올려도
+       supervisor/브랜치가 같은 박스를 기록할 수 있다.
+
+    transcript_fn을 같은 컨텍스트에서 그냥 await하면 1번만 덮이고 2번은 검증되지
+    않는다. LangGraph는 노드를 copy_context()로 감싸 실행하므로, 실제로 건너야
+    하는 경계는 이 홉이다. 노드 하나짜리 그래프면 그 경계를 그대로 만든다.
+    """
+    from langgraph.graph import END, START, StateGraph
+
+    async def inner_node(state: _VendorState) -> _VendorState:
+        result = await transcript_fn(ChatRequestOrMessage(input_message=state["text"]))
+        # vendor는 마지막 메시지의 content(str)만 상태에 남긴다 — 필드 소실 지점.
+        return {"text": chat_response_plain_text(result)}
+
+    graph = StateGraph(_VendorState)
+    graph.add_node("inner", inner_node)
+    graph.add_edge(START, "inner")
+    graph.add_edge("inner", END)
+    return graph.compile()
+
+
 @asynccontextmanager
 async def _memory_chain(tmp_path, inner_response_fn):
     """router.yml 체인: trace_agent → auto_memory_agent(vendor) → transcript_agent → 브랜치.
 
-    가운데 vendor 흉내는 실제 `_response_fn(input_message: str) -> str` 시그니처를
-    그대로 재현한다 — NAT 타입 변환이 요청을 문자열로 눕히고, 반환도 문자열이라
-    안쪽이 ChatResponse에 붙인 추가 필드는 **여기서 전부 사라진다**. #273의 원인이
-    바로 이 지점이므로, 흉내를 느슨하게 만들면 회귀 테스트가 아무것도 지키지 않는다.
+    가운데 vendor 흉내는 실제 `_response_fn(input_message: str) -> str` 시그니처와
+    `graph.ainvoke(state)` 홉을 함께 재현한다 — NAT 타입 변환이 요청을 문자열로
+    눕히고, 반환도 문자열이라 안쪽이 ChatResponse에 붙인 추가 필드는 **여기서 전부
+    사라진다**. #273의 원인이 바로 이 지점이므로, 흉내를 느슨하게 만들면 회귀
+    테스트가 아무것도 지키지 않는다. LangGraph 홉을 넣는 이유는
+    :func:`_compiled_vendor_graph` 참고.
     """
     transcript_config = FinusSqliteTranscriptAgentConfig(
         inner_agent_name="router_supervisor_agent",
@@ -494,12 +531,12 @@ async def _memory_chain(tmp_path, inner_response_fn):
     async with finus_sqlite_transcript_agent(
         transcript_config, _builder_returning(_as_function(inner_response_fn))
     ) as transcript_info:
-        transcript_fn = transcript_info.single_fn
+        vendor_graph = _compiled_vendor_graph(transcript_info.single_fn)
 
         async def vendor_auto_memory(request):
             text = GlobalTypeConverter.get().convert(request, to_type=str)
-            result = await transcript_fn(ChatRequestOrMessage(input_message=text))
-            return chat_response_plain_text(result)
+            result_state = await vendor_graph.ainvoke({"text": text})
+            return str(result_state["text"])
 
         async with finus_reasoning_trace_agent(
             FinusReasoningTraceAgentConfig(inner_agent_name="memory_router_agent"),


### PR DESCRIPTION
## 📝 개요

`--memory` 모드에서 답변 근거 각주가 경고 없이 사라지던 문제를 고친다. 각주를 붙이는 지점을 vendor 메모리 래퍼 **바깥**의 최상위 workflow로 올려, 두 라우터 설정이 같은 지점을 공유하게 했다.

- 동작 변경: 단일 문자열 입력으로 워크플로를 직접 실행할 때 반환이 응답 객체에서 평문으로 바뀐다. HTTP 경로(backend·scheduler)는 대화 메시지를 보내므로 영향받지 않는다.
- 알려진 한계: 브랜치가 예외로 죽으면 메모리 래퍼가 그 예외를 삼키고 에러 문자열을 답변으로 돌려주는데, 여기에도 각주가 붙는다. 메모리 모드는 여태 각주가 아예 없었으니 이 PR로 새로 도달 가능해진 경로다. 막으려면 vendor의 실패 문자열을 알아봐야 하고 그게 이 PR이 없애려던 결합이라 그대로 뒀다 — **후속 이슈 #294로 분리했다**(리뷰 승인 후 등록).

## 🔍 발견된 문제

1. `--memory` 모드에서 답변 근거 각주가 아무 경고 없이 표시되지 않았다. 메모리 래퍼가 응답을 문자열로 눕히면서 각주 메타데이터를 버리는데, 소비자는 메타데이터가 없으면 각주를 조용히 생략하도록 설계돼 있어 로그도 예외도 남지 않았다. 관측 형태가 "메모리 모드로 켜면 각주가 안 나온다"뿐이라 원인 도달 비용이 컸다.
2. 1번의 회귀 테스트가 실제 실행 경로의 절반만 재현했다. 문자열 경계는 충실히 흉내냈지만 메모리 래퍼의 그래프 실행 홉을 건너뛰어서, 수정이 기대는 두 가정 중 "기록 상자가 그 경계를 안쪽으로 넘어간다"는 축이 검증되지 않은 채 남았다.

## 🔧 문제 해결 방법

1. 각주를 붙이는 전용 최상위 workflow를 새로 두고 두 라우터 설정이 모두 이것을 최상단에 쓰게 했다. 메모리 래퍼는 그 아래로 내려가므로 래퍼가 무엇을 버리든 무관해진다 — 래퍼를 통과시키도록 감싸는 대안은 vendor 시그니처에 의존해 NAT 업그레이드 때 같은 방식으로 다시 깨지므로 택하지 않았다. 기록 상자를 겸해 들고 있던 안쪽 에이전트에서는 그 역할을 걷어냈다. 두 곳이 겸하면 상자가 두 겹이 되어 안쪽이 바깥 상자를 가린다.
2. 테스트의 래퍼 흉내를 노드 하나짜리 그래프로 감싸, 실제로 건너야 하는 실행 경계를 그대로 만들었다.

## ✅ 검증

- **회귀 테스트가 실제로 버그를 잡는지 되돌려 실측했다.** 부착 지점을 되돌리면 메모리 모드 파라미터 2건 + 상자 소유 테스트가 red, 메모리 없는 모드 파라미터는 green으로 남아 모드 한정 회귀임을 가른다. 설정을 되돌리면 설정 형태 가드 2건이 red.
- **컨텍스트 경계를 설치된 langgraph로 실측했다.** 바깥이 심은 상자는 노드 안에서 보이고(안쪽 전파 O), 노드 안의 `set()`은 바깥으로 새지 않는다(경계 실재 O). 2번 가정이 실제로 성립함을 확인한 것이다.

## 🔗 관련 이슈

- Closes #273
- 후속: #294 (vendor 에러 문자열에 각주가 붙는 경로)
- 관련: #260 (각주 도입), #263 (기능 수정 없이 제약만 명시했던 선행 PR)

