### PR TITLE
feat: 신호 유의성 판별을 -3~+3 점수화로 승격 (근거 + 불확실성 포함) (#298)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,15 @@ DART_API_KEY=your_dart_api_key_here
 # Database
 DB_ECHO=false
 
+# 신호 유의성 점수화 (#298)
+# 감시 파이프라인의 2차 필터가 뉴스/외부 signal을 -3~+3으로 채점하고,
+# |점수| >= SIGNAL_SCORE_THRESHOLD 이면 고성능 에이전트 분석을 태웁니다.
+# 1로 낮추면 약한 호재/악재까지 분석해 비용이 늘고, 3으로 올리면 대형 이벤트만 통과합니다.
+# 1~3 범위 밖이거나 숫자가 아니면 기본값 2로 되돌립니다.
+# SIGNAL_SCORE_THRESHOLD=2
+# 기사별 점수의 표준편차가 이 값 이상이면 텔레그램 알림에 "기사 간 평가 엇갈림"을 표시합니다.
+# SIGNAL_UNCERTAINTY_ALERT_THRESHOLD=1.0
+
 # Redis
 REDIS_URL=redis://localhost:6379/0
 # Telegram Bot

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,3 +1,4 @@
+import math
 import os
 from pathlib import Path
 from dotenv import load_dotenv
@@ -79,7 +80,7 @@ DATABASE_URL = os.environ.get("DATABASE_URL") or f"sqlite:///{_FIN_US_ROOT}/back
 DB_ECHO = os.getenv("DB_ECHO", "false").lower() == "true"
 
 # 신호 유의성 점수화 (#298).
-# 2차 필터(services.check_signal_significance)가 YES/NO 대신 -3~+3 정수를 받는다.
+# 2차 필터(services.score_signal)가 YES/NO 대신 -3~+3 정수를 받는다.
 # 레인지를 좁게 잡은 것은 의도다 — 경량 모델은 0~100 같은 넓은 축에서 재현성이 없다.
 SIGNAL_SCORE_MIN = -3
 SIGNAL_SCORE_MAX = 3
@@ -117,7 +118,12 @@ def _float_env(name: str, default: float) -> float:
         value = float(raw)
     except ValueError:
         return default
-    return value if value >= 0 else default
+    # isfinite로 inf/nan을 함께 막는다. inf를 통과시키면 "기사 간 평가 엇갈림"이
+    # 영구히 침묵하는데, 이는 _int_env_in_range가 배격한 것과 같은 실패 유형이다
+    # (설정이 조용히 기능 하나를 끄는 것).
+    if not math.isfinite(value) or value < 0:
+        return default
+    return value
 
 
 # 기사별 점수의 표준편차가 이 값 이상이면 "기사 간 평가 엇갈림"을 알림에 표시한다.

--- a/backend/config.py
+++ b/backend/config.py
@@ -78,6 +78,53 @@ _MCP_ENV_ALLOWED_PREFIXES = ("FIN_US_", "FINUS_KIS_", "KIS_")
 DATABASE_URL = os.environ.get("DATABASE_URL") or f"sqlite:///{_FIN_US_ROOT}/backend/finus.db"
 DB_ECHO = os.getenv("DB_ECHO", "false").lower() == "true"
 
+# 신호 유의성 점수화 (#298).
+# 2차 필터(services.check_signal_significance)가 YES/NO 대신 -3~+3 정수를 받는다.
+# 레인지를 좁게 잡은 것은 의도다 — 경량 모델은 0~100 같은 넓은 축에서 재현성이 없다.
+SIGNAL_SCORE_MIN = -3
+SIGNAL_SCORE_MAX = 3
+
+
+def _int_env_in_range(name: str, default: int, low: int, high: int) -> int:
+    """정수 env를 [low, high]로 강제한다. 값이 없거나 이상하면 default로 되돌린다.
+
+    범위를 벗어난 임계값은 조용히 파이프라인을 망가뜨린다 — 0이면 모든 signal이
+    유의미해져 필터가 사라지고, 4 이상이면 어떤 점수도 통과하지 못해 감시가
+    영구히 침묵한다. 둘 다 "놓침 방지"(REQ-04) 관점에서 사고이므로 받아들이지 않는다.
+    """
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    if not low <= value <= high:
+        return default
+    return value
+
+
+# |score| >= 이 값이면 유의미로 판정한다. 1이면 약한 호재/악재까지 상세 분석을 태우고,
+# 3이면 대형 이벤트만 통과한다. 기본 2 = "방향이 분명한" 신호부터.
+SIGNAL_SCORE_THRESHOLD = _int_env_in_range("SIGNAL_SCORE_THRESHOLD", 2, 1, SIGNAL_SCORE_MAX)
+
+
+def _float_env(name: str, default: float) -> float:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return value if value >= 0 else default
+
+
+# 기사별 점수의 표준편차가 이 값 이상이면 "기사 간 평가 엇갈림"을 알림에 표시한다.
+# 기본 1.0 = 7단계 축에서 기사들이 한 칸 넘게 흩어졌다는 뜻.
+SIGNAL_UNCERTAINTY_ALERT_THRESHOLD = _float_env("SIGNAL_UNCERTAINTY_ALERT_THRESHOLD", 1.0)
+
+
 # Redis cache/lock settings for scheduler state.
 REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
 

--- a/backend/database.py
+++ b/backend/database.py
@@ -19,6 +19,26 @@ _PENDING_COLUMN_MIGRATIONS: tuple[tuple[str, str, str], ...] = (
         # 있으므로(#162) 반드시 0(False)이어야 한다.
         "ALTER TABLE agentreport ADD COLUMN provider_supports_tools BOOLEAN NOT NULL DEFAULT 0",
     ),
+    # #298: 신호 점수화. 세 컬럼 모두 NULL 허용이고 DEFAULT를 주지 않는다 —
+    # provider_supports_tools와 정반대의 선택이며, 이유도 정반대다. 저쪽은 "구버전
+    # 행은 도구를 쓰지 않았다"가 코드로 증명되는 사실이라 0으로 채웠다. 이쪽은
+    # 구버전 행이 몇 점이었는지 알 방법이 없다. DEFAULT 0을 주면 "모델이 중립이라고
+    # 판단함"이라는 없던 사실이 소급 생성된다(#122·#162의 "0과 모름 구분").
+    (
+        "agentreport",
+        "signal_score",
+        "ALTER TABLE agentreport ADD COLUMN signal_score INTEGER",
+    ),
+    (
+        "agentreport",
+        "signal_reason",
+        "ALTER TABLE agentreport ADD COLUMN signal_reason VARCHAR",
+    ),
+    (
+        "agentreport",
+        "signal_uncertainty",
+        "ALTER TABLE agentreport ADD COLUMN signal_uncertainty FLOAT",
+    ),
 )
 
 
@@ -82,12 +102,16 @@ _RECREATE_AGENTREPORT_NULLABLE_DDL = (
     "confidence_score FLOAT, "      # nullable: 도구 없는 provider는 null
     "reason VARCHAR NOT NULL DEFAULT '', "
     "provider_supports_tools BOOLEAN NOT NULL DEFAULT 0, "
+    "signal_score INTEGER, "            # nullable: 채점 실패(fail-open)와 구버전 행은 null (#298)
+    "signal_reason VARCHAR, "           # nullable: 위와 동일
+    "signal_uncertainty FLOAT, "        # nullable: 기사 2건 미만이면 흩어짐이 정의되지 않음
     "created_at DATETIME NOT NULL"
     ")"
 )
 _RECREATE_AGENTREPORT_COLS = (
     "id, stock_code, stock_name, provider, summary, decision, "
-    "confidence_score, reason, provider_supports_tools, created_at"
+    "confidence_score, reason, provider_supports_tools, "
+    "signal_score, signal_reason, signal_uncertainty, created_at"
 )
 # Improvement #1 (#162 리뷰): 재생성 직전 실제 컬럼 집합과 DDL 가정을 비교하는 단언에 쓴다.
 # _PENDING_COLUMN_MIGRATIONS에 agentreport 컬럼이 추가되어도 이 집합을 갱신하지 않으면

--- a/backend/models.py
+++ b/backend/models.py
@@ -72,11 +72,15 @@ class AgentReport(SQLModel, table=True):
         description="provider가 도구(MCP/KIS/뉴스) 호출 경로로 구성돼 있는지 여부 (provider 능력 신호, 실제 호출 관측 아님).",
     )
     # #298: 2차 필터가 매긴 신호 점수. 셋 다 nullable이며 기본값을 채우지 않는다 —
-    # "0과 모름"은 다른 값이다(#122·#162). signal_score=0은 "모델이 무관/중립이라고
-    # 판단했다"이고, null은 "채점 자체가 없었다"(LLM 호출·파싱 실패로 fail-open했거나,
-    # 점수화 이전에 저장된 행이거나, 스케줄러를 거치지 않은 수동 분석)이다.
-    # 이 구분이 무너지면 평가셋(scripts/build_signal_eval_set.py)의 모델점수 열이
-    # 실패를 중립으로 오염시킨다.
+    # "0과 모름"은 다른 값이다(#122·#162). null은 "채점 자체가 없었다"는 뜻이고,
+    # LLM 호출·파싱 실패로 fail-open했거나, 점수화 이전에 저장된 행이거나,
+    # 스케줄러를 거치지 않은 수동 분석인 경우다.
+    #
+    # 이 테이블에 실제로 남는 점수는 |score| >= SIGNAL_SCORE_THRESHOLD인 값뿐이다.
+    # 임계값 미만이면 스케줄러가 상세 분석 자체를 건너뛰므로 리포트 행이 생기지
+    # 않는다 — 즉 기본 임계값에서 0이나 ±1인 행은 구조적으로 존재할 수 없다.
+    # 걸러진 신호의 점수 분포는 scheduler의 "유의미한 변화 없음(score=...)" 로그와
+    # 평가셋(backend/scripts/build_signal_eval_set.py)에서 본다.
     signal_score: Optional[int] = Field(
         default=None,
         description=(

--- a/backend/models.py
+++ b/backend/models.py
@@ -71,6 +71,30 @@ class AgentReport(SQLModel, table=True):
         default=False,
         description="provider가 도구(MCP/KIS/뉴스) 호출 경로로 구성돼 있는지 여부 (provider 능력 신호, 실제 호출 관측 아님).",
     )
+    # #298: 2차 필터가 매긴 신호 점수. 셋 다 nullable이며 기본값을 채우지 않는다 —
+    # "0과 모름"은 다른 값이다(#122·#162). signal_score=0은 "모델이 무관/중립이라고
+    # 판단했다"이고, null은 "채점 자체가 없었다"(LLM 호출·파싱 실패로 fail-open했거나,
+    # 점수화 이전에 저장된 행이거나, 스케줄러를 거치지 않은 수동 분석)이다.
+    # 이 구분이 무너지면 평가셋(scripts/build_signal_eval_set.py)의 모델점수 열이
+    # 실패를 중립으로 오염시킨다.
+    signal_score: Optional[int] = Field(
+        default=None,
+        description=(
+            "신호 영향도 점수 (-3~+3 정수). 감시 파이프라인의 2차 필터가 매긴다. "
+            "채점하지 못했으면 null (fail-open)."
+        ),
+    )
+    signal_reason: Optional[str] = Field(
+        default=None,
+        description="signal_score의 한 줄 근거. 점수가 null이면 함께 null.",
+    )
+    signal_uncertainty: Optional[float] = Field(
+        default=None,
+        description=(
+            "기사별 점수의 표준편차. 기사가 2건 미만이면 흩어짐을 정의할 수 없으므로 null "
+            "(0.0이 아니다 — 0.0은 '기사들이 완전히 일치했다'는 뜻)."
+        ),
+    )
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="생성 일시")
 
 class Diary(SQLModel, table=True):

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -9,14 +9,18 @@ from sqlmodel import Session, select
 from .catalyst_repo import CatalystEventInput, SqliteCatalystEventRepo
 from .ws_manager import manager
 from .database import engine
-from .config import NEWS_MCP_PARAMS, TRADING_MCP_PARAMS, DART_MCP_PARAMS
+from .config import (
+    NEWS_MCP_PARAMS,
+    TRADING_MCP_PARAMS,
+    DART_MCP_PARAMS,
+    SIGNAL_SCORE_THRESHOLD,
+)
 from .redis_state import RedisSchedulerState, signal_hash, redis_state
 from .services import (
     perform_stock_analysis,
     run_mcp_tool,
-    check_signal_significance,
+    score_signal,
     generate_morning_briefing,
-    take_last_signal_score,
 )
 from .models import Portfolio
 from .timeutil import KST
