### PR TITLE
test: TOOL_LABELS/AGENT_LABELS의 finus_nat 식별자 드리프트를 CI로 잡는다 (#282)

### DIFF
--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -254,7 +254,8 @@ REASONING_FOOTNOTE_SEPARATOR = "─────"
 REASONING_FOOTNOTE_MAX_CHARS = 300
 
 # NAT supervisor 브랜치명 → 사용자에게 보여줄 한국어 라벨.
-# 키는 finus_nat/configs/router*.yml의 branches[].name과 같아야 한다.
+# 키는 finus_nat/configs/router*.yml의 branches[].name과 같아야 한다 —
+# 누락은 backend/tests/test_label_drift.py가 CI에서 잡는다 (#282).
 AGENT_LABELS: dict[str, str] = {
     "trading_agent": "트레이딩 에이전트",
     "monitoring_agent": "모니터링 에이전트",
@@ -267,7 +268,9 @@ AGENT_LABELS: dict[str, str] = {
 # 도구 강제 원장(finus_nat/src/nat_finus_nat/finus_api.py의 _record_to_ledger 호출부)에
 # 기록되는 내부 도구명 → 사용자에게 보여줄 한국어 라벨.
 # 매핑에 없는 도구는 내부 이름을 그대로 노출한다 — 조용히 감추면 각주가 "확인한 자료"를
-# 실제보다 적게 보여주게 되어, 근거를 보여준다는 목적 자체가 무너진다.
+# 실제보다 적게 보여주게 되어, 근거를 보여준다는 목적 자체가 무너진다. 그렇게 열화가
+# graceful한 만큼 누락을 아무도 눈치채지 못하므로, 원장 도구명과의 드리프트는
+# backend/tests/test_label_drift.py가 CI에서 잡는다 (#282).
 TOOL_LABELS: dict[str, str] = {
     "finus_account_balance": "KIS 시세·계좌 조회",
     "finus_market_news": "뉴스 검색",

--- a/backend/tests/test_label_drift.py
+++ b/backend/tests/test_label_drift.py
@@ -30,9 +30,18 @@ import yaml
 from backend.telegram_commands import AGENT_LABELS, TOOL_LABELS
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
-_FINUS_API_PATH = _REPO_ROOT / "finus_nat" / "src" / "nat_finus_nat" / "finus_api.py"
-_CONFIGS_ROOT = _REPO_ROOT / "finus_nat" / "configs"
-_ROUTER_CONFIGS = [_CONFIGS_ROOT / "router.yml", _CONFIGS_ROOT / "router_nomemory.yml"]
+_FINUS_NAT_ROOT = _REPO_ROOT / "finus_nat"
+_SRC_ROOT = _FINUS_NAT_ROOT / "src"
+_CONFIGS_ROOT = _FINUS_NAT_ROOT / "configs"
+
+# 스캔 대상은 파일 목록이 아니라 **패턴**이다. 오늘 원장 기록은 finus_api.py 한 곳에만,
+# branches는 router 두 파일에만 있지만, 그걸 상수로 박아 두면 새 모듈·새 라우터 config가
+# 검사 밖에서 조용히 자란다 — 이 검사가 막으려던 것과 정확히 같은 실패 모드를 한 겹
+# 안쪽에 다시 만드는 셈이다(1400줄짜리 finus_api.py가 분할되는 시점이 특히 그렇다).
+# telegram_commands.py의 주석도 특정 파일이 아니라 router*.yml로 계약을 적어 뒀다.
+# 두 목록이 비면 검사가 통째로 공허해지므로 아래 test_scan_inputs_are_discovered가 잡는다.
+_SOURCE_FILES = sorted(_SRC_ROOT.rglob("*.py"))
+_ROUTER_CONFIGS = sorted(_CONFIGS_ROOT.glob("router*.yml"))
 
 # 원장 기록 함수와, 그 함수에 도구명을 흘려 보내는 래퍼의 키워드 인자.
 # finus_api.py의 원격 MCP 호출 래퍼는 도구명을 자기 파라미터로 받아 _record_to_ledger에
@@ -86,24 +95,33 @@ def _ledger_tool_name_exprs(tree: ast.Module) -> list[ast.expr]:
 
 
 def _extract_ledger_tool_names() -> tuple[set[str], list[str]]:
-    """(도구명 집합, 정적으로 해석하지 못한 표현식 목록)."""
-    assert _FINUS_API_PATH.exists(), f"finus_nat 소스가 없습니다: {_FINUS_API_PATH}"
-    tree = ast.parse(_FINUS_API_PATH.read_text(encoding="utf-8"))
-    constants = _module_level_str_constants(tree)
+    """finus_nat/src 전체를 훑어 (도구명 집합, 정적으로 해석하지 못한 표현식 목록)을 낸다.
 
+    상수는 파일별로 계산한다 — 모듈이 갈라져도 각자의 최상위 상수로 해석되고, 다른
+    모듈의 동명 상수가 끼어들지 않는다. 남의 모듈에서 import해 온 이름은 미해석으로
+    잡히는데, 그게 맞다: _record_to_ledger의 docstring이 "리터럴이나 모듈 상수로
+    유지하라"를 계약으로 못박아 뒀고, 어긴 자리는 조용히 넘어가는 대신 빨간불이 된다.
+    """
     names: set[str] = set()
     unresolved: list[str] = []
-    for expr in _ledger_tool_name_exprs(tree):
-        if isinstance(expr, ast.Constant) and isinstance(expr.value, str):
-            names.add(expr.value)
-        elif isinstance(expr, ast.Name) and expr.id in constants:
-            names.add(constants[expr.id])
-        elif isinstance(expr, ast.Name) and expr.id == _LEDGER_KWARG:
-            # 래퍼가 자기 파라미터를 그대로 전달하는 자리. 실제 값은 호출부의
-            # ledger_tool_name= 리터럴에서 이미 수집된다.
+    for path in _SOURCE_FILES:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        exprs = _ledger_tool_name_exprs(tree)
+        if not exprs:  # 원장을 건드리지 않는 모듈이 대부분이다
             continue
-        else:
-            unresolved.append(f"{_FINUS_API_PATH.name}:{expr.lineno}: {ast.unparse(expr)}")
+        constants = _module_level_str_constants(tree)
+        for expr in exprs:
+            if isinstance(expr, ast.Constant) and isinstance(expr.value, str):
+                names.add(expr.value)
+            elif isinstance(expr, ast.Name) and expr.id in constants:
+                names.add(constants[expr.id])
+            elif isinstance(expr, ast.Name) and expr.id == _LEDGER_KWARG:
+                # 래퍼가 자기 파라미터를 그대로 전달하는 자리. 실제 값은 호출부의
+                # ledger_tool_name= 리터럴에서 이미 수집된다.
+                continue
+            else:
+                location = path.relative_to(_REPO_ROOT).as_posix()
+                unresolved.append(f"{location}:{expr.lineno}: {ast.unparse(expr)}")
     return names, unresolved
 
 
@@ -150,16 +168,26 @@ def _extract_branch_names(path: Path) -> set[str]:
     return names
 
 
+def test_scan_inputs_are_discovered():
+    """스캔 입력이 비면 아래 검사들이 통째로 공허해지므로 목록부터 확인한다.
+
+    router config 목록은 특히 조용하다 — 비면 parametrize가 빈 파라미터 집합이 되어
+    커버리지 테스트가 실패가 아니라 skip으로 사라진다.
+    """
+    assert _SOURCE_FILES, f"finus_nat 소스를 하나도 찾지 못했습니다: {_SRC_ROOT}"
+    assert _ROUTER_CONFIGS, f"router*.yml을 하나도 찾지 못했습니다: {_CONFIGS_ROOT}"
+
+
 def test_every_ledger_tool_name_is_statically_resolvable():
     """도구명을 하나라도 정적으로 못 읽으면 아래 커버리지 검사가 공허해지므로 먼저 막는다."""
     names, unresolved = _extract_ledger_tool_names()
     assert unresolved == [], (
-        "finus_api.py의 도구 원장 기록에서 도구명을 정적으로 해석하지 못했습니다. "
+        "finus_nat 소스의 도구 원장 기록에서 도구명을 정적으로 해석하지 못했습니다. "
         "리터럴이나 모듈 상수로 되돌리거나, 이 파일의 추출 규칙을 함께 넓히세요 "
         f"(그대로 두면 #282 드리프트 검사가 조용히 비어 갑니다): {unresolved}"
     )
     assert names, (
-        f"{_FINUS_API_PATH.name}에서 도구명을 하나도 찾지 못했습니다 — "
+        f"{_SRC_ROOT.name} 아래에서 도구명을 하나도 찾지 못했습니다 — "
         f"'{_LEDGER_FUNC}' 호출 규약이 바뀌었다면 추출 규칙을 함께 고쳐야 합니다."
     )
 

--- a/backend/tests/test_label_drift.py
+++ b/backend/tests/test_label_drift.py
@@ -1,0 +1,191 @@
+"""TOOL_LABELS/AGENT_LABELS와 finus_nat 식별자의 드리프트 검사 (#282).
+
+`backend/telegram_commands.py`의 두 라벨 맵은 **다른 서비스(finus_nat)의 식별자**를
+키로 쓴다 — `TOOL_LABELS`는 도구 강제 원장에 기록되는 내부 도구명,
+`AGENT_LABELS`는 supervisor 브랜치명이다. finus_nat이 도구를 리네임하면 backend에는
+아무 신호도 가지 않고, 각주에 한국어 라벨 대신 내부 이름이 그대로 노출된다.
+열화가 graceful해서(#260) 장애로 드러나지 않으므로 아무도 모른 채 오래간다.
+
+**검사 방향**: finus_nat에 있는데 backend에 없는 키만 실패시킨다. backend에 남는 키(더
+이상 존재하지 않는 도구·브랜치)는 각주 품질을 해치지 않으므로 실패시키지 않는다.
+반대 방향까지 걸면 finus_nat 쪽 도구를 지우는 PR이 backend 수정을 강제로 끌고 들어온다.
+
+**왜 backend 테스트인가**: 제약의 소유자가 backend이기 때문이다. "finus_nat의 식별자를
+전부 덮어야 한다"는 요구는 backend 라벨 맵의 요구이고, 깨졌을 때 고칠 파일도 backend에
+있다. finus_nat 쪽 잡에 두면 finus_nat만 건드린 PR이 backend 파일 때문에 빨간불이 되어
+실패 지점과 수정 지점이 어긋난다. CI는 레포 전체를 체크아웃하므로 backend 잡에서
+finus_nat 소스를 읽을 수 있고, 이미 같은 방식으로 서비스 경계를 넘는 테스트가 있다
+(`test_stock_code.py`가 mcp-trading의 종목마스터를 읽는다). 새 잡을 만들 이유는 없다.
+
+finus_nat 소스는 **정적으로만** 읽는다(ast/yaml). backend 잡에는 nvidia-nat 의존성이
+없으므로 import는 불가능하고, 필요하지도 않다.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+import yaml
+
+from backend.telegram_commands import AGENT_LABELS, TOOL_LABELS
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_FINUS_API_PATH = _REPO_ROOT / "finus_nat" / "src" / "nat_finus_nat" / "finus_api.py"
+_CONFIGS_ROOT = _REPO_ROOT / "finus_nat" / "configs"
+_ROUTER_CONFIGS = [_CONFIGS_ROOT / "router.yml", _CONFIGS_ROOT / "router_nomemory.yml"]
+
+# 원장 기록 함수와, 그 함수에 도구명을 흘려 보내는 래퍼의 키워드 인자.
+# finus_api.py의 원격 MCP 호출 래퍼는 도구명을 자기 파라미터로 받아 _record_to_ledger에
+# 그대로 넘긴다 — 그 경로의 실제 도구명은 호출부의 ledger_tool_name= 리터럴에만 있다.
+_LEDGER_FUNC = "_record_to_ledger"
+_LEDGER_FIRST_PARAM = "tool_name"
+_LEDGER_KWARG = "ledger_tool_name"
+
+
+def _module_level_str_constants(tree: ast.Module) -> dict[str, str]:
+    """모듈 최상위의 문자열 상수 이름 → 값. 상수로 뽑아 쓴 도구명을 되짚는 데 쓴다."""
+    constants: dict[str, str] = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            targets = [t for t in node.targets if isinstance(t, ast.Name)]
+            value = node.value
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            targets = [node.target]
+            value = node.value
+        else:
+            continue
+        if isinstance(value, ast.Constant) and isinstance(value.value, str):
+            for target in targets:
+                constants[target.id] = value.value
+    return constants
+
+
+def _ledger_tool_name_exprs(tree: ast.Module) -> list[ast.expr]:
+    """도구명이 담기는 표현식을 전부 모은다 — _record_to_ledger 첫 인자 + ledger_tool_name=."""
+    exprs: list[ast.expr] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Name):
+            called = func.id
+        elif isinstance(func, ast.Attribute):
+            called = func.attr
+        else:
+            called = None
+        if called == _LEDGER_FUNC:
+            if node.args:
+                exprs.append(node.args[0])
+            else:
+                # 첫 인자를 키워드로 넘긴 형태. 둘 다 없으면 아래 keywords 루프에도 걸리지
+                # 않아 미해석으로 잡히지 못하므로, 호출 노드 자체를 넣어 드러나게 한다.
+                by_kw = [kw.value for kw in node.keywords if kw.arg == _LEDGER_FIRST_PARAM]
+                exprs.append(by_kw[0] if by_kw else node)
+        exprs.extend(kw.value for kw in node.keywords if kw.arg == _LEDGER_KWARG)
+    return exprs
+
+
+def _extract_ledger_tool_names() -> tuple[set[str], list[str]]:
+    """(도구명 집합, 정적으로 해석하지 못한 표현식 목록)."""
+    assert _FINUS_API_PATH.exists(), f"finus_nat 소스가 없습니다: {_FINUS_API_PATH}"
+    tree = ast.parse(_FINUS_API_PATH.read_text(encoding="utf-8"))
+    constants = _module_level_str_constants(tree)
+
+    names: set[str] = set()
+    unresolved: list[str] = []
+    for expr in _ledger_tool_name_exprs(tree):
+        if isinstance(expr, ast.Constant) and isinstance(expr.value, str):
+            names.add(expr.value)
+        elif isinstance(expr, ast.Name) and expr.id in constants:
+            names.add(constants[expr.id])
+        elif isinstance(expr, ast.Name) and expr.id == _LEDGER_KWARG:
+            # 래퍼가 자기 파라미터를 그대로 전달하는 자리. 실제 값은 호출부의
+            # ledger_tool_name= 리터럴에서 이미 수집된다.
+            continue
+        else:
+            unresolved.append(f"{_FINUS_API_PATH.name}:{expr.lineno}: {ast.unparse(expr)}")
+    return names, unresolved
+
+
+def _config_chain(path: Path) -> list[Path]:
+    """`base:` 상속 체인을 따라간 config 파일 목록(자기 자신 포함)."""
+    chain: list[Path] = []
+    seen: set[Path] = set()
+    current: Path | None = path.resolve()
+    while current is not None and current not in seen:
+        assert current.exists(), f"finus_nat config가 없습니다: {current}"
+        seen.add(current)
+        chain.append(current)
+        document = yaml.safe_load(current.read_text(encoding="utf-8")) or {}
+        base = document.get("base") if isinstance(document, dict) else None
+        current = (current.parent / base).resolve() if isinstance(base, str) else None
+    return chain
+
+
+def _extract_branch_names(path: Path) -> set[str]:
+    """config(+`base:` 상속 체인) 안의 모든 `branches[].name`.
+
+    supervisor 함수 이름에 의존하지 않고 재귀로 훑는다. 정의가 다른 키 아래로 옮겨가도
+    계속 잡히고, 그래도 비면 호출부 테스트가 빨간불이 되므로 fail-open으로 무너지지 않는다.
+    """
+    names: set[str] = set()
+
+    def walk(node: object) -> None:
+        if isinstance(node, dict):
+            branches = node.get("branches")
+            if isinstance(branches, list):
+                names.update(
+                    branch["name"]
+                    for branch in branches
+                    if isinstance(branch, dict) and isinstance(branch.get("name"), str)
+                )
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, list):
+            for value in node:
+                walk(value)
+
+    for config_path in _config_chain(path):
+        walk(yaml.safe_load(config_path.read_text(encoding="utf-8")) or {})
+    return names
+
+
+def test_every_ledger_tool_name_is_statically_resolvable():
+    """도구명을 하나라도 정적으로 못 읽으면 아래 커버리지 검사가 공허해지므로 먼저 막는다."""
+    names, unresolved = _extract_ledger_tool_names()
+    assert unresolved == [], (
+        "finus_api.py의 도구 원장 기록에서 도구명을 정적으로 해석하지 못했습니다. "
+        "리터럴이나 모듈 상수로 되돌리거나, 이 파일의 추출 규칙을 함께 넓히세요 "
+        f"(그대로 두면 #282 드리프트 검사가 조용히 비어 갑니다): {unresolved}"
+    )
+    assert names, (
+        f"{_FINUS_API_PATH.name}에서 도구명을 하나도 찾지 못했습니다 — "
+        f"'{_LEDGER_FUNC}' 호출 규약이 바뀌었다면 추출 규칙을 함께 고쳐야 합니다."
+    )
+
+
+def test_ledger_tool_names_are_covered_by_tool_labels():
+    """finus_nat이 원장에 기록하는 도구는 전부 TOOL_LABELS에 한국어 라벨이 있어야 한다."""
+    names, _ = _extract_ledger_tool_names()
+    missing = sorted(names - TOOL_LABELS.keys())
+    assert missing == [], (
+        "finus_nat이 원장에 기록하는 다음 도구가 backend TOOL_LABELS에 없습니다. "
+        "각주에 한국어 라벨 대신 내부 이름이 노출됩니다 — "
+        f"backend/telegram_commands.py의 TOOL_LABELS에 추가하세요: {missing}"
+    )
+
+
+@pytest.mark.parametrize("config_path", _ROUTER_CONFIGS, ids=lambda p: p.name)
+def test_router_branch_names_are_covered_by_agent_labels(config_path: Path):
+    """router*.yml의 supervisor 브랜치는 전부 AGENT_LABELS에 한국어 라벨이 있어야 한다."""
+    names = _extract_branch_names(config_path)
+    assert names, (
+        f"{config_path.name}에서 branches[].name을 하나도 찾지 못했습니다 — "
+        "브랜치 정의 위치가 바뀌었다면 추출 규칙을 함께 고쳐야 합니다."
+    )
+    missing = sorted(names - AGENT_LABELS.keys())
+    assert missing == [], (
+        f"{config_path.name}의 다음 supervisor 브랜치가 backend AGENT_LABELS에 없습니다. "
+        "각주에 한국어 라벨 대신 내부 이름이 노출됩니다 — "
+        f"backend/telegram_commands.py의 AGENT_LABELS에 추가하세요: {missing}"
+    )

--- a/finus_nat/src/nat_finus_nat/finus_api.py
+++ b/finus_nat/src/nat_finus_nat/finus_api.py
@@ -267,6 +267,13 @@ def _record_to_ledger(tool_name: str, result: str) -> None:
     ContextVar (e.g., outside a run_subagent context).  The resulting empty
     ledger causes the gate to trip for any numeric claim, which is the
     correct conservative behaviour.
+
+    ``tool_name`` leaves this service: backend renders it in the reasoning
+    footnote through ``TOOL_LABELS`` (backend/telegram_commands.py, #260).
+    Renaming a tool without updating that map degrades gracefully — the raw
+    internal name shows up instead of the Korean label — so the mismatch is
+    caught by backend/tests/test_label_drift.py in CI (#282). Keep the name a
+    literal or a module-level constant; that check reads it statically.
     """
     ledger = DATA_TOOL_LEDGER.get()
     if ledger is None:


### PR DESCRIPTION
## 📝 개요

텔레그램 추론 각주의 한국어 라벨 맵은 다른 서비스(finus_nat)의 식별자를 키로 쓰는데, 저쪽이 이름을 바꿔도 이쪽에는 아무 신호가 가지 않았다. 그 드리프트를 CI에서 빨간불로 드러낸다.

- 알려진 한계: 도구명은 정적으로만 읽으므로 리터럴이나 모듈 최상위 상수로 유지해야 한다. 어기면 커버리지 검사가 조용히 비는 대신 "해석 불가"로 빨간불이 된다.

## 🔍 발견된 문제

1. 각주 라벨 맵의 키가 finus_nat의 내부 도구명·라우터 브랜치명이라, 저쪽에서 하나를 리네임하면 사용자에게 한국어 라벨 대신 내부 이름이 그대로 보인다. 열화가 graceful해서 장애로 드러나지 않고, 그래서 아무도 모른 채 오래간다.
2. 두 서비스가 별도 CI 잡으로 돌아, 검사를 어디에 두느냐에 따라 빨간불이 뜨는 곳과 고쳐야 할 파일이 어긋난다.
3. 검사기 자신이 같은 실패 모드를 가질 수 있다. 스캔 대상을 파일 목록으로 박아 두면 새 모듈·새 라우터 config가 검사 밖에서 자라고, 그 사실 역시 조용하다.

## 🔧 문제 해결 방법

1. finus_nat 소스를 정적으로 훑어(코드는 ast, config는 yaml) 식별자 집합을 뽑고 라벨 맵이 전부 덮는지 검사한다. 방향은 한쪽만 건다 — finus_nat에 있는데 라벨이 없는 것만 실패시키고, 남는 라벨은 통과시킨다. 반대까지 걸면 도구를 지우는 PR이 backend 수정을 강제로 끌고 들어온다.
2. 제약의 소유자이자 수정 지점인 backend 쪽 테스트로 넣었다. CI가 레포 전체를 체크아웃하므로 새 잡도, 워크플로 변경도 필요 없다.
3. 스캔 대상을 파일 목록이 아니라 패턴으로 두고, 입력 목록이 비거나 도구명을 정적으로 해석하지 못하면 그 자체로 실패시킨다. 특히 라우터 config 목록이 비면 커버리지 검사가 실패가 아니라 skip으로 사라진다.

## ✅ 검증

- 실측 대조: 원장 도구 9개, 라우터 브랜치 6개를 실제 소스에서 뽑아 라벨 맵과 대조 — 누락·오검출 0 (PR #263 리뷰 실측 수치와 일치)
- 뮤테이션(도구): `finus_save_diary` → `finus_save_journal` 리네임, 모듈 상수 `_KIS_BALANCE_LEDGER_NAME` 값 변경 — 각각 누락으로 red
- 뮤테이션(브랜치): `router.yml`의 `news_agent` 리네임 — red
- 뮤테이션(fail-open): 도구명을 f-string으로 바꾸면 커버리지 검사보다 먼저 "해석 불가"가 red
- 뮤테이션(스캔 범위): 새 모듈에서 원장에 기록, 새 `router*.yml`에서 브랜치 추가 — 3번 수정 전에는 둘 다 통과했고, 수정 후 각각 red

## 🔗 관련 이슈

- Closes #282
- 배경: #260 (추론 각주), #263 (라벨 일치 실측)