@@ -762,21 +766,28 @@ async def _monitor_signal(
             last_signal = await state.get_last_signal_text(source.name, stock)
 
         # 2. 유의미성 판단 (Local Model or Mini LLM API)
-        #    #298: 판정은 |score| >= 임계값이다. bool 뒤에 딸린 점수·근거·불확실성은
-        #    take_last_signal_score()로 꺼내 분석 리포트와 알림까지 실어 나른다.
-        #    채점을 하지 못했으면(fail-open) None이며, 그대로 null로 남는다.
-        is_significant = await check_signal_significance(
+        #    #298: 판정은 |score| >= 임계값이다. 점수·근거·불확실성은 판정과 같은
+        #    호출에서 함께 받아 분석 리포트와 알림까지 실어 나른다. 채점하지 못했으면
+        #    (fail-open) score가 None이며 그대로 null로 남는다.
+        signal_score = await score_signal(
             stock,
             current_signal,
             last_signal,
             source=source.name,
             provider=FILTER_PROVIDER,
         )
-        signal_score = take_last_signal_score()
 
-        if not is_significant:
+        if not signal_score.is_significant:
             await _set_last_signal_state(state, source.name, stock, current_signal, current_digest)
-            logger.info(f"[{source.name}:{stock}] 유의미한 변화 없음. 분석을 건너뜁니다.")
+            # 걸러진 신호의 점수도 남긴다. 임계값 미만은 AgentReport에 저장되지 않으므로
+            # (분석 자체를 건너뛴다) 임계값을 조정할 때 참고할 분포가 이 로그뿐이다.
+            logger.info(
+                "[%s:%s] 유의미한 변화 없음(score=%s, 임계값=%s). 분석을 건너뜁니다.",
+                source.name,
+                stock,
+                signal_score.score,
+                SIGNAL_SCORE_THRESHOLD,
+            )
             return
 
         # 3. 유의미한 변화가 있을 때만 고성능 에이전트 분석 실행

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -16,6 +16,7 @@ from .services import (
     run_mcp_tool,
     check_signal_significance,
     generate_morning_briefing,
+    take_last_signal_score,
 )
 from .models import Portfolio
 from .timeutil import KST
@@ -761,6 +762,9 @@ async def _monitor_signal(
             last_signal = await state.get_last_signal_text(source.name, stock)
 
         # 2. 유의미성 판단 (Local Model or Mini LLM API)
+        #    #298: 판정은 |score| >= 임계값이다. bool 뒤에 딸린 점수·근거·불확실성은
+        #    take_last_signal_score()로 꺼내 분석 리포트와 알림까지 실어 나른다.
+        #    채점을 하지 못했으면(fail-open) None이며, 그대로 null로 남는다.
         is_significant = await check_signal_significance(
             stock,
             current_signal,
@@ -768,6 +772,7 @@ async def _monitor_signal(
             source=source.name,
             provider=FILTER_PROVIDER,
         )
+        signal_score = take_last_signal_score()
 
         if not is_significant:
             await _set_last_signal_state(state, source.name, stock, current_signal, current_digest)
@@ -782,6 +787,7 @@ async def _monitor_signal(
             session,
             trigger_source=source.name,
             trigger_signal=current_signal,
+            signal_score=signal_score,
         )
         await _set_last_signal_state(state, source.name, stock, current_signal, current_digest)
 

--- a/backend/schema_docs.md
+++ b/backend/schema_docs.md
@@ -34,6 +34,9 @@ erDiagram
         float confidence_score "신뢰도 점수"
         string reason "투자 결정 근거"
         boolean provider_supports_tools "provider가 도구 호출 가능 경로인지 (실제 호출 관측 아님, #162)"
+        int signal_score "신호 영향도 -3~+3 (채점 실패·필터 미경유 시 null, #298)"
+        string signal_reason "signal_score의 한 줄 근거 (#298)"
+        float signal_uncertainty "기사별 점수의 표준편차 (기사 2건 미만이면 null, #298)"
         datetime created_at "생성 일시"
     }
     Diary {

--- a/backend/scripts/build_signal_eval_set.py
+++ b/backend/scripts/build_signal_eval_set.py
@@ -1,0 +1,187 @@
+"""신호 점수화(#298) 평가셋을 CSV로 뽑는다.
+
+뉴스 MCP로 기사를 모아 기사 하나씩 모델에 채점시키고, 사람 채점 열은 비워 둔
+CSV를 만든다. 사람 채점은 이 스크립트가 하지 않는다 — 나중에 별도로 손으로 채운 뒤
+모델점수와 대조해 임계값(SIGNAL_SCORE_THRESHOLD)과 프롬프트를 조정하는 것이 목적이다.
+
+기사 하나씩 채점하는 이유: 운영 파이프라인은 기사 여러 건을 한 번에 넘겨 종합
+점수를 받지만, 그 점수는 사람이 채점하기 어렵다("이 3건을 합치면 몇 점인가?"에는
+정답이 없다). 기사 단위라면 사람과 모델이 같은 질문에 답하므로 비교가 성립한다.
+운영 프롬프트와 같은 함수(services.score_signal)를 그대로 쓰므로 기준은 공유된다.
+
+사용:
+    python -m backend.scripts.build_signal_eval_set --count 30 --output eval.csv
+    python -m backend.scripts.build_signal_eval_set --stocks 삼성전자 SK하이닉스
+
+뉴스 MCP(mcp-news)가 네이버 API 키를 필요로 하므로 .env 설정이 되어 있어야 한다.
+"""
+import argparse
+import asyncio
+import csv
+import sys
+from pathlib import Path
+from typing import Any, NamedTuple
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from sqlmodel import Session  # noqa: E402
+
+from backend.config import NEWS_MCP_PARAMS  # noqa: E402
+from backend.database import engine  # noqa: E402
+from backend.scheduler import DEFAULT_MONITOR_STOCKS  # noqa: E402
+from backend.services import run_mcp_tool, score_signal  # noqa: E402
+from backend.watchlist_repo import SqliteWatchlistRepo  # noqa: E402
+
+DEFAULT_COUNT = 30
+DEFAULT_OUTPUT = "signal_eval_set.csv"
+# 사람이 엑셀로 열어 채점할 파일이다. utf-8-sig가 아니면 한글이 깨진 채 열린다.
+CSV_ENCODING = "utf-8-sig"
+CSV_HEADER = ("종목", "제목", "본문요약", "모델점수", "모델근거", "사람점수")
+
+
+class Article(NamedTuple):
+    stock: str
+    title: str
+    summary: str
+
+
+def parse_article_line(stock: str, line: str) -> Article | None:
+    """mcp-news의 한 줄(``제목 - 설명 | 날짜 | 링크``)을 제목/본문요약으로 나눈다.
+
+    형식이 어긋나면 줄 전체를 제목으로 두고 본문요약을 비운다 — 버리지 않는 이유는
+    평가셋에 "형식이 이상한 기사"도 들어가야 모델의 실제 입력 분포를 닮기 때문이다.
+    """
+    text = line.strip()
+    if not text:
+        return None
+
+    title, separator, rest = text.partition(" - ")
+    if not separator:
+        return Article(stock=stock, title=text, summary="")
+
+    # 설명 뒤에 " | 날짜 | 링크"가 붙는다. 사람이 읽을 부분은 설명까지다.
+    summary = rest.split(" | ")[0].strip()
+    return Article(stock=stock, title=title.strip(), summary=summary)
+
+
+async def collect_articles(stocks: list[str], count: int) -> list[Article]:
+    """종목을 돌며 기사를 count건 모은다. 제목이 같은 기사는 한 번만 담는다."""
+    articles: list[Article] = []
+    seen_titles: set[str] = set()
+
+    for stock in stocks:
+        if len(articles) >= count:
+            break
+        try:
+            raw = await run_mcp_tool(
+                NEWS_MCP_PARAMS, "get_market_news", {"stock_name": stock}
+            )
+        except Exception as exc:  # noqa: BLE001 - 한 종목 실패로 수집 전체를 중단하지 않는다
+            print(f"[skip] {stock}: 뉴스 수집 실패 — {exc}", file=sys.stderr)
+            continue
+
+        for line in str(raw).splitlines():
+            article = parse_article_line(stock, line)
+            if article is None or article.title in seen_titles:
+                continue
+            seen_titles.add(article.title)
+            articles.append(article)
+            if len(articles) >= count:
+                break
+
+    return articles
+
+
+async def score_articles(articles: list[Article], provider: str) -> list[dict[str, Any]]:
+    """기사별로 모델 점수를 매긴다. 채점에 실패한 기사는 점수 칸을 비운다.
+
+    실패를 0점으로 적으면 평가셋 자체가 오염된다 — 사람 채점과 대조할 때 "모델이
+    중립이라고 봤다"와 "모델이 답을 못 냈다"가 같은 행으로 섞여 정확도가 왜곡된다.
+    """
+    rows: list[dict[str, Any]] = []
+    for index, article in enumerate(articles, start=1):
+        signal_text = article.title
+        if article.summary:
+            signal_text = f"{article.title} - {article.summary}"
+
+        scored = await score_signal(
+            article.stock, signal_text, source="news", provider=provider
+        )
+        # 채점 실패(fail-open)는 is_significant=True에 score=None으로 온다.
+        model_score = "" if scored.score is None else scored.score
+        rows.append(
+            {
+                "종목": article.stock,
+                "제목": article.title,
+                "본문요약": article.summary,
+                "모델점수": model_score,
+                "모델근거": scored.reason or "",
+                "사람점수": "",  # 나중에 손으로 채운다
+            }
+        )
+        print(f"[{index}/{len(articles)}] {article.stock}: {model_score or '채점 실패'}")
+    return rows
+
+
+def write_csv(rows: list[dict[str, Any]], output: Path) -> None:
+    with output.open("w", encoding=CSV_ENCODING, newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(CSV_HEADER))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+async def resolve_stocks(explicit: list[str] | None) -> list[str]:
+    """--stocks가 없으면 관심종목 + 기본 감시 종목을 쓴다 (순서 유지, 중복 제거)."""
+    if explicit:
+        return list(dict.fromkeys(explicit))
+
+    try:
+        watchlist = await SqliteWatchlistRepo(lambda: Session(engine)).get_watchlist()
+    except Exception as exc:  # noqa: BLE001 - DB가 없어도 기본 종목으로는 돌아가야 한다
+        print(f"[warn] 관심종목 조회 실패 — 기본 종목만 사용합니다: {exc}", file=sys.stderr)
+        watchlist = []
+
+    return list(dict.fromkeys([*watchlist, *DEFAULT_MONITOR_STOCKS]))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="신호 점수화 평가셋(사람 채점용 CSV)을 만든다. (#298)",
+    )
+    parser.add_argument("--count", type=int, default=DEFAULT_COUNT, help="수집할 기사 수")
+    parser.add_argument("--output", default=DEFAULT_OUTPUT, help="CSV 출력 경로")
+    parser.add_argument("--provider", default="ollama", help="채점에 쓸 경량 LLM provider")
+    parser.add_argument("--stocks", nargs="*", help="수집 대상 종목 (미지정 시 관심종목+기본 종목)")
+    return parser
+
+
+async def main() -> int:
+    args = build_parser().parse_args()
+
+    stocks = await resolve_stocks(args.stocks)
+    print(f"수집 대상 종목: {', '.join(stocks)}")
+
+    articles = await collect_articles(stocks, args.count)
+    if not articles:
+        print("수집된 기사가 없습니다. 뉴스 MCP 설정(.env)을 확인하세요.", file=sys.stderr)
+        return 1
+    if len(articles) < args.count:
+        # 조용히 적게 뽑고 끝내면 평가셋이 왜 30건이 아닌지 나중에 아무도 모른다.
+        print(
+            f"[warn] {args.count}건을 요청했지만 {len(articles)}건만 모았습니다 "
+            "(종목당 기사 수 한도). --stocks로 종목을 늘리세요.",
+            file=sys.stderr,
+        )
+
+    rows = await score_articles(articles, args.provider)
+    output = Path(args.output)
+    write_csv(rows, output)
+
+    scored_count = sum(1 for row in rows if row["모델점수"] != "")
+    print(f"{output} 에 {len(rows)}행을 썼습니다 (채점 성공 {scored_count}행).")
+    print("'사람점수' 열은 비어 있습니다 — 손으로 채운 뒤 모델점수와 대조하세요.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/backend/services.py
+++ b/backend/services.py
@@ -2,8 +2,10 @@ import json
 import httpx
 import logging
 import re
+from contextvars import ContextVar
 from datetime import date
-from typing import Any, Literal, NamedTuple, Optional, get_args, overload
+from statistics import pstdev
+from typing import Any, Literal, NamedTuple, Optional, Sequence, get_args, overload
 from urllib.parse import quote as _url_quote
 from fastapi import HTTPException
 from anthropic import AsyncAnthropic
@@ -19,6 +21,7 @@ from .config import (
     OLLAMA_API_KEY, OLLAMA_MODEL, OLLAMA_BASE_URL,
     NAT_BASE_URL, NAT_CHAT_MODEL, NAT_CONVERSATION_ID,
     NEWS_MCP_PARAMS, TRADING_MCP_PARAMS,
+    SIGNAL_SCORE_MIN, SIGNAL_SCORE_MAX, SIGNAL_SCORE_THRESHOLD,
 )
 from .schemas import TradingSignal, AnalysisReport
 from .models import AgentReport
@@ -320,6 +323,7 @@ async def perform_stock_analysis(
     *,
     trigger_source: str | None = None,
     trigger_signal: str | None = None,
+    signal_score: "SignalScore | None" = None,
     conversation_id: str | None = None,
 ) -> dict[str, Any]:
     """
@@ -331,6 +335,10 @@ async def perform_stock_analysis(
 
     provider=openai/anthropic/ollama: 도구 없이 일반 배경 설명만 생성한다.
     decision·confidence_score는 저장하지 않는다 (DB와 API 응답 모두 null).
+
+    signal_score: 감시 파이프라인의 2차 필터가 매긴 채점 결과 (#298). 필터를 거치지
+    않은 경로(수동 분석, API 직접 호출)는 None이며, 이때 신호 점수 세 필드는 모두
+    null로 남는다 — 0으로 채우지 않는다.
     """
     key = normalize_llm_provider(provider)
     supports_tools = provider_supports_tools(key)
@@ -366,6 +374,15 @@ async def perform_stock_analysis(
     data["provider"] = key
     data["provider_supports_tools"] = supports_tools
 
+    # #298: 2차 필터의 채점 결과도 같은 자리에서 응답·DB 양쪽에 붙인다. 알림
+    # 포매터(telegram_notifier.format_analysis_alert)는 이 세 키만 보고 영향도 줄을
+    # 만들므로, 여기서 빠지면 알림에서 조용히 사라진다.
+    data["signal_score"] = signal_score.score if signal_score is not None else None
+    data["signal_reason"] = signal_score.reason if signal_score is not None else None
+    data["signal_uncertainty"] = (
+        signal_score.uncertainty if signal_score is not None else None
+    )
+
     # 분석 리포트를 데이터베이스에 자동으로 저장
     try:
         stock_code = await _resolve_stock_code(stock)
@@ -378,6 +395,9 @@ async def perform_stock_analysis(
             confidence_score=confidence_score,
             reason=reason,
             provider_supports_tools=supports_tools,
+            signal_score=data["signal_score"],
+            signal_reason=data["signal_reason"],
+            signal_uncertainty=data["signal_uncertainty"],
         )
         session.add(report)
         session.commit()
@@ -473,6 +493,229 @@ def _string_list(value: Any) -> list[str]:
     return []
 
 
+class SignalScore(NamedTuple):
+    """2차 필터가 signal 하나에 대해 내린 채점 결과 (#298).
+
+    ``score``/``reason``/``uncertainty``가 None인 것과 0/""인 것은 다른 상태다.
+    None은 "채점하지 못했다", 0은 "무관/중립이라고 채점했다"이다 (#122·#162).
+    """
+
+    score: Optional[int]
+    reason: Optional[str]
+    uncertainty: Optional[float]
+    headline_scores: tuple[int, ...]
+    is_significant: bool
+
+
+# 채점에 실패했을 때의 결과. is_significant=True가 핵심이다 (REQ-04 fail-open):
+# 경량 LLM이 죽었다고 상세 분석까지 건너뛰면 진짜 대형 악재를 통째로 놓친다.
+# 점수는 null로 남겨 "통과시켰지만 몇 점인지는 모른다"를 사후에 구분할 수 있게 한다.
+_FAIL_OPEN_SIGNAL_SCORE = SignalScore(None, None, None, (), True)
+# 채점 이전에 걸러진 signal(빈 내용, 직전과 동일 내용). LLM을 부르지도 않았으므로 점수가 없다.
+_SKIPPED_SIGNAL_SCORE = SignalScore(None, None, None, (), False)
+
+# reason은 알림 한 줄에 들어간다. 모델이 장문을 뱉으면 잘라 쓴다.
+_SIGNAL_REASON_MAX_CHARS = 120
+# 채점 프롬프트에 넣는 signal 본문 상한 (기존 YES/NO 필터와 동일하게 유지).
+_SIGNAL_SNIPPET_CHARS = 1000
+
+# 직전 check_signal_significance 호출의 채점 결과를 담는 사이드 채널.
+#
+# check_signal_significance의 반환형은 bool로 유지한다 — "유의미한가"는 이 함수의
+# 공개 계약이고, 호출부(scheduler, check_news_significance)와 테스트가 그 계약에
+# 의존한다. 점수·근거·불확실성은 그 판정에 딸린 진단 정보이므로, 반환형을 바꿔
+# 모든 호출부를 흔드는 대신 컨텍스트 지역 변수로 흘린다.
+#
+# ContextVar를 쓰는 이유: 감시 루프는 종목·소스마다 별개의 asyncio 태스크로 갈릴 수
+# 있고, 모듈 전역 변수는 그때 서로의 점수를 덮어쓴다. ContextVar는 태스크별로
+# 격리되면서, await로 이어진 같은 태스크 안에서는 호출부에 그대로 보인다.
+_last_signal_score: ContextVar[Optional[SignalScore]] = ContextVar(
+    "fin_us_last_signal_score", default=None
+)
+
+
+def take_last_signal_score() -> Optional[SignalScore]:
+    """직전 채점 결과를 꺼내고 비운다. 채점이 없었으면 None.
+
+    꺼내면서 비우는 것이 중요하다. 남겨 두면 다음 종목이 채점 경로를 타지 않고
+    지나갈 때(테스트에서 함수가 monkeypatch된 경우 등) 앞 종목의 점수를 자기
+    것으로 착각한다.
+    """
+    value = _last_signal_score.get()
+    _last_signal_score.set(None)
+    return value
+
+
+def _coerce_signal_score(value: Any) -> Optional[int]:
+    """임의의 JSON 값을 -3~+3 정수로 좁힌다. 숫자로 볼 수 없으면 None.
+
+    소수(2.5)는 반올림한다 — 프롬프트는 정수를 요구하지만 경량 모델은 자주 어긴다.
+    레인지를 벗어난 값(7, -9)은 버리지 않고 끝값으로 자른다: "아주 큰 호재"라는
+    방향 정보 자체는 유효하고, 이걸 파싱 실패로 처리하면 하필 대형 신호에서만
+    fail-open이 잦아진다. bool은 int의 하위형이라 True가 1점으로 새는 것을 막는다.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, str):
+        try:
+            value = float(value.strip())
+        except ValueError:
+            return None
+    if not isinstance(value, (int, float)):
+        return None
+    if value != value or value in (float("inf"), float("-inf")):  # NaN/±inf
+        return None
+    return max(SIGNAL_SCORE_MIN, min(SIGNAL_SCORE_MAX, int(round(value))))
+
+
+def signal_score_uncertainty(headline_scores: Sequence[int]) -> Optional[float]:
+    """기사별 점수의 표준편차. 기사가 2건 미만이면 None.
+
+    LLM에게 확신도를 묻지 않고 코드로 계산한다 — 모델이 스스로 신고하는 확신도는
+    보정되지 않은 값이지만, "여러 기사가 서로 다른 방향을 가리킨다"는 관측된 사실이다.
+
+    모집단 표준편차(pstdev)를 쓴다: 이 기사 묶음은 더 큰 모집단에서 뽑은 표본이
+    아니라 판단에 실제로 쓴 전부다. 1건이면 0.0이 아니라 None이다 — 0.0은
+    "기사들이 완전히 일치했다"는 뜻이고, 1건은 흩어짐을 정의할 수 없는 상태다.
+    """
+    if len(headline_scores) < 2:
+        return None
+    return pstdev(headline_scores)
+
+
+def parse_signal_score(raw: str) -> Optional[SignalScore]:
+    """채점 응답 텍스트에서 SignalScore를 뽑는다. 실패하면 None.
+
+    None은 호출부에서 fail-open(유의미 취급)으로 이어진다. 그래서 "적당히 넘겨
+    짚기"보다 명확히 실패로 떨어뜨리는 편이 안전하다 — 점수를 지어내면 그 값이
+    DB와 평가셋에 그대로 남지만, 실패는 null로 남아 구분된다.
+    """
+    for data in _json_objects_from_text(raw or ""):
+        score = _coerce_signal_score(data.get("score"))
+        if score is None:
+            continue
+
+        raw_reason = data.get("reason")
+        reason: Optional[str] = None
+        if isinstance(raw_reason, str):
+            # 알림 한 줄에 들어가므로 줄바꿈을 접는다.
+            collapsed = " ".join(raw_reason.split())
+            reason = collapsed[:_SIGNAL_REASON_MAX_CHARS] or None
+
+        raw_headlines = data.get("headline_scores")
+        headline_scores: tuple[int, ...] = ()
+        if isinstance(raw_headlines, list):
+            # 숫자로 볼 수 없는 원소는 버린다. 개수가 기사 수와 어긋날 수 있지만,
+            # 표준편차는 "실제로 채점된 기사들"의 흩어짐이면 충분하다.
+            headline_scores = tuple(
+                coerced
+                for coerced in (_coerce_signal_score(item) for item in raw_headlines)
+                if coerced is not None
+            )
+
+        return SignalScore(
+            score=score,
+            reason=reason,
+            uncertainty=signal_score_uncertainty(headline_scores),
+            headline_scores=headline_scores,
+            is_significant=abs(score) >= SIGNAL_SCORE_THRESHOLD,
+        )
+    return None
+
+
+def _build_signal_score_prompt(stock: str, source: str, snippet: str) -> str:
+    """채점 프롬프트. 단계별 기준을 모두 적어 모델이 축을 스스로 상상하지 않게 한다.
+
+    레인지를 -3~+3으로 좁게 잡은 것은 의도다. 0~100 같은 넓은 축에서 경량 모델은
+    같은 기사에 매번 다른 점수를 준다 — 좁은 축은 재현성을 사고, 잃는 해상도는
+    이 필터가 애초에 필요로 하지 않는다.
+    """
+    headline_count = len([line for line in snippet.splitlines() if line.strip()])
+    return (
+        f"당신은 전문 주식 분석가입니다. 다음은 '{stock}' 종목에 대한 최신 외부 signal입니다.\n"
+        f"signal 출처: {source}\n\n"
+        f"--- signal 내용 ---\n{snippet}\n"
+        "------------------\n\n"
+        f"이 signal이 '{stock}'의 투자 판단에 미치는 영향을 아래 기준으로 채점하십시오.\n"
+        "+3: 실적 서프라이즈, 대형 수주·계약, M&A 등 명확한 대형 호재\n"
+        "+2: 방향이 분명한 호재 (신규 대형 고객사, 의미 있는 가이던스 상향 등)\n"
+        "+1: 약한 호재 또는 우호적인 분위기\n"
+        " 0: 투자 판단과 무관하거나 중립 (홍보성 기사, 단순 시황 나열, 반복되는 내용)\n"
+        "-1: 약한 악재\n"
+        "-2: 방향이 분명한 악재 (가이던스 하향, 주요 고객 이탈 등)\n"
+        "-3: 실적 쇼크, 대형 소송·제재, 회계 이슈 등 명확한 대형 악재\n\n"
+        f"signal 내용은 기사 {headline_count}건이 줄 단위로 이어져 있습니다. "
+        "headline_scores에는 각 기사를 같은 기준으로 따로 채점한 정수를 원문 순서대로 담으십시오.\n\n"
+        "반드시 아래 JSON 객체 하나만 출력하고 다른 설명은 붙이지 마십시오.\n"
+        '{"score": <-3~3 정수>, "reason": "<점수 근거 한 줄, 40자 이내>", '
+        '"headline_scores": [<-3~3 정수>, ...]}'
+    )
+
+
+async def score_signal(
+    stock: str,
+    signal_content: str,
+    last_signal_content: Optional[str] = None,
+    *,
+    source: str = "signal",
+    provider: str = "ollama",
+) -> SignalScore:
+    """외부 signal을 -3~+3으로 채점한다 (#298).
+
+    로컬 초경량 모델(예: gemma4) 또는 경량 API 모델(예: gpt-5.4-mini)을 1차
+    필터로 사용해 비용과 정확도의 균형을 맞춘다.
+
+    호출·파싱에 실패하면 예외를 올리지 않고 fail-open한다 — 유의미로 통과시키되
+    점수는 null로 남긴다 (REQ-04 놓침 방지).
+    """
+    if not signal_content:
+        return _SKIPPED_SIGNAL_SCORE
+
+    if signal_content == last_signal_content:
+        return _SKIPPED_SIGNAL_SCORE
+
+    prompt = _build_signal_score_prompt(
+        stock, source, signal_content[:_SIGNAL_SNIPPET_CHARS]
+    )
+
+    try:
+        # 설정된 provider(ollama, openai 등)에 따라 경량 모델 호출
+        raw = await llm_chat(provider, prompt)
+    except Exception as e:
+        logger.error(
+            "signal 채점 호출 실패 (%s, %s, %s): %s — 유의미로 통과시킵니다(fail-open)",
+            source,
+            stock,
+            provider,
+            e,
+        )
+        return _FAIL_OPEN_SIGNAL_SCORE
+
+    parsed = parse_signal_score(str(raw))
+    if parsed is None:
+        logger.warning(
+            "signal 채점 응답을 파싱하지 못했습니다 [%s:%s] (Provider: %s) — "
+            "유의미로 통과시킵니다(fail-open)",
+            source,
+            stock,
+            provider,
+        )
+        return _FAIL_OPEN_SIGNAL_SCORE
+
+    logger.info(
+        "signal 채점 [%s:%s] (Provider: %s): score=%s, 유의미=%s, 기사별=%s, 흩어짐=%s, 근거=%s",
+        source,
+        stock,
+        provider,
+        parsed.score,
+        parsed.is_significant,
+        list(parsed.headline_scores),
+        parsed.uncertainty,
+        parsed.reason,
+    )
+    return parsed
+
+
 async def check_signal_significance(
     stock: str,
     signal_content: str,
@@ -481,46 +724,22 @@ async def check_signal_significance(
     source: str = "signal",
     provider: str = "ollama"
 ) -> bool:
-    """
-    외부 signal을 분석하여 투자 관점에서 유의미한 변화가 있는지 판단합니다.
-    로컬 초경량 모델(예: gemma4) 또는 경량 API 모델(예: gpt-5.4-mini)을 
-    1차 필터로 사용하여 비용과 정확도의 균형을 맞출 수 있습니다.
-    """
-    if not signal_content:
-        return False
-    
-    if signal_content == last_signal_content:
-        return False
+    """외부 signal이 투자 관점에서 유의미한 변화인지 판단합니다.
 
-    # signal 텍스트 상단 1000자 사용
-    snip_content = signal_content[:1000]
-
-    prompt = (
-        f"당신은 전문 주식 분석가입니다. 다음은 '{stock}' 종목에 대한 최신 외부 signal입니다.\n"
-        f"signal 출처: {source}\n\n"
-        f"--- signal 내용 ---\n{snip_content}\n"
-        "------------------\n\n"
-        "이 signal이 기존 상황을 바꿀 만큼 유의미한 새로운 투자 정보"
-        "(실적 발표, 계약, M&A, 수급 변화, 평판 리스크, 급격한 여론 변화 등)를 포함하고 있습니까?\n"
-        "중요한 변화가 있다면 'YES', 사소하거나 반복되는 signal이라면 'NO'라고만 답하세요.\n"
-        "답변은 반드시 다른 설명 없이 'YES' 또는 'NO' 중 하나로만 대답하십시오."
+    판정은 :func:`score_signal`의 점수를 ``|score| >= SIGNAL_SCORE_THRESHOLD``로
+    환산한 것이다 (#298 이전에는 경량 LLM에 YES/NO를 직접 물었다). 반환형은 bool
+    그대로 유지하고, 점수·근거·불확실성은 :func:`take_last_signal_score`로 꺼낸다
+    (사이드 채널을 쓰는 이유는 ``_last_signal_score`` 주석 참고).
+    """
+    scored = await score_signal(
+        stock,
+        signal_content,
+        last_signal_content,
+        source=source,
+        provider=provider,
     )
-
-    try:
-        # 설정된 provider(ollama, openai 등)에 따라 경량 모델 호출
-        result = await llm_chat(provider, prompt)
-        is_significant = "YES" in result.upper()
-        logger.info(
-            "signal 유의미성 확인 [%s:%s] (Provider: %s): %s",
-            source,
-            stock,
-            provider,
-            is_significant,
-        )
-        return is_significant
-    except Exception as e:
-        logger.error(f"signal 유의미성 확인 중 오류 발생 ({source}, {stock}, {provider}): {e}")
-        return True
+    _last_signal_score.set(scored)
+    return scored.is_significant
 
 
 async def check_news_significance(

--- a/backend/services.py
+++ b/backend/services.py
@@ -2,7 +2,6 @@ import json
 import httpx
 import logging
 import re
-from contextvars import ContextVar
 from datetime import date
 from statistics import pstdev
 from typing import Any, Literal, NamedTuple, Optional, Sequence, get_args, overload
@@ -519,33 +518,6 @@ _SIGNAL_REASON_MAX_CHARS = 120
 # 채점 프롬프트에 넣는 signal 본문 상한 (기존 YES/NO 필터와 동일하게 유지).
 _SIGNAL_SNIPPET_CHARS = 1000
 
-# 직전 check_signal_significance 호출의 채점 결과를 담는 사이드 채널.
-#
-# check_signal_significance의 반환형은 bool로 유지한다 — "유의미한가"는 이 함수의
-# 공개 계약이고, 호출부(scheduler, check_news_significance)와 테스트가 그 계약에
-# 의존한다. 점수·근거·불확실성은 그 판정에 딸린 진단 정보이므로, 반환형을 바꿔
-# 모든 호출부를 흔드는 대신 컨텍스트 지역 변수로 흘린다.
-#
-# ContextVar를 쓰는 이유: 감시 루프는 종목·소스마다 별개의 asyncio 태스크로 갈릴 수
-# 있고, 모듈 전역 변수는 그때 서로의 점수를 덮어쓴다. ContextVar는 태스크별로
-# 격리되면서, await로 이어진 같은 태스크 안에서는 호출부에 그대로 보인다.
-_last_signal_score: ContextVar[Optional[SignalScore]] = ContextVar(
-    "fin_us_last_signal_score", default=None
-)
-
-
-def take_last_signal_score() -> Optional[SignalScore]:
-    """직전 채점 결과를 꺼내고 비운다. 채점이 없었으면 None.
-
-    꺼내면서 비우는 것이 중요하다. 남겨 두면 다음 종목이 채점 경로를 타지 않고
-    지나갈 때(테스트에서 함수가 monkeypatch된 경우 등) 앞 종목의 점수를 자기
-    것으로 착각한다.
-    """
-    value = _last_signal_score.get()
-    _last_signal_score.set(None)
-    return value
-
-
 def _coerce_signal_score(value: Any) -> Optional[int]:
     """임의의 JSON 값을 -3~+3 정수로 좁힌다. 숫자로 볼 수 없으면 None.
 
@@ -571,8 +543,11 @@ def _coerce_signal_score(value: Any) -> Optional[int]:
 def signal_score_uncertainty(headline_scores: Sequence[int]) -> Optional[float]:
     """기사별 점수의 표준편차. 기사가 2건 미만이면 None.
 
-    LLM에게 확신도를 묻지 않고 코드로 계산한다 — 모델이 스스로 신고하는 확신도는
-    보정되지 않은 값이지만, "여러 기사가 서로 다른 방향을 가리킨다"는 관측된 사실이다.
+    LLM에게 확신도를 직접 묻지 않고 코드로 계산한다. headline_scores도 결국 같은
+    모델의 자기보고이므로 이것이 "객관적 사실"이 되는 것은 아니다 — 다만 항목별로
+    따로 받은 점수의 흩어짐은 한 번에 물어본 확신도보다 다루기 쉽다. 계산 규칙이
+    코드에 고정돼 있어 프롬프트가 바뀌어도 일관되고, 사람이 같은 기사에 매긴 점수로
+    똑같이 계산해 대조할 수 있다.
 
     모집단 표준편차(pstdev)를 쓴다: 이 기사 묶음은 더 큰 모집단에서 뽑은 표본이
     아니라 판단에 실제로 쓴 전부다. 1건이면 0.0이 아니라 None이다 — 0.0은
@@ -621,6 +596,24 @@ def parse_signal_score(raw: str) -> Optional[SignalScore]:
             is_significant=abs(score) >= SIGNAL_SCORE_THRESHOLD,
         )
     return None
+
+
+def _signal_snippet(signal_content: str) -> str:
+    """채점에 넣을 본문을 상한까지 자르되, 잘려 나간 마지막 줄은 버린다.
+
+    signal은 기사 한 건이 한 줄이다. 상한에서 반토막 난 줄을 남기면 모델은 그것을
+    온전한 기사 1건으로 세어 점수를 매기고, 그 값이 headline_scores를 거쳐
+    signal_uncertainty(표준편차)까지 오염시킨다.
+
+    상한 안에 줄바꿈이 하나도 없으면 통째로 한 기사이므로 자른 그대로 쓴다 —
+    이때는 버릴 온전한 줄이 없어서, 버리면 채점할 내용 자체가 사라진다.
+    """
+    if len(signal_content) <= _SIGNAL_SNIPPET_CHARS:
+        return signal_content
+
+    truncated = signal_content[:_SIGNAL_SNIPPET_CHARS]
+    head, separator, _partial = truncated.rpartition("\n")
+    return head if separator else truncated
 
 
 def _build_signal_score_prompt(stock: str, source: str, snippet: str) -> str:
@@ -674,9 +667,7 @@ async def score_signal(
     if signal_content == last_signal_content:
         return _SKIPPED_SIGNAL_SCORE
 
-    prompt = _build_signal_score_prompt(
-        stock, source, signal_content[:_SIGNAL_SNIPPET_CHARS]
-    )
+    prompt = _build_signal_score_prompt(stock, source, _signal_snippet(signal_content))
 
     try:
         # 설정된 provider(ollama, openai 등)에 따라 경량 모델 호출
@@ -727,9 +718,11 @@ async def check_signal_significance(
     """외부 signal이 투자 관점에서 유의미한 변화인지 판단합니다.
 
     판정은 :func:`score_signal`의 점수를 ``|score| >= SIGNAL_SCORE_THRESHOLD``로
-    환산한 것이다 (#298 이전에는 경량 LLM에 YES/NO를 직접 물었다). 반환형은 bool
-    그대로 유지하고, 점수·근거·불확실성은 :func:`take_last_signal_score`로 꺼낸다
-    (사이드 채널을 쓰는 이유는 ``_last_signal_score`` 주석 참고).
+    환산한 것이다 (#298 이전에는 경량 LLM에 YES/NO를 직접 물었다).
+
+    점수·근거·불확실성까지 필요한 호출부는 :func:`score_signal`을 직접 쓴다 —
+    감시 파이프라인(scheduler)이 그렇게 한다. 이 함수는 "유의미한가"만 알면 되는
+    호출부를 위한 얇은 래퍼다.
     """
     scored = await score_signal(
         stock,
@@ -738,7 +731,6 @@ async def check_signal_significance(
         source=source,
         provider=provider,
     )
-    _last_signal_score.set(scored)
     return scored.is_significant
 
 

--- a/backend/telegram_notifier.py
+++ b/backend/telegram_notifier.py
@@ -5,7 +5,12 @@ from typing import Any
 
 import httpx
 
-from .config import TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID, is_placeholder_secret
+from .config import (
+    TELEGRAM_BOT_TOKEN,
+    TELEGRAM_CHAT_ID,
+    SIGNAL_UNCERTAINTY_ALERT_THRESHOLD,
+    is_placeholder_secret,
+)
 
 logger = logging.getLogger(__name__)
 _TELEGRAM_BOT_URL_RE = re.compile(r"(https://api\.telegram\.org/bot)[^/\s\"]+")
@@ -15,6 +20,12 @@ TELEGRAM_MESSAGE_LIMIT = 4000
 
 URGENT_TELEGRAM_LEVELS = {"high", "critical"}
 TELEGRAM_ALERT_MODES = {"urgent", "all", "off"}
+
+# #298 신호 점수 표시 문자열. 상수로 분리해 둔 것은 출력 계층 작업(#7)이 이 조각을
+# 그대로 감싸거나 다른 채널(웹, 음성)로 옮길 때 문구를 다시 찾아 헤매지 않게 하기
+# 위함이다. 문구를 바꿀 일이 생기면 여기 한 곳만 고친다.
+SIGNAL_SCORE_LABEL = "📊 영향도"
+SIGNAL_DISAGREEMENT_NOTE = "⚠️ 기사 간 평가 엇갈림"
 
 
 def _redact_telegram_bot_token(value: str) -> str:
@@ -244,6 +255,46 @@ def should_send_telegram_alert(
     )
 
 
+def format_signal_score_line(
+    score: Any,
+    reason: Any = None,
+    uncertainty: Any = None,
+    *,
+    uncertainty_threshold: float = SIGNAL_UNCERTAINTY_ALERT_THRESHOLD,
+) -> str | None:
+    """신호 점수 한 줄을 만든다. 점수가 없으면 None (#298).
+
+    ``📊 영향도 -2 (주요 고객 이탈 보도)`` 형태이고, 기사별 점수가 크게 흩어졌으면
+    뒤에 ``⚠️ 기사 간 평가 엇갈림``을 붙인다.
+
+    score가 None이면 줄 자체를 만들지 않는다. "미측정"을 항상 붙이면 필터를 거치지
+    않는 수동 분석 알림까지 오염되는데, analysis_data만 봐서는 "채점 실패(fail-open)"
+    와 "애초에 채점 경로가 아님"을 구분할 수 없다. 둘의 구분이 필요하면 DB의
+    AgentReport.signal_score(null)와 로그를 본다.
+
+    이 함수는 메서드가 아니라 모듈 함수다 — 알림 이외의 출력 계층도 TelegramNotifier
+    인스턴스 없이 같은 문구를 쓸 수 있어야 한다.
+    """
+    if isinstance(score, bool) or not isinstance(score, Real):
+        return None
+
+    # +2/-2로 부호를 명시한다. 0은 "+0"이 어색하므로 그대로 0.
+    score_text = "0" if score == 0 else f"{int(score):+d}"
+    line = f"{SIGNAL_SCORE_LABEL} {score_text}"
+
+    if isinstance(reason, str) and reason.strip():
+        line = f"{line} ({' '.join(reason.split())})"
+
+    if (
+        isinstance(uncertainty, Real)
+        and not isinstance(uncertainty, bool)
+        and uncertainty >= uncertainty_threshold
+    ):
+        line = f"{line} · {SIGNAL_DISAGREEMENT_NOTE}"
+
+    return line
+
+
 def _message_id_from_send_body(body: Any) -> int | None:
     """sendMessage 응답 본문에서 ``message_id``를 뽑는다 (#260).
 
@@ -308,6 +359,15 @@ class TelegramNotifier:
             f"Reason: {reason}",
             f"Urgency: {urgency} - {urgency_reason}",
         ]
+        # #298: 이 알림을 촉발한 signal이 몇 점이었는지. 점수가 없으면 줄이 통째로
+        # 빠진다 — 제목 바로 아래에 넣어 Decision보다 먼저 읽히게 한다.
+        score_line = format_signal_score_line(
+            analysis_data.get("signal_score"),
+            analysis_data.get("signal_reason"),
+            analysis_data.get("signal_uncertainty"),
+        )
+        if score_line is not None:
+            lines.insert(1, score_line)
         if summary:
             lines.append(f"Summary: {summary}")
         return "\n".join(lines)[:TELEGRAM_MESSAGE_LIMIT]

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -228,3 +228,15 @@ def test_signal_uncertainty_alert_threshold_rejects_negative_and_garbage(
 
     monkeypatch.setenv("SIGNAL_UNCERTAINTY_ALERT_THRESHOLD", "0.75")
     assert importlib.reload(config).SIGNAL_UNCERTAINTY_ALERT_THRESHOLD == 0.75
+
+
+@pytest.mark.parametrize("raw", ["inf", "-inf", "nan"])
+def test_signal_uncertainty_alert_threshold_rejects_non_finite(monkeypatch, restore_config, raw):
+    """float()가 받아 주는 inf/nan을 통과시키면 안 된다.
+
+    inf면 "기사 간 평가 엇갈림"이 어떤 표준편차로도 표시되지 않아 기능 하나가 조용히
+    꺼진다. nan은 모든 비교가 False라 같은 결과다.
+    """
+    monkeypatch.setenv("SIGNAL_UNCERTAINTY_ALERT_THRESHOLD", raw)
+
+    assert importlib.reload(config).SIGNAL_UNCERTAINTY_ALERT_THRESHOLD == 1.0

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -166,3 +166,65 @@ def test_visualization_url_is_trimmed_and_trailing_slash_preserved(monkeypatch):
     reloaded = importlib.reload(config)
 
     assert reloaded.VISUALIZATION_URL == "https://finus-visual.example/portfolio/"
+
+
+# --- #298: 신호 점수 임계값 -------------------------------------------------
+
+
+@pytest.fixture
+def restore_config():
+    """env를 바꿔 config를 reload한 테스트가 끝나면 원래 env로 되돌린다.
+
+    importlib.reload는 모듈 객체를 제자리에서 바꾸므로, 되돌리지 않으면 뒤따르는
+    테스트가 이 테스트의 env로 계산된 상수를 보게 된다.
+    """
+    yield
+    importlib.reload(config)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("1", 1),
+        ("3", 3),
+        (" 2 ", 2),
+    ],
+)
+def test_signal_score_threshold_reads_valid_env(monkeypatch, restore_config, raw, expected):
+    monkeypatch.setenv("SIGNAL_SCORE_THRESHOLD", raw)
+
+    assert importlib.reload(config).SIGNAL_SCORE_THRESHOLD == expected
+
+
+@pytest.mark.parametrize("raw", ["0", "4", "-2", "높음", "1.5", ""])
+def test_signal_score_threshold_falls_back_to_default_on_bad_env(
+    monkeypatch, restore_config, raw
+):
+    """범위를 벗어난 임계값은 조용히 파이프라인을 망가뜨린다.
+
+    0이면 모든 signal이 유의미해져 2차 필터가 사라지고(비용 폭증), 4 이상이면 어떤
+    점수도 통과하지 못해 감시가 영구히 침묵한다(놓침). 둘 다 사고이므로 기본값 2로
+    되돌린다.
+    """
+    monkeypatch.setenv("SIGNAL_SCORE_THRESHOLD", raw)
+
+    assert importlib.reload(config).SIGNAL_SCORE_THRESHOLD == 2
+
+
+def test_signal_score_threshold_defaults_to_two_when_unset(monkeypatch, restore_config):
+    monkeypatch.delenv("SIGNAL_SCORE_THRESHOLD", raising=False)
+
+    assert importlib.reload(config).SIGNAL_SCORE_THRESHOLD == 2
+
+
+def test_signal_uncertainty_alert_threshold_rejects_negative_and_garbage(
+    monkeypatch, restore_config
+):
+    monkeypatch.setenv("SIGNAL_UNCERTAINTY_ALERT_THRESHOLD", "-1")
+    assert importlib.reload(config).SIGNAL_UNCERTAINTY_ALERT_THRESHOLD == 1.0
+
+    monkeypatch.setenv("SIGNAL_UNCERTAINTY_ALERT_THRESHOLD", "높음")
+    assert importlib.reload(config).SIGNAL_UNCERTAINTY_ALERT_THRESHOLD == 1.0
+
+    monkeypatch.setenv("SIGNAL_UNCERTAINTY_ALERT_THRESHOLD", "0.75")
+    assert importlib.reload(config).SIGNAL_UNCERTAINTY_ALERT_THRESHOLD == 0.75

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -8,7 +8,23 @@ from fastapi.testclient import TestClient
 from unittest.mock import MagicMock
 from ..main import app
 from ..redis_state import RedisSchedulerState
+from ..services import SignalScore
 from .test_balance_parser import TRUNCATION_NOTES_BY_REASON
+
+
+def _scored(is_significant: bool, score: int | None = None) -> SignalScore:
+    """유의성 판정만 고정하는 SignalScore (#298).
+
+    2차 필터는 bool이 아니라 SignalScore를 돌려준다. 점수·근거를 함께 검증하는
+    테스트가 아니라면 판정만 지정하고 나머지는 "채점 정보 없음"(null)으로 둔다.
+    """
+    return SignalScore(
+        score=score,
+        reason=None,
+        uncertainty=None,
+        headline_scores=(),
+        is_significant=is_significant,
+    )
 
 
 def _resolved_broadcast_mock() -> MagicMock:
@@ -217,9 +233,9 @@ async def test_monitor_market_task_filtering(monkeypatch):
             return "[보유 종목 리스트]\n- 삼성전자 (005930): 10주\n- SK하이닉스 (000660): 2주\n- 현대차 (005380): 1주"
         return f"Latest news for {args['stock_name']}"
     
-    async def mock_check_significance(stock, current, last, *, source, provider):
+    async def mock_score_signal(stock, current, last, *, source, provider):
         _ = source
-        return current != last
+        return _scored(current != last)
 
     mock_perform_analysis = MagicMock(return_value=asyncio.Future())
     mock_perform_analysis.return_value.set_result({"summary": "Mocked", "details": {"decision": "BUY"}})
@@ -237,7 +253,7 @@ async def test_monitor_market_task_filtering(monkeypatch):
         "backend.scheduler.SIGNAL_SOURCES",
         [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
     )
-    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
     monkeypatch.setattr("backend.scheduler.perform_stock_analysis", mock_perform_analysis)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", mock_broadcast)
     monkeypatch.setattr("backend.scheduler.redis_state", unavailable_redis_state)
@@ -338,9 +354,9 @@ async def test_monitor_signal_sends_telegram_for_urgent_analysis(monkeypatch):
         _ = params, name, args
         return "urgent signal"
 
-    async def mock_check_significance(stock, current, last, *, source, provider):
+    async def mock_score_signal(stock, current, last, *, source, provider):
         _ = stock, current, last, source, provider
-        return True
+        return _scored(True)
 
     async def mock_perform_analysis(*args, **kwargs):
         _ = args, kwargs
@@ -357,7 +373,7 @@ async def test_monitor_signal_sends_telegram_for_urgent_analysis(monkeypatch):
     mock_broadcast.return_value.set_result(None)
 
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
-    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
     monkeypatch.setattr("backend.scheduler.perform_stock_analysis", mock_perform_analysis)
     monkeypatch.setattr("backend.scheduler.telegram_notifier.send_analysis_alert", mock_telegram)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", mock_broadcast)
@@ -380,9 +396,9 @@ async def test_monitor_signal_sends_telegram_for_all_mode_analysis(monkeypatch):
         _ = params, name, args
         return "normal signal"
 
-    async def mock_check_significance(stock, current, last, *, source, provider):
+    async def mock_score_signal(stock, current, last, *, source, provider):
         _ = stock, current, last, source, provider
-        return True
+        return _scored(True)
 
     async def mock_perform_analysis(*args, **kwargs):
         _ = args, kwargs
@@ -399,7 +415,7 @@ async def test_monitor_signal_sends_telegram_for_all_mode_analysis(monkeypatch):
     mock_broadcast.return_value.set_result(None)
 
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
-    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
     monkeypatch.setattr("backend.scheduler.perform_stock_analysis", mock_perform_analysis)
     monkeypatch.setattr("backend.scheduler.telegram_notifier.send_analysis_alert", mock_telegram)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", mock_broadcast)
@@ -421,9 +437,9 @@ async def test_monitor_signal_skips_telegram_when_alert_mode_off(monkeypatch):
         _ = params, name, args
         return "urgent signal"
 
-    async def mock_check_significance(stock, current, last, *, source, provider):
+    async def mock_score_signal(stock, current, last, *, source, provider):
         _ = stock, current, last, source, provider
-        return True
+        return _scored(True)
 
     async def mock_perform_analysis(*args, **kwargs):
         _ = args, kwargs
@@ -440,7 +456,7 @@ async def test_monitor_signal_skips_telegram_when_alert_mode_off(monkeypatch):
     mock_broadcast.return_value.set_result(None)
 
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
-    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
     monkeypatch.setattr("backend.scheduler.perform_stock_analysis", mock_perform_analysis)
     monkeypatch.setattr("backend.scheduler.telegram_notifier.send_analysis_alert", mock_telegram)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", mock_broadcast)
@@ -462,9 +478,9 @@ async def test_monitor_signal_keeps_websocket_when_telegram_fails(monkeypatch):
         _ = params, name, args
         return "urgent signal"
 
-    async def mock_check_significance(stock, current, last, *, source, provider):
+    async def mock_score_signal(stock, current, last, *, source, provider):
         _ = stock, current, last, source, provider
-        return True
+        return _scored(True)
 
     async def mock_perform_analysis(*args, **kwargs):
         _ = args, kwargs
@@ -483,7 +499,7 @@ async def test_monitor_signal_keeps_websocket_when_telegram_fails(monkeypatch):
     mock_broadcast.return_value.set_result(None)
 
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
-    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
     monkeypatch.setattr("backend.scheduler.perform_stock_analysis", mock_perform_analysis)
     monkeypatch.setattr("backend.scheduler.telegram_notifier.send_analysis_alert", failing_telegram)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", mock_broadcast)
@@ -515,9 +531,9 @@ async def test_monitor_market_task_uses_default_stocks_when_balance_empty(monkey
         monitored_stocks.append(args["stock_name"])
         return f"Latest news for {args['stock_name']}"
 
-    async def mock_check_significance(stock, current, last, *, source, provider):
+    async def mock_score_signal(stock, current, last, *, source, provider):
         _ = stock, current, last, source, provider
-        return False
+        return _scored(False)
 
     mock_perform_analysis = MagicMock(return_value=asyncio.Future())
     mock_perform_analysis.return_value.set_result({"summary": "Mocked"})
@@ -530,7 +546,7 @@ async def test_monitor_market_task_uses_default_stocks_when_balance_empty(monkey
         [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
-    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
     monkeypatch.setattr("backend.scheduler.perform_stock_analysis", mock_perform_analysis)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", mock_broadcast)
     # 이 테스트의 관심사는 기본 감시 종목 사용 여부이지 Portfolio 동기화가 아니다.
@@ -565,9 +581,9 @@ async def test_monitor_market_task_uses_redis_hash_to_skip_duplicate_news(monkey
             return "[보유 종목 리스트]\n- 삼성전자 (005930): 10주"
         return "Latest news for Samsung"
 
-    async def mock_check_significance(stock, current, last, *, source, provider):
+    async def mock_score_signal(stock, current, last, *, source, provider):
         _ = stock, current, last, source, provider
-        return True
+        return _scored(True)
 
     mock_perform_analysis = MagicMock(return_value=asyncio.Future())
     mock_perform_analysis.return_value.set_result({"summary": "Mocked"})
@@ -580,7 +596,7 @@ async def test_monitor_market_task_uses_redis_hash_to_skip_duplicate_news(monkey
         [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
-    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
     monkeypatch.setattr("backend.scheduler.perform_stock_analysis", mock_perform_analysis)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", mock_broadcast)
     # 이 테스트의 관심사는 Redis 해시로 뉴스 중복을 걸러내는지이지 Portfolio 동기화가
@@ -621,9 +637,9 @@ async def test_monitor_market_task_processes_multiple_signal_sources_independent
             return "[보유 종목 리스트]\n- 삼성전자 (005930): 10주"
         return f"{name}: {args['stock_name']}"
 
-    async def mock_check_significance(stock, current, last, *, source, provider):
+    async def mock_score_signal(stock, current, last, *, source, provider):
         _ = stock, current, last, source, provider
-        return True
+        return _scored(True)
 
     mock_perform_analysis = MagicMock(return_value=asyncio.Future())
     mock_perform_analysis.return_value.set_result({"summary": "Mocked"})
@@ -633,7 +649,7 @@ async def test_monitor_market_task_processes_multiple_signal_sources_independent
     monkeypatch.setattr("backend.scheduler.SIGNAL_SOURCES", sources)
     monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
-    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
     monkeypatch.setattr("backend.scheduler.perform_stock_analysis", mock_perform_analysis)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", mock_broadcast)
 
@@ -682,9 +698,9 @@ async def test_agent_analysis_broadcast_carries_no_analysis_body(monkeypatch):
             return "[보유 종목 리스트]\n- 삼성전자 (005930): 10주"
         return f"{name}: {args['stock_name']}"
 
-    async def mock_check_significance(stock, current, last, *, source, provider):
+    async def mock_score_signal(stock, current, last, *, source, provider):
         _ = stock, current, last, source, provider
-        return True
+        return _scored(True)
 
     mock_perform_analysis = MagicMock(return_value=asyncio.Future())
     mock_perform_analysis.return_value.set_result({"summary": secret})
@@ -697,7 +713,7 @@ async def test_agent_analysis_broadcast_carries_no_analysis_body(monkeypatch):
     )
     monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
-    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
     monkeypatch.setattr("backend.scheduler.perform_stock_analysis", mock_perform_analysis)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", mock_broadcast)
     # 텔레그램 알림에는 분석 전문이 그대로 가야 한다 — 인증된 채널이고, 이 이슈가 좁힌
@@ -771,9 +787,9 @@ async def test_concurrent_monitor_market_task_runs_once_with_scheduler_lock(monk
             return "[보유 종목 리스트]\n- 삼성전자 (005930): 10주"
         return "Latest news for Samsung"
 
-    async def mock_check_significance(stock, current, last, *, source, provider):
+    async def mock_score_signal(stock, current, last, *, source, provider):
         _ = stock, current, last, source, provider
-        return True
+        return _scored(True)
 
     mock_perform_analysis = MagicMock(return_value=asyncio.Future())
     mock_perform_analysis.return_value.set_result({"summary": "Mocked"})
@@ -786,7 +802,7 @@ async def test_concurrent_monitor_market_task_runs_once_with_scheduler_lock(monk
         [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
-    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
     monkeypatch.setattr("backend.scheduler.perform_stock_analysis", mock_perform_analysis)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", mock_broadcast)
     # 이 테스트의 관심사는 스케줄러 락에 의한 동시 실행 방지이지 Portfolio 동기화가
@@ -830,8 +846,8 @@ async def test_monitor_market_task_includes_watchlist_stocks(monkeypatch):
         monitored_stocks.append(args["stock_name"])
         return f"news for {args['stock_name']}"
 
-    async def mock_check_significance(stock, current, last, *, source, provider):
-        return False
+    async def mock_score_signal(stock, current, last, *, source, provider):
+        return _scored(False)
 
     monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
     monkeypatch.setattr(
@@ -839,7 +855,7 @@ async def test_monitor_market_task_includes_watchlist_stocks(monkeypatch):
         [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
-    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast_mock())
 
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo(["NAVER"]))
@@ -867,8 +883,8 @@ async def test_monitor_market_task_continues_owned_stock_when_watchlist_fails(mo
         monitored_stocks.append(args["stock_name"])
         return "news"
 
-    async def mock_check_significance(stock, current, last, *, source, provider):
-        return False
+    async def mock_score_signal(stock, current, last, *, source, provider):
+        return _scored(False)
 
     monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
     monkeypatch.setattr(
@@ -876,7 +892,7 @@ async def test_monitor_market_task_continues_owned_stock_when_watchlist_fails(mo
         [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
-    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast_mock())
 
     await monitor_market_task(watchlist_repo=FailingWatchlistRepo())
@@ -903,8 +919,8 @@ async def test_monitor_market_task_deduplicates_watchlist_and_owned_stocks(monke
         monitored_stocks.append(args["stock_name"])
         return "news"
 
-    async def mock_check_significance(stock, current, last, *, source, provider):
-        return False
+    async def mock_score_signal(stock, current, last, *, source, provider):
+        return _scored(False)
 
     monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
     monkeypatch.setattr(
@@ -912,7 +928,7 @@ async def test_monitor_market_task_deduplicates_watchlist_and_owned_stocks(monke
         [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
-    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast_mock())
 
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo(["삼성전자"]))
@@ -939,8 +955,8 @@ async def test_monitor_market_task_uses_default_stocks_only_when_both_empty(monk
         monitored_stocks.append(args["stock_name"])
         return "news"
 
-    async def mock_check_significance(stock, current, last, *, source, provider):
-        return False
+    async def mock_score_signal(stock, current, last, *, source, provider):
+        return _scored(False)
 
     monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
     monkeypatch.setattr(
@@ -948,7 +964,7 @@ async def test_monitor_market_task_uses_default_stocks_only_when_both_empty(monk
         [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
-    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast_mock())
 
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
@@ -975,8 +991,8 @@ async def test_monitor_market_task_watchlist_alone_skips_default_fallback(monkey
         monitored_stocks.append(args["stock_name"])
         return "news"
 
-    async def mock_check_significance(stock, current, last, *, source, provider):
-        return False
+    async def mock_score_signal(stock, current, last, *, source, provider):
+        return _scored(False)
 
     monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
     monkeypatch.setattr(
@@ -984,7 +1000,7 @@ async def test_monitor_market_task_watchlist_alone_skips_default_fallback(monkey
         [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
-    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast_mock())
 
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo(["카카오"]))
@@ -1173,8 +1189,8 @@ async def test_monitor_market_task_logs_warning_when_balance_truncated(monkeypat
             return TRUNCATED_BALANCE_TEXT
         return "news"
 
-    async def mock_check_significance(stock, current, last, *, source, provider):
-        return False
+    async def mock_score_signal(stock, current, last, *, source, provider):
+        return _scored(False)
 
     monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
     monkeypatch.setattr(
@@ -1182,7 +1198,7 @@ async def test_monitor_market_task_logs_warning_when_balance_truncated(monkeypat
         [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
-    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast_mock())
 
     with caplog.at_level(logging.WARNING, logger=scheduler_module.logger.name):
@@ -1216,8 +1232,8 @@ async def test_monitor_market_task_no_warning_when_balance_not_truncated(monkeyp
         monitored_stocks.append(args["stock_name"])
         return "news"
 
-    async def mock_check_significance(stock, current, last, *, source, provider):
-        return False
+    async def mock_score_signal(stock, current, last, *, source, provider):
+        return _scored(False)
 
     monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
     monkeypatch.setattr(
@@ -1225,7 +1241,7 @@ async def test_monitor_market_task_no_warning_when_balance_not_truncated(monkeyp
         [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
-    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast_mock())
 
     with caplog.at_level(logging.WARNING, logger=scheduler_module.logger.name):
@@ -1259,8 +1275,8 @@ async def test_monitor_market_task_still_watches_stocks_returned_despite_truncat
         monitored_stocks.append(args["stock_name"])
         return "news"
 
-    async def mock_check_significance(stock, current, last, *, source, provider):
-        return False
+    async def mock_score_signal(stock, current, last, *, source, provider):
+        return _scored(False)
 
     monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
     monkeypatch.setattr(
@@ -1268,7 +1284,7 @@ async def test_monitor_market_task_still_watches_stocks_returned_despite_truncat
         [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
-    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast_mock())
 
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
@@ -1297,8 +1313,8 @@ def _make_balance_failure_mocks(monkeypatch, mock_run_mcp_tool_fn):
     async def fake_redis_state():
         yield state
 
-    async def mock_check_significance(stock, current, last, *, source, provider):
-        return False
+    async def mock_score_signal(stock, current, last, *, source, provider):
+        return _scored(False)
 
     monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
     monkeypatch.setattr(
@@ -1306,7 +1322,7 @@ def _make_balance_failure_mocks(monkeypatch, mock_run_mcp_tool_fn):
         [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool_fn)
-    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast_mock())
 
     return state
@@ -1685,8 +1701,8 @@ async def test_monitor_market_task_syncs_portfolio_when_balance_succeeds(monkeyp
     def mock_sync_portfolio(balance_text, session, **kwargs):
         sync_calls.append(balance_text)
 
-    async def mock_check_significance(stock, current, last, *, source, provider):
-        return False
+    async def mock_score_signal(stock, current, last, *, source, provider):
+        return _scored(False)
 
     monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
     monkeypatch.setattr(
@@ -1695,7 +1711,7 @@ async def test_monitor_market_task_syncs_portfolio_when_balance_succeeds(monkeyp
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
     monkeypatch.setattr("backend.scheduler._sync_portfolio_from_balance", mock_sync_portfolio)
-    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast_mock())
 
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
@@ -1728,8 +1744,8 @@ async def test_monitor_market_task_does_not_sync_when_balance_fails(monkeypatch)
     def mock_sync_portfolio(balance_text, session, **kwargs):
         sync_calls.append(balance_text)
 
-    async def mock_check_significance(stock, current, last, *, source, provider):
-        return False
+    async def mock_score_signal(stock, current, last, *, source, provider):
+        return _scored(False)
 
     monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
     monkeypatch.setattr(
@@ -1738,7 +1754,7 @@ async def test_monitor_market_task_does_not_sync_when_balance_fails(monkeypatch)
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
     monkeypatch.setattr("backend.scheduler._sync_portfolio_from_balance", mock_sync_portfolio)
-    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast_mock())
 
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo(["카카오"]))
@@ -1777,8 +1793,8 @@ async def test_monitor_market_task_broadcasts_portfolio_update_on_sync_success(m
     def mock_sync_portfolio(balance_text, session, **kwargs):
         return 3
 
-    async def mock_check_significance(stock, current, last, *, source, provider):
-        return False
+    async def mock_score_signal(stock, current, last, *, source, provider):
+        return _scored(False)
 
     mock_broadcast = MagicMock(return_value=asyncio.Future())
     mock_broadcast.return_value.set_result(None)
@@ -1790,7 +1806,7 @@ async def test_monitor_market_task_broadcasts_portfolio_update_on_sync_success(m
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
     monkeypatch.setattr("backend.scheduler._sync_portfolio_from_balance", mock_sync_portfolio)
-    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", mock_broadcast)
 
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
@@ -1832,8 +1848,8 @@ async def test_monitor_market_task_broadcasts_portfolio_update_when_holdings_bec
     def mock_sync_portfolio(balance_text, session, **kwargs):
         return 0
 
-    async def mock_check_significance(stock, current, last, *, source, provider):
-        return False
+    async def mock_score_signal(stock, current, last, *, source, provider):
+        return _scored(False)
 
     mock_broadcast = MagicMock(return_value=asyncio.Future())
     mock_broadcast.return_value.set_result(None)
@@ -1845,7 +1861,7 @@ async def test_monitor_market_task_broadcasts_portfolio_update_when_holdings_bec
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
     monkeypatch.setattr("backend.scheduler._sync_portfolio_from_balance", mock_sync_portfolio)
-    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", mock_broadcast)
 
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
@@ -1883,8 +1899,8 @@ async def test_monitor_market_task_no_portfolio_broadcast_when_balance_truncated
             return truncated_text
         return "news"
 
-    async def mock_check_significance(stock, current, last, *, source, provider):
-        return False
+    async def mock_score_signal(stock, current, last, *, source, provider):
+        return _scored(False)
 
     mock_broadcast = MagicMock(return_value=asyncio.Future())
     mock_broadcast.return_value.set_result(None)
@@ -1895,7 +1911,7 @@ async def test_monitor_market_task_no_portfolio_broadcast_when_balance_truncated
         [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
-    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", mock_broadcast)
 
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
@@ -1923,8 +1939,8 @@ async def test_monitor_market_task_no_portfolio_broadcast_when_marker_absent(mon
             return "응답을 가져왔지만 종목 섹션이 없습니다."
         return "news"
 
-    async def mock_check_significance(stock, current, last, *, source, provider):
-        return False
+    async def mock_score_signal(stock, current, last, *, source, provider):
+        return _scored(False)
 
     mock_broadcast = MagicMock(return_value=asyncio.Future())
     mock_broadcast.return_value.set_result(None)
@@ -1935,7 +1951,7 @@ async def test_monitor_market_task_no_portfolio_broadcast_when_marker_absent(mon
         [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
-    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", mock_broadcast)
 
     await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
@@ -1973,8 +1989,8 @@ async def test_monitor_market_task_survives_portfolio_broadcast_failure(monkeypa
     def mock_sync_portfolio(balance_text, session, **kwargs):
         return 1
 
-    async def mock_check_significance(stock, current, last, *, source, provider):
-        return False
+    async def mock_score_signal(stock, current, last, *, source, provider):
+        return _scored(False)
 
     async def failing_broadcast(payload):
         raise RuntimeError("websocket down")
@@ -1986,7 +2002,7 @@ async def test_monitor_market_task_survives_portfolio_broadcast_failure(monkeypa
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
     monkeypatch.setattr("backend.scheduler._sync_portfolio_from_balance", mock_sync_portfolio)
-    monkeypatch.setattr("backend.scheduler.check_signal_significance", mock_check_significance)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", failing_broadcast)
 
     # 예외 없이 완료되어야 한다.
@@ -2168,10 +2184,9 @@ def test_portfolio_endpoint_includes_price_known_flag(client):
 async def test_monitor_signal_passes_signal_score_to_analysis(monkeypatch):
     """2차 필터가 매긴 점수가 perform_stock_analysis까지 도달해야 한다.
 
-    check_signal_significance는 bool만 돌려주고 점수는 사이드 채널
-    (services.take_last_signal_score)로 온다. 스케줄러가 그걸 꺼내 넘기지 않으면
-    점수는 로그에만 남고 DB·알림에서 사라진다 — 그래서 여기서는 필터를
-    monkeypatch하지 않고 llm_chat만 갈아끼워 실제 채점 경로를 태운다.
+    스케줄러가 score_signal의 결과를 그대로 넘기지 않으면 점수는 로그에만 남고
+    DB·알림에서 사라진다. 여기서는 필터를 monkeypatch하지 않고 llm_chat만
+    갈아끼워 실제 채점 경로를 태운다.
     """
     from backend import services
     from ..scheduler import SignalSource, monitor_market_task

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -2160,3 +2160,115 @@ def test_portfolio_endpoint_includes_price_known_flag(client):
             for row in session.exec(select(Portfolio)).all():
                 session.delete(row)
             session.commit()
+
+# --- #298: 신호 점수가 분석까지 흘러가는지 ---------------------------------
+
+
+@pytest.mark.asyncio
+async def test_monitor_signal_passes_signal_score_to_analysis(monkeypatch):
+    """2차 필터가 매긴 점수가 perform_stock_analysis까지 도달해야 한다.
+
+    check_signal_significance는 bool만 돌려주고 점수는 사이드 채널
+    (services.take_last_signal_score)로 온다. 스케줄러가 그걸 꺼내 넘기지 않으면
+    점수는 로그에만 남고 DB·알림에서 사라진다 — 그래서 여기서는 필터를
+    monkeypatch하지 않고 llm_chat만 갈아끼워 실제 채점 경로를 태운다.
+    """
+    from backend import services
+    from ..scheduler import SignalSource, monitor_market_task
+
+    state = RedisSchedulerState(FakeRedis())
+
+    @asynccontextmanager
+    async def fake_redis_state():
+        yield state
+
+    async def mock_run_mcp_tool(params, name, args):
+        if name == "get_balance":
+            return "[보유 종목 리스트]\n- 삼성전자 (005930): 10주"
+        return "삼성전자, 대형 수주 공시\n증권가 목표주가 상향"
+
+    async def fake_llm_chat(provider, prompt, *, conversation_id=None):
+        return '{"score": 3, "reason": "대형 수주 공시", "headline_scores": [3, 2]}'
+
+    monkeypatch.setattr(services, "llm_chat", fake_llm_chat)
+
+    mock_perform_analysis = MagicMock(return_value=asyncio.Future())
+    mock_perform_analysis.return_value.set_result({"summary": "Mocked"})
+    mock_broadcast = MagicMock(return_value=asyncio.Future())
+    mock_broadcast.return_value.set_result(None)
+
+    monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
+    monkeypatch.setattr(
+        "backend.scheduler.SIGNAL_SOURCES",
+        [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
+    )
+    monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
+    monkeypatch.setattr("backend.scheduler.perform_stock_analysis", mock_perform_analysis)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", mock_broadcast)
+    monkeypatch.setattr(
+        "backend.scheduler._sync_portfolio_from_balance",
+        lambda balance_text, session, **kwargs: None,
+    )
+
+    await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
+
+    assert mock_perform_analysis.call_count == 1
+    passed = mock_perform_analysis.call_args.kwargs["signal_score"]
+    assert passed is not None
+    assert passed.score == 3
+    assert passed.reason == "대형 수주 공시"
+    assert passed.headline_scores == (3, 2)
+    assert passed.uncertainty == 0.5
+
+
+@pytest.mark.asyncio
+async def test_monitor_signal_passes_none_when_scoring_fails_open(monkeypatch):
+    """채점에 실패하면 분석은 계속하되(fail-open) 점수는 null로 넘어가야 한다.
+
+    실패를 0점으로 넘기면 "모델이 중립이라고 판단함"이라는 없던 사실이 DB에 남는다.
+    """
+    from backend import services
+    from ..scheduler import SignalSource, monitor_market_task
+
+    state = RedisSchedulerState(FakeRedis())
+
+    @asynccontextmanager
+    async def fake_redis_state():
+        yield state
+
+    async def mock_run_mcp_tool(params, name, args):
+        if name == "get_balance":
+            return "[보유 종목 리스트]\n- 삼성전자 (005930): 10주"
+        return "삼성전자 관련 뉴스"
+
+    async def exploding_llm_chat(provider, prompt, *, conversation_id=None):
+        raise RuntimeError("ollama 연결 실패")
+
+    monkeypatch.setattr(services, "llm_chat", exploding_llm_chat)
+
+    mock_perform_analysis = MagicMock(return_value=asyncio.Future())
+    mock_perform_analysis.return_value.set_result({"summary": "Mocked"})
+    mock_broadcast = MagicMock(return_value=asyncio.Future())
+    mock_broadcast.return_value.set_result(None)
+
+    monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
+    monkeypatch.setattr(
+        "backend.scheduler.SIGNAL_SOURCES",
+        [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
+    )
+    monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
+    monkeypatch.setattr("backend.scheduler.perform_stock_analysis", mock_perform_analysis)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", mock_broadcast)
+    monkeypatch.setattr(
+        "backend.scheduler._sync_portfolio_from_balance",
+        lambda balance_text, session, **kwargs: None,
+    )
+
+    await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
+
+    # fail-open: 분석은 수행된다
+    assert mock_perform_analysis.call_count == 1
+    passed = mock_perform_analysis.call_args.kwargs["signal_score"]
+    assert passed is not None
+    assert passed.is_significant is True
+    assert passed.score is None

--- a/backend/tests/test_schema_migrations.py
+++ b/backend/tests/test_schema_migrations.py
@@ -524,3 +524,97 @@ def test_nullable_migration_preserves_indexes(tmp_path, monkeypatch):
     assert _agentreport_index_names(str(db_path)) == before, (
         "테이블 재생성 마이그레이션이 인덱스를 잃었습니다"
     )
+
+
+# --- #298: 신호 점수화 컬럼 -------------------------------------------------
+
+
+def test_init_db_adds_nullable_signal_scoring_columns(tmp_path, monkeypatch):
+    """구버전 DB에 signal_score·signal_reason·signal_uncertainty가 추가되어야 한다.
+
+    셋 다 NULL 허용이어야 하고 DEFAULT가 없어야 한다. provider_supports_tools처럼
+    DEFAULT 0을 주면 "모델이 0점(무관/중립)으로 채점했다"는 없던 사실이 과거 행에
+    소급 생성된다 — #122·#162의 "0과 모름 구분" 원칙 위반이다.
+
+    이 테스트가 잡는 mutation: _PENDING_COLUMN_MIGRATIONS의 세 항목 제거,
+    또는 NOT NULL DEFAULT 0 추가.
+    """
+    db_path = tmp_path / "old_schema_signal.db"
+    _create_old_schema_agentreport(str(db_path))
+
+    test_engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+    monkeypatch.setattr(database, "engine", test_engine)
+
+    database.init_db()
+
+    conn = sqlite3.connect(str(db_path))
+    cols = {row[1]: row for row in conn.execute("PRAGMA table_info(agentreport)")}
+    raw = conn.execute(
+        "SELECT signal_score, signal_reason, signal_uncertainty FROM agentreport"
+    ).fetchone()
+    conn.close()
+
+    expected_types = {
+        "signal_score": "INTEGER",
+        "signal_reason": "VARCHAR",
+        "signal_uncertainty": "FLOAT",
+    }
+    for name, expected_type in expected_types.items():
+        assert name in cols, f"{name} 컬럼이 추가되지 않았다"
+        _, _, col_type, notnull, default, _pk = cols[name]
+        assert col_type.upper() == expected_type
+        assert notnull == 0, f"{name}이 NOT NULL이면 '모름'을 표현할 수 없다"
+        assert default is None, f"{name}에 DEFAULT가 있으면 과거 행에 없던 점수가 생긴다"
+
+    # 마이그레이션 이전에 저장된 행은 세 값 모두 NULL로 남아야 한다.
+    assert raw == (None, None, None)
+
+
+def _create_pre_signal_scoring_agentreport(db_path: str) -> None:
+    """#298 이전이면서 decision이 아직 NOT NULL인 agentreport를 재현한다.
+
+    signal_* 컬럼은 _run_schema_migrations()의 ALTER로 먼저 붙으므로, 테이블 재생성
+    (_run_table_recreate_migrations)이 도는 시점에는 이미 존재한다. 재생성 DDL이
+    이 컬럼들을 모르면 컬럼과 데이터가 통째로 사라진다 — 그 경로를 고정한다.
+    """
+    _create_post_c_schema_agentreport(db_path)
+
+    conn = sqlite3.connect(db_path)
+    for alter in (
+        "ALTER TABLE agentreport ADD COLUMN signal_score INTEGER",
+        "ALTER TABLE agentreport ADD COLUMN signal_reason VARCHAR",
+        "ALTER TABLE agentreport ADD COLUMN signal_uncertainty FLOAT",
+    ):
+        conn.execute(alter)
+    conn.execute(
+        "UPDATE agentreport SET signal_score = -2, signal_reason = '수주 취소 공시', "
+        "signal_uncertainty = 1.25"
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_nullable_recreation_preserves_signal_scoring_columns(tmp_path, monkeypatch):
+    """테이블 재생성 마이그레이션이 signal_* 컬럼과 그 값을 보존해야 한다.
+
+    이 테스트가 잡는 mutation: _RECREATE_AGENTREPORT_NULLABLE_DDL 또는
+    _RECREATE_AGENTREPORT_COLS에서 signal_* 누락 (누락 시 RuntimeError로 부팅이
+    막히거나, DDL만 고치고 COLS를 빠뜨리면 값이 조용히 사라진다).
+    """
+    db_path = tmp_path / "pre_signal_scoring.db"
+    _create_pre_signal_scoring_agentreport(str(db_path))
+
+    test_engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+    monkeypatch.setattr(database, "engine", test_engine)
+
+    database.init_db()
+
+    conn = sqlite3.connect(str(db_path))
+    col_info = {row[1]: row for row in conn.execute("PRAGMA table_info(agentreport)")}
+    row = conn.execute(
+        "SELECT signal_score, signal_reason, signal_uncertainty FROM agentreport"
+    ).fetchall()
+    conn.close()
+
+    assert col_info["decision"][3] == 0, "재생성이 수행되지 않았다 (decision이 여전히 NOT NULL)"
+    assert row == [(-2, "수주 취소 공시", 1.25)], "재생성이 신호 점수 값을 잃었다"

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -1930,7 +1930,10 @@ async def test_score_signal_prompt_states_the_scale_and_headline_count(monkeypat
 
 @pytest.mark.asyncio
 async def test_check_signal_significance_still_returns_plain_bool(monkeypatch):
-    """공개 계약 유지: 반환값은 bool이다. 점수는 사이드 채널로만 노출한다."""
+    """공개 계약 유지: 판정만 필요한 호출부를 위해 bool 래퍼를 남겨 둔다.
+
+    점수까지 필요한 호출부(scheduler)는 score_signal을 직접 쓴다.
+    """
     async def fake_llm_chat(provider, prompt, *, conversation_id=None):
         return '{"score": -3, "reason": "회계 이슈", "headline_scores": [-3, -2]}'
 
@@ -1939,26 +1942,6 @@ async def test_check_signal_significance_still_returns_plain_bool(monkeypatch):
     result = await services.check_signal_significance("삼성전자", "감리 착수", source="news")
 
     assert result is True
-
-    scored = services.take_last_signal_score()
-    assert scored is not None
-    assert scored.score == -3
-    assert scored.reason == "회계 이슈"
-    assert scored.uncertainty == 0.5
-
-
-@pytest.mark.asyncio
-async def test_take_last_signal_score_is_consumed_once(monkeypatch):
-    """두 번째 호출은 None이어야 한다 — 남겨 두면 다음 종목이 앞 종목의 점수를 물려받는다."""
-    async def fake_llm_chat(provider, prompt, *, conversation_id=None):
-        return '{"score": 2}'
-
-    monkeypatch.setattr(services, "llm_chat", fake_llm_chat)
-
-    await services.check_signal_significance("삼성전자", "수주 공시", source="news")
-
-    assert services.take_last_signal_score() is not None
-    assert services.take_last_signal_score() is None
 
 
 @pytest.mark.asyncio
@@ -1971,65 +1954,48 @@ async def test_check_news_significance_keeps_delegating(monkeypatch):
     result = await services.check_news_significance("삼성전자", "신제품 홍보")
 
     assert result is False
-    assert services.take_last_signal_score().score == 0
+
+
+def test_signal_snippet_drops_the_line_cut_by_the_char_limit():
+    """상한에서 반토막 난 기사는 버린다.
+
+    남겨 두면 모델이 반토막을 온전한 기사 1건으로 세어 점수를 매기고, 그 값이
+    headline_scores를 거쳐 signal_uncertainty(표준편차)까지 오염시킨다.
+    """
+    limit = services._SIGNAL_SNIPPET_CHARS
+    first = "가" * (limit - 10)
+    content = f"{first}\n두 번째 기사인데 상한에서 잘린다"
+
+    assert services._signal_snippet(content) == first
+
+
+def test_signal_snippet_keeps_a_single_overlong_line():
+    """상한 안에 줄바꿈이 없으면 버릴 온전한 줄이 없다 — 자른 그대로 쓴다."""
+    content = "가" * (services._SIGNAL_SNIPPET_CHARS + 50)
+
+    snippet = services._signal_snippet(content)
+
+    assert len(snippet) == services._SIGNAL_SNIPPET_CHARS
+
+
+def test_signal_snippet_passes_short_content_through():
+    assert services._signal_snippet("기사1\n기사2") == "기사1\n기사2"
 
 
 @pytest.mark.asyncio
-async def test_perform_stock_analysis_persists_signal_score(monkeypatch):
-    """2차 필터의 채점 결과가 AgentReport와 API 응답 양쪽에 실려야 한다.
+async def test_score_signal_prompt_counts_only_whole_articles(monkeypatch):
+    """프롬프트의 기사 수는 잘린 반토막을 빼고 세야 한다."""
+    prompts = []
 
-    perform_stock_analysis가 signal_score를 무시하면 점수가 DB에도 알림에도 남지
-    않고, 나중에 평가셋으로 모델을 검증할 방법이 사라진다.
-    """
     async def fake_llm_chat(provider, prompt, *, conversation_id=None):
-        return "plain analysis"
-
-    async def fake_run_mcp_tool(params, tool_name, arguments):
-        return "삼성전자 (005930, KOSPI)"
+        prompts.append(prompt)
+        return '{"score": 1}'
 
     monkeypatch.setattr(services, "llm_chat", fake_llm_chat)
-    monkeypatch.setattr(services, "run_mcp_tool", fake_run_mcp_tool)
 
-    scored = services.SignalScore(
-        score=-2,
-        reason="주요 고객 이탈 보도",
-        uncertainty=1.5,
-        headline_scores=(-3, 0),
-        is_significant=True,
-    )
+    limit = services._SIGNAL_SNIPPET_CHARS
+    content = "기사1\n" + "가" * (limit - 10) + "\n잘리는 기사"
 
-    session = FakeSession()
-    result = await services.perform_stock_analysis(
-        "삼성전자", "openai", session, signal_score=scored
-    )
+    await services.score_signal("삼성전자", content, source="news")
 
-    assert session.report.signal_score == -2
-    assert session.report.signal_reason == "주요 고객 이탈 보도"
-    assert session.report.signal_uncertainty == 1.5
-    assert result["signal_score"] == -2
-    assert result["signal_reason"] == "주요 고객 이탈 보도"
-    assert result["signal_uncertainty"] == 1.5
-
-
-@pytest.mark.asyncio
-async def test_perform_stock_analysis_leaves_signal_score_null_without_filter(monkeypatch):
-    """필터를 거치지 않은 경로(수동 분석·API 직접 호출)는 세 값 모두 null이어야 한다.
-
-    0으로 채우면 "모델이 중립으로 채점했다"는 없던 사실이 생긴다 (#122·#162).
-    """
-    async def fake_llm_chat(provider, prompt, *, conversation_id=None):
-        return "plain analysis"
-
-    async def fake_run_mcp_tool(params, tool_name, arguments):
-        return "삼성전자 (005930, KOSPI)"
-
-    monkeypatch.setattr(services, "llm_chat", fake_llm_chat)
-    monkeypatch.setattr(services, "run_mcp_tool", fake_run_mcp_tool)
-
-    session = FakeSession()
-    result = await services.perform_stock_analysis("삼성전자", "openai", session)
-
-    assert session.report.signal_score is None
-    assert session.report.signal_reason is None
-    assert session.report.signal_uncertainty is None
-    assert result["signal_score"] is None
+    assert "기사 2건" in prompts[0]

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -1717,3 +1717,319 @@ def test_morning_briefing_from_text_skips_non_briefing_candidates():
         "브리핑 키 없는 후보가 reversed 선두에 와도 건너뛰고 올바른 후보를 써야 한다"
     )
     assert result["watchlist"] == ["삼성전자"]
+
+
+# --- #298: 신호 유의성 점수화 -----------------------------------------------
+
+
+def test_parse_signal_score_reads_score_reason_and_headline_scores():
+    parsed = services.parse_signal_score(
+        '{"score": -2, "reason": "주요 고객 이탈 보도", "headline_scores": [-3, -2, -1]}'
+    )
+
+    assert parsed is not None
+    assert parsed.score == -2
+    assert parsed.reason == "주요 고객 이탈 보도"
+    assert parsed.headline_scores == (-3, -2, -1)
+    assert parsed.is_significant is True
+
+
+def test_parse_signal_score_ignores_prose_around_the_json():
+    """경량 모델은 JSON만 달라고 해도 설명을 앞뒤로 붙인다. 그걸로 실패하면 안 된다."""
+    parsed = services.parse_signal_score(
+        '분석 결과입니다.\n{"score": 3, "reason": "대형 수주 공시", "headline_scores": [3]}\n감사합니다.'
+    )
+
+    assert parsed is not None
+    assert parsed.score == 3
+
+
+def test_parse_signal_score_clamps_out_of_range_and_rounds_floats():
+    """레인지를 벗어난 값은 버리지 않고 자른다 — 방향 정보는 살아 있다.
+
+    이 경계 처리를 파싱 실패로 바꾸면 하필 대형 신호(모델이 7점을 주는 경우)에서만
+    fail-open이 잦아진다.
+    """
+    assert services.parse_signal_score('{"score": 9}').score == 3
+    assert services.parse_signal_score('{"score": -9}').score == -3
+    assert services.parse_signal_score('{"score": 2.4}').score == 2
+    assert services.parse_signal_score('{"score": "2"}').score == 2
+    assert (
+        services.parse_signal_score('{"score": 1, "headline_scores": [8, -8]}').headline_scores
+        == (3, -3)
+    )
+
+
+def test_parse_signal_score_rejects_non_numeric_score():
+    """숫자로 볼 수 없으면 실패(None)로 떨어뜨린다 — 점수를 지어내지 않는다.
+
+    bool은 int의 하위형이라 별도로 막지 않으면 True가 1점으로 샌다.
+    """
+    assert services.parse_signal_score('{"score": "매우 긍정적"}') is None
+    assert services.parse_signal_score('{"score": null}') is None
+    assert services.parse_signal_score('{"score": true}') is None
+    assert services.parse_signal_score('{"reason": "점수 없음"}') is None
+
+
+def test_parse_signal_score_returns_none_for_broken_json():
+    assert services.parse_signal_score('{"score": -2, "reason": ') is None
+    assert services.parse_signal_score("YES") is None
+    assert services.parse_signal_score("") is None
+
+
+def test_parse_signal_score_drops_unusable_headline_entries():
+    parsed = services.parse_signal_score(
+        '{"score": 1, "headline_scores": [2, "몰라", null, -1]}'
+    )
+
+    assert parsed is not None
+    assert parsed.headline_scores == (2, -1)
+
+
+def test_parse_signal_score_collapses_multiline_reason():
+    """reason은 알림 한 줄에 들어간다. 줄바꿈이 그대로 들어가면 메시지 형식이 깨진다."""
+    parsed = services.parse_signal_score('{"score": 2, "reason": "수주\\n공시\\n확인"}')
+
+    assert parsed is not None
+    assert parsed.reason == "수주 공시 확인"
+
+
+def test_parse_signal_score_truncates_overlong_reason():
+    parsed = services.parse_signal_score(
+        '{"score": 2, "reason": "%s"}' % ("가" * 500)
+    )
+
+    assert parsed is not None
+    assert len(parsed.reason) == services._SIGNAL_REASON_MAX_CHARS
+
+
+def test_signal_score_uncertainty_is_none_below_two_headlines():
+    """1건이면 0.0이 아니라 None이다. 0.0은 '기사들이 완전히 일치했다'는 뜻이다."""
+    assert services.signal_score_uncertainty([]) is None
+    assert services.signal_score_uncertainty([2]) is None
+
+
+def test_signal_score_uncertainty_is_population_stdev():
+    assert services.signal_score_uncertainty([2, 2, 2]) == 0.0
+    assert services.signal_score_uncertainty([-3, 3]) == 3.0
+    assert services.signal_score_uncertainty([1, 2]) == 0.5
+
+
+def test_parse_signal_score_computes_uncertainty_from_headline_scores():
+    """불확실성은 LLM이 신고한 값이 아니라 기사별 점수에서 코드로 계산해야 한다."""
+    parsed = services.parse_signal_score(
+        '{"score": 0, "headline_scores": [3, -3], "uncertainty": 0.0}'
+    )
+
+    assert parsed is not None
+    assert parsed.uncertainty == 3.0  # LLM이 준 0.0이 아니라 코드 계산값
+
+    single = services.parse_signal_score('{"score": 2, "headline_scores": [2]}')
+    assert single is not None
+    assert single.uncertainty is None
+
+
+@pytest.mark.parametrize(
+    ("score", "threshold", "expected"),
+    [
+        (0, 2, False),
+        (1, 2, False),
+        (-1, 2, False),
+        (2, 2, True),
+        (-2, 2, True),
+        (3, 2, True),
+        (1, 1, True),
+        (2, 3, False),
+        (-3, 3, True),
+    ],
+)
+def test_significance_is_threshold_on_absolute_score(monkeypatch, score, threshold, expected):
+    """유의성은 |score| >= 임계값이다. 부호(호재/악재)는 판정에 영향을 주지 않는다."""
+    monkeypatch.setattr(services, "SIGNAL_SCORE_THRESHOLD", threshold)
+
+    parsed = services.parse_signal_score('{"score": %d}' % score)
+
+    assert parsed is not None
+    assert parsed.is_significant is expected
+
+
+@pytest.mark.asyncio
+async def test_score_signal_fails_open_when_llm_call_raises(monkeypatch):
+    """REQ-04: LLM 호출이 실패해도 유의미로 통과시킨다. 단 점수는 null로 남긴다.
+
+    이 fail-open이 없으면 ollama가 죽어 있는 동안 대형 악재가 통째로 묻힌다.
+    """
+    async def exploding_llm_chat(provider, prompt, *, conversation_id=None):
+        raise RuntimeError("ollama 연결 실패")
+
+    monkeypatch.setattr(services, "llm_chat", exploding_llm_chat)
+
+    scored = await services.score_signal("삼성전자", "긴급 공시", source="news")
+
+    assert scored.is_significant is True
+    assert scored.score is None
+    assert scored.reason is None
+    assert scored.uncertainty is None
+
+
+@pytest.mark.asyncio
+async def test_score_signal_fails_open_when_response_is_unparseable(monkeypatch):
+    async def fake_llm_chat(provider, prompt, *, conversation_id=None):
+        return "죄송합니다. 점수를 매길 수 없습니다."
+
+    monkeypatch.setattr(services, "llm_chat", fake_llm_chat)
+
+    scored = await services.score_signal("삼성전자", "긴급 공시", source="news")
+
+    assert scored.is_significant is True
+    assert scored.score is None
+
+
+@pytest.mark.asyncio
+async def test_score_signal_skips_empty_and_unchanged_content(monkeypatch):
+    """채점 이전에 걸러지는 경로는 LLM을 부르지 않고, 점수도 남기지 않는다."""
+    calls = []
+
+    async def fake_llm_chat(provider, prompt, *, conversation_id=None):
+        calls.append(prompt)
+        return '{"score": 3}'
+
+    monkeypatch.setattr(services, "llm_chat", fake_llm_chat)
+
+    empty = await services.score_signal("삼성전자", "", source="news")
+    unchanged = await services.score_signal("삼성전자", "같은 뉴스", "같은 뉴스", source="news")
+
+    assert empty.is_significant is False and empty.score is None
+    assert unchanged.is_significant is False and unchanged.score is None
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_score_signal_prompt_states_the_scale_and_headline_count(monkeypatch):
+    prompts = []
+
+    async def fake_llm_chat(provider, prompt, *, conversation_id=None):
+        prompts.append(prompt)
+        return '{"score": 2, "reason": "수주", "headline_scores": [2, 2, 2]}'
+
+    monkeypatch.setattr(services, "llm_chat", fake_llm_chat)
+
+    await services.score_signal(
+        "삼성전자",
+        "기사1 - 내용\n기사2 - 내용\n기사3 - 내용",
+        source="news",
+        provider="ollama",
+    )
+
+    prompt = prompts[0]
+    # 단계별 기준이 프롬프트에 명시돼야 한다 — 축을 모델 상상에 맡기면 재현성이 없다.
+    assert "+3:" in prompt and "-3:" in prompt and " 0:" in prompt
+    assert "기사 3건" in prompt
+    assert "headline_scores" in prompt
+
+
+@pytest.mark.asyncio
+async def test_check_signal_significance_still_returns_plain_bool(monkeypatch):
+    """공개 계약 유지: 반환값은 bool이다. 점수는 사이드 채널로만 노출한다."""
+    async def fake_llm_chat(provider, prompt, *, conversation_id=None):
+        return '{"score": -3, "reason": "회계 이슈", "headline_scores": [-3, -2]}'
+
+    monkeypatch.setattr(services, "llm_chat", fake_llm_chat)
+
+    result = await services.check_signal_significance("삼성전자", "감리 착수", source="news")
+
+    assert result is True
+
+    scored = services.take_last_signal_score()
+    assert scored is not None
+    assert scored.score == -3
+    assert scored.reason == "회계 이슈"
+    assert scored.uncertainty == 0.5
+
+
+@pytest.mark.asyncio
+async def test_take_last_signal_score_is_consumed_once(monkeypatch):
+    """두 번째 호출은 None이어야 한다 — 남겨 두면 다음 종목이 앞 종목의 점수를 물려받는다."""
+    async def fake_llm_chat(provider, prompt, *, conversation_id=None):
+        return '{"score": 2}'
+
+    monkeypatch.setattr(services, "llm_chat", fake_llm_chat)
+
+    await services.check_signal_significance("삼성전자", "수주 공시", source="news")
+
+    assert services.take_last_signal_score() is not None
+    assert services.take_last_signal_score() is None
+
+
+@pytest.mark.asyncio
+async def test_check_news_significance_keeps_delegating(monkeypatch):
+    async def fake_llm_chat(provider, prompt, *, conversation_id=None):
+        return '{"score": 0, "reason": "홍보성 기사"}'
+
+    monkeypatch.setattr(services, "llm_chat", fake_llm_chat)
+
+    result = await services.check_news_significance("삼성전자", "신제품 홍보")
+
+    assert result is False
+    assert services.take_last_signal_score().score == 0
+
+
+@pytest.mark.asyncio
+async def test_perform_stock_analysis_persists_signal_score(monkeypatch):
+    """2차 필터의 채점 결과가 AgentReport와 API 응답 양쪽에 실려야 한다.
+
+    perform_stock_analysis가 signal_score를 무시하면 점수가 DB에도 알림에도 남지
+    않고, 나중에 평가셋으로 모델을 검증할 방법이 사라진다.
+    """
+    async def fake_llm_chat(provider, prompt, *, conversation_id=None):
+        return "plain analysis"
+
+    async def fake_run_mcp_tool(params, tool_name, arguments):
+        return "삼성전자 (005930, KOSPI)"
+
+    monkeypatch.setattr(services, "llm_chat", fake_llm_chat)
+    monkeypatch.setattr(services, "run_mcp_tool", fake_run_mcp_tool)
+
+    scored = services.SignalScore(
+        score=-2,
+        reason="주요 고객 이탈 보도",
+        uncertainty=1.5,
+        headline_scores=(-3, 0),
+        is_significant=True,
+    )
+
+    session = FakeSession()
+    result = await services.perform_stock_analysis(
+        "삼성전자", "openai", session, signal_score=scored
+    )
+
+    assert session.report.signal_score == -2
+    assert session.report.signal_reason == "주요 고객 이탈 보도"
+    assert session.report.signal_uncertainty == 1.5
+    assert result["signal_score"] == -2
+    assert result["signal_reason"] == "주요 고객 이탈 보도"
+    assert result["signal_uncertainty"] == 1.5
+
+
+@pytest.mark.asyncio
+async def test_perform_stock_analysis_leaves_signal_score_null_without_filter(monkeypatch):
+    """필터를 거치지 않은 경로(수동 분석·API 직접 호출)는 세 값 모두 null이어야 한다.
+
+    0으로 채우면 "모델이 중립으로 채점했다"는 없던 사실이 생긴다 (#122·#162).
+    """
+    async def fake_llm_chat(provider, prompt, *, conversation_id=None):
+        return "plain analysis"
+
+    async def fake_run_mcp_tool(params, tool_name, arguments):
+        return "삼성전자 (005930, KOSPI)"
+
+    monkeypatch.setattr(services, "llm_chat", fake_llm_chat)
+    monkeypatch.setattr(services, "run_mcp_tool", fake_run_mcp_tool)
+
+    session = FakeSession()
+    result = await services.perform_stock_analysis("삼성전자", "openai", session)
+
+    assert session.report.signal_score is None
+    assert session.report.signal_reason is None
+    assert session.report.signal_uncertainty is None
+    assert result["signal_score"] is None

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -1999,3 +1999,64 @@ async def test_score_signal_prompt_counts_only_whole_articles(monkeypatch):
     await services.score_signal("삼성전자", content, source="news")
 
     assert "기사 2건" in prompts[0]
+
+
+@pytest.mark.asyncio
+async def test_perform_stock_analysis_persists_signal_score(monkeypatch):
+    """2차 필터의 채점 결과가 AgentReport와 API 응답 양쪽에 실려야 한다.
+
+    perform_stock_analysis가 signal_score를 무시하면 점수가 DB에도 알림에도 남지
+    않고, 나중에 평가셋으로 모델을 검증할 방법이 사라진다.
+    """
+    async def fake_llm_chat(provider, prompt, *, conversation_id=None):
+        return "plain analysis"
+
+    async def fake_run_mcp_tool(params, tool_name, arguments):
+        return "삼성전자 (005930, KOSPI)"
+
+    monkeypatch.setattr(services, "llm_chat", fake_llm_chat)
+    monkeypatch.setattr(services, "run_mcp_tool", fake_run_mcp_tool)
+
+    scored = services.SignalScore(
+        score=-2,
+        reason="주요 고객 이탈 보도",
+        uncertainty=1.5,
+        headline_scores=(-3, 0),
+        is_significant=True,
+    )
+
+    session = FakeSession()
+    result = await services.perform_stock_analysis(
+        "삼성전자", "openai", session, signal_score=scored
+    )
+
+    assert session.report.signal_score == -2
+    assert session.report.signal_reason == "주요 고객 이탈 보도"
+    assert session.report.signal_uncertainty == 1.5
+    assert result["signal_score"] == -2
+    assert result["signal_reason"] == "주요 고객 이탈 보도"
+    assert result["signal_uncertainty"] == 1.5
+
+
+@pytest.mark.asyncio
+async def test_perform_stock_analysis_leaves_signal_score_null_without_filter(monkeypatch):
+    """필터를 거치지 않은 경로(수동 분석·API 직접 호출)는 세 값 모두 null이어야 한다.
+
+    0으로 채우면 "모델이 중립으로 채점했다"는 없던 사실이 생긴다 (#122·#162).
+    """
+    async def fake_llm_chat(provider, prompt, *, conversation_id=None):
+        return "plain analysis"
+
+    async def fake_run_mcp_tool(params, tool_name, arguments):
+        return "삼성전자 (005930, KOSPI)"
+
+    monkeypatch.setattr(services, "llm_chat", fake_llm_chat)
+    monkeypatch.setattr(services, "run_mcp_tool", fake_run_mcp_tool)
+
+    session = FakeSession()
+    result = await services.perform_stock_analysis("삼성전자", "openai", session)
+
+    assert session.report.signal_score is None
+    assert session.report.signal_reason is None
+    assert session.report.signal_uncertainty is None
+    assert result["signal_score"] is None

--- a/backend/tests/test_signal_eval_set.py
+++ b/backend/tests/test_signal_eval_set.py
@@ -1,0 +1,148 @@
+"""#298 평가셋 스크립트(backend/scripts/build_signal_eval_set.py) 테스트.
+
+사람 채점과 대조하는 것이 이 CSV의 유일한 목적이므로, "실패를 0점으로 적지 않는다"와
+"헤더·인코딩이 사람이 열 수 있는 형태다"가 핵심 회귀 지점이다.
+"""
+import csv
+
+import pytest
+
+from backend.scripts import build_signal_eval_set as eval_set
+from backend.services import SignalScore
+
+
+def test_parse_article_line_splits_title_and_summary():
+    article = eval_set.parse_article_line(
+        "삼성전자",
+        "삼성전자, 3분기 영업이익 10조 - 시장 기대치를 웃돌았다 | Mon, 18 Aug 2026 | https://n.example/1",
+    )
+
+    assert article == eval_set.Article(
+        stock="삼성전자",
+        title="삼성전자, 3분기 영업이익 10조",
+        summary="시장 기대치를 웃돌았다",
+    )
+
+
+def test_parse_article_line_keeps_lines_without_separator():
+    """형식이 어긋난 줄도 버리지 않는다 — 실제 입력 분포에 그런 줄이 섞여 있다."""
+    article = eval_set.parse_article_line("삼성전자", "구분자 없는 제목")
+
+    assert article == eval_set.Article(stock="삼성전자", title="구분자 없는 제목", summary="")
+
+
+def test_parse_article_line_drops_blank_lines():
+    assert eval_set.parse_article_line("삼성전자", "   ") is None
+
+
+@pytest.mark.asyncio
+async def test_collect_articles_dedupes_and_respects_count(monkeypatch):
+    async def fake_run_mcp_tool(params, tool_name, arguments):
+        stock = arguments["stock_name"]
+        return f"{stock} 기사A - 설명\n공통 기사 - 설명\n{stock} 기사B - 설명"
+
+    monkeypatch.setattr(eval_set, "run_mcp_tool", fake_run_mcp_tool)
+
+    articles = await eval_set.collect_articles(["삼성전자", "SK하이닉스"], count=10)
+
+    titles = [article.title for article in articles]
+    assert titles.count("공통 기사") == 1  # 종목이 달라도 같은 제목은 한 번만
+    assert len(articles) == 5
+
+    limited = await eval_set.collect_articles(["삼성전자", "SK하이닉스"], count=2)
+    assert len(limited) == 2
+
+
+@pytest.mark.asyncio
+async def test_collect_articles_skips_failing_stock(monkeypatch):
+    """한 종목의 뉴스 수집이 실패해도 나머지 종목으로 계속 모아야 한다."""
+    async def fake_run_mcp_tool(params, tool_name, arguments):
+        if arguments["stock_name"] == "삼성전자":
+            raise RuntimeError("뉴스 API 실패")
+        return "정상 기사 - 설명"
+
+    monkeypatch.setattr(eval_set, "run_mcp_tool", fake_run_mcp_tool)
+
+    articles = await eval_set.collect_articles(["삼성전자", "SK하이닉스"], count=10)
+
+    assert [article.title for article in articles] == ["정상 기사"]
+
+
+@pytest.mark.asyncio
+async def test_score_articles_leaves_model_score_blank_on_failure(monkeypatch):
+    """채점 실패는 빈 칸이어야 한다. 0으로 적으면 '중립 판단'과 섞여 평가가 왜곡된다."""
+    scores = iter(
+        [
+            SignalScore(2, "수주 공시", None, (2,), True),
+            SignalScore(None, None, None, (), True),  # fail-open
+            SignalScore(0, None, None, (0,), False),
+        ]
+    )
+
+    async def fake_score_signal(stock, signal_text, *args, **kwargs):
+        return next(scores)
+
+    monkeypatch.setattr(eval_set, "score_signal", fake_score_signal)
+
+    rows = await eval_set.score_articles(
+        [
+            eval_set.Article("삼성전자", "수주", "설명"),
+            eval_set.Article("삼성전자", "실패", "설명"),
+            eval_set.Article("삼성전자", "중립", "설명"),
+        ],
+        provider="ollama",
+    )
+
+    assert [row["모델점수"] for row in rows] == [2, "", 0]
+    assert [row["모델근거"] for row in rows] == ["수주 공시", "", ""]
+    # 사람 채점 열은 언제나 비어 있어야 한다 — 모델 점수를 미리 넣으면 채점자가 끌려간다.
+    assert all(row["사람점수"] == "" for row in rows)
+
+
+@pytest.mark.asyncio
+async def test_score_articles_sends_title_and_summary_to_the_model(monkeypatch):
+    seen = []
+
+    async def fake_score_signal(stock, signal_text, *args, **kwargs):
+        seen.append(signal_text)
+        return SignalScore(1, "근거", None, (1,), False)
+
+    monkeypatch.setattr(eval_set, "score_signal", fake_score_signal)
+
+    await eval_set.score_articles(
+        [
+            eval_set.Article("삼성전자", "제목", "요약"),
+            eval_set.Article("삼성전자", "요약 없는 제목", ""),
+        ],
+        provider="ollama",
+    )
+
+    assert seen == ["제목 - 요약", "요약 없는 제목"]
+
+
+def test_write_csv_is_readable_with_the_expected_header(tmp_path):
+    output = tmp_path / "eval.csv"
+    rows = [
+        {
+            "종목": "삼성전자",
+            "제목": "대형 수주",
+            "본문요약": "설명",
+            "모델점수": 3,
+            "모델근거": "수주 공시",
+            "사람점수": "",
+        }
+    ]
+
+    eval_set.write_csv(rows, output)
+
+    with output.open(encoding=eval_set.CSV_ENCODING, newline="") as handle:
+        loaded = list(csv.DictReader(handle))
+
+    assert list(loaded[0].keys()) == list(eval_set.CSV_HEADER)
+    assert loaded[0]["모델점수"] == "3"
+    assert loaded[0]["사람점수"] == ""
+
+
+@pytest.mark.asyncio
+async def test_resolve_stocks_prefers_explicit_list():
+    assert await eval_set.resolve_stocks(["A", "B", "A"]) == ["A", "B"]

--- a/backend/tests/test_telegram_notifier.py
+++ b/backend/tests/test_telegram_notifier.py
@@ -892,3 +892,86 @@ async def test_send_text_publishes_and_clears_retry_after(monkeypatch):
     monkeypatch.setattr(notifier, "_post_message", succeed)
     assert await notifier.send_text("안녕") is True
     assert notifier.last_retry_after_seconds is None
+
+
+# --- #298: 신호 점수 표시 ---------------------------------------------------
+
+
+def test_format_signal_score_line_renders_score_and_reason():
+    line = backend.telegram_notifier.format_signal_score_line(-2, "주요 고객 이탈 보도")
+
+    assert line == "📊 영향도 -2 (주요 고객 이탈 보도)"
+
+
+def test_format_signal_score_line_marks_positive_scores_with_sign():
+    assert backend.telegram_notifier.format_signal_score_line(3, "대형 수주") == (
+        "📊 영향도 +3 (대형 수주)"
+    )
+    # 0은 "+0"이 어색하다. 그리고 0은 "모름"이 아니라 "중립으로 채점됨"이므로 표시한다.
+    assert backend.telegram_notifier.format_signal_score_line(0, "홍보성 기사") == (
+        "📊 영향도 0 (홍보성 기사)"
+    )
+
+
+def test_format_signal_score_line_appends_disagreement_note_when_uncertain():
+    line = backend.telegram_notifier.format_signal_score_line(
+        1, "평가 갈림", uncertainty=2.5
+    )
+
+    assert line == "📊 영향도 +1 (평가 갈림) · ⚠️ 기사 간 평가 엇갈림"
+
+
+def test_format_signal_score_line_omits_note_below_threshold():
+    line = backend.telegram_notifier.format_signal_score_line(
+        1, "일관된 평가", uncertainty=0.5
+    )
+
+    assert backend.telegram_notifier.SIGNAL_DISAGREEMENT_NOTE not in line
+
+
+def test_format_signal_score_line_returns_none_without_score():
+    """채점하지 못했으면 줄 자체가 없어야 한다 — 없는 점수를 0으로 그리지 않는다."""
+    assert backend.telegram_notifier.format_signal_score_line(None, "근거") is None
+    assert backend.telegram_notifier.format_signal_score_line("2") is None
+    assert backend.telegram_notifier.format_signal_score_line(True) is None
+
+
+def test_format_analysis_alert_includes_signal_score_line():
+    notifier = TelegramNotifier(bot_token="token", chat_id="chat")
+
+    message = notifier.format_analysis_alert(
+        stock="삼성전자",
+        source="news",
+        analysis_data={
+            "summary": "요약",
+            "details": {"decision": "SELL", "confidence_score": 0.8, "reason": "고객 이탈"},
+            "urgency": "high",
+            "telegram_alert": True,
+            "signal_score": -2,
+            "signal_reason": "주요 고객 이탈 보도",
+            "signal_uncertainty": 1.5,
+        },
+    )
+
+    lines = message.split("\n")
+    assert lines[0] == "[긴급] 삼성전자 / news"
+    # 제목 바로 아래 — Decision보다 먼저 읽혀야 한다.
+    assert lines[1] == "📊 영향도 -2 (주요 고객 이탈 보도) · ⚠️ 기사 간 평가 엇갈림"
+    assert lines[2].startswith("Decision: SELL")
+
+
+def test_format_analysis_alert_without_signal_score_is_unchanged():
+    """점수가 없는 알림(수동 분석, fail-open)은 기존 형식 그대로여야 한다."""
+    notifier = TelegramNotifier(bot_token="token", chat_id="chat")
+    analysis_data = {
+        "summary": "요약",
+        "details": {"decision": "HOLD", "confidence_score": 0.5, "reason": "관망"},
+        "urgency": "normal",
+    }
+
+    message = notifier.format_analysis_alert(
+        stock="삼성전자", source="news", analysis_data=analysis_data
+    )
+
+    assert backend.telegram_notifier.SIGNAL_SCORE_LABEL not in message
+    assert message.split("\n")[1].startswith("Decision: HOLD")


### PR DESCRIPTION
## 📝 개요

감시 파이프라인의 2차 필터를 YES/NO 이진 판정에서 -3~+3 점수화로 승격한다. 점수·근거·불확실성을 함께 받아 DB(AgentReport)와 텔레그램 알림까지 실어 나른다.

- 평가셋 CSV 생성 스크립트는 네이버 API 키와 ollama가 필요해 이 브랜치에서 실제 실행하지 않았다. 로직은 단위 테스트로만 검증했다.
- 임계값 미만 신호는 상세 분석 자체를 건너뛰므로 AgentReport에 남지 않는다. 걸러진 점수 분포는 현재 스케줄러 로그로만 볼 수 있고, 구조화 저장은 후속 이슈로 등록하겠다.
- 파이썬 스크립트가 모두 `backend/scripts/`에 있어(루트 `scripts/`는 셸 전용) 평가셋 스크립트도 거기에 뒀다.

## 🔍 발견된 문제

1. 2차 필터가 YES/NO만 답해 "소소한 수주"와 "대형 실적 서프라이즈"가 똑같은 통과 신호가 된다. 강도와 방향(호재/악재)이 전부 소실돼 알림에 우선순위를 매길 근거가 없다.
2. 왜 유의미하다고 봤는지 근거가 어디에도 남지 않는다. 필터가 옳았는지 사후에 확인할 방법이 없고, 프롬프트를 고쳐도 나아졌는지 잴 수 없다.
3. 기사마다 평가가 엇갈려도 드러나지 않는다. 3건 중 1건만 극단적이어도 전체가 확신에 찬 통과로 보인다.
4. 필터의 판단이 저장되지 않아, 어떤 신호가 어떤 분석을 촉발했는지 리포트만 보고는 되짚을 수 없다.

## 🔧 문제 해결 방법

1. -3~+3 정수 채점으로 바꾸고 유의성 판정을 `|점수| >= 임계값`(기본 2, env로 1\~3)으로 대체한다. 레인지를 좁게 잡은 것은 의도다 — 0\~100 같은 넓은 축에서 경량 모델은 같은 기사에 매번 다른 점수를 준다.
2. 점수와 근거를 한 번의 호출에서 같이 요청한다. 사후에 따로 물으면 모델이 이미 낸 점수를 정당화하는 글을 쓴다. 단계별 기준(+3=대형 호재 … -3=대형 악재)은 프롬프트에 전부 적어 축을 모델 상상에 맡기지 않는다.
3. 기사별 점수를 함께 받아 표준편차를 코드에서 계산하고, 값이 크면 알림에 "기사 간 평가 엇갈림"을 붙인다. 기사가 2건 미만이면 0.0이 아니라 null이다 — 0.0은 "기사들이 완전히 일치했다"는 다른 뜻이다.
4. AgentReport에 nullable 컬럼 3개를 더한다(수제 마이그레이션, DEFAULT 없음). 호출·파싱 실패는 fail-open으로 통과시키되 점수를 null로 남겨 "모델이 중립으로 채점함"과 "채점하지 못함"을 구분한다.

## ✅ 검증

- 자가리뷰에서 리팩터링 중 테스트 2개가 지워진 것을 발견해 복원했고, 뮤테이션으로 구멍이 실제로 막혔는지 확인했다. `AgentReport(...)`의 `signal_*` 인자 3줄 삭제 / `data["signal_*"]`를 None 고정 — 복원 전에는 두 변형 모두 전체 통과, 복원 후에는 각각 1 failed.
- 실제 알림 출력을 렌더해 확인했다(diff에는 조립 코드만 보인다).
  ```
  [긴급] 삼성전자 / news
  📊 영향도 -2 (주요 고객 이탈 보도) · ⚠️ 기사 간 평가 엇갈림
  Decision: SELL (0.78)
  ```
  채점 실패(fail-open) 알림은 영향도 줄이 통째로 빠진다 — 필터를 거치지 않는 수동 분석까지 "미측정"으로 오염시키지 않기 위함이다.
- 스케줄러 테스트의 필터 mock 26개가 bool 대신 `SignalScore`를 반환하도록 바뀌었다. 협력자의 반환 타입이 바뀐 데 따른 기계적 수정이고 단언은 그대로다.

## 🔗 관련 이슈

- Closes #298
- 걸러진 신호(임계값 미만)의 점수 분포를 로그가 아닌 구조화된 형태로 남겨 임계값 튜닝 근거로 쓰는 건은 별도 이슈로 등록하겠습니다.
