### PR TITLE
fix: fetchAllPaged가 pageDelayMs 대기 후 시간 예산을 재확인한다 (#307)

### DIFF
--- a/mcp-trading/balance.js
+++ b/mcp-trading/balance.js
@@ -91,18 +91,35 @@ export async function fetchAllPaged(fetchPage, {
     // 페이지 사이에만 대기한다. `pages > 0`이므로 첫 페이지 요청 전에는 대기가 없고,
     // 위 두 break(max_pages/time_budget)나 아래쪽의 no_cursor/repeated_cursor/정상
     // 종료 break는 모두 이 지점을 다시 지나기 전에 루프를 빠져나가므로 마지막 페이지
-    // 이후에도 대기가 붙지 않는다.
+    // 이후에도 대기가 붙지 않는다. 아래 재확인 break는 대기가 이미 끝난 뒤에 걸리므로
+    // 이 불변식에 대기를 하나도 더 보태지 않는다 — 다만 그 마지막 대기 자체는 "다음
+    // 페이지를 요청한다"는 전제로 이미 들어간 뒤라 되돌릴 수 없다. 되돌리려면 대기 전에
+    // pageDelayMs를 미리 차감해 예측해야 하는데, 그건 아직 흐르지 않은 시간을 예산에서
+    // 빼는 다른 설계다.
     //
-    // 대기 시간을 시간 예산 소진에서 일부러 빼지 않는다: 이 함수의 상위 호출자는
-    // 내부 시간 예산과 무관하게 실제 벽시계 시간으로 잘린다 — backend/services.py의
-    // run_mcp_tool 30초 하드컷(get_balance), diary_agent.yml의 timeout_sec: 120
-    // (fetchAllDailyOrderCcld/fetchAllBalanceRlzPl). 대기 시간을 예산 계산에서
-    // 제외하면 내부적으로는 예산 안에 있다고 판단해도 실제 총 소요 시간이 이 상위
-    // 하드컷을 넘어설 수 있다. now/sleep 모두 기본값이 실제 시각(Date.now)·실제
-    // 대기(setTimeout)이므로 별도 처리 없이 두면 대기 시간이 자연히 다음 반복의
-    // `now() - startedAt`에 반영된다 — 이것이 의도한 동작이다.
+    // 대기 시간은 여전히 시간 예산에서 빼지 않는다(대기한 만큼 예산이 그대로 줄어든다):
+    // 이 함수의 상위 호출자는 내부 시간 예산과 무관하게 실제 벽시계 시간으로 잘린다 —
+    // backend/services.py의 run_mcp_tool 30초 하드컷(get_balance), diary_agent.yml의
+    // timeout_sec: 120 (fetchAllDailyOrderCcld/fetchAllBalanceRlzPl). 대기 시간을
+    // 예산 계산에서 제외하면 내부적으로는 예산 안에 있다고 판단해도 실제 총 소요 시간이
+    // 이 상위 하드컷을 넘어설 수 있다. now/sleep 모두 기본값이 실제 시각(Date.now)·실제
+    // 대기(setTimeout)이므로 대기 시간은 자연히 `now() - startedAt`에 반영된다.
+    // 이 방침 자체는 그대로다.
+    //
+    // 바뀐 것은 "예산을 언제 보는가"다(이슈 #307). 위쪽 체크는 대기가 시작되기 전 시각을
+    // 기준으로 하므로, 그 시점에는 예산이 남아 있었더라도 대기 중에 소진되면 예산이 끝난
+    // 상태로 다음 요청이 나가고 그 응답까지 기다리게 된다(초과분 ≈ pageDelayMs). 그래서
+    // 대기가 끝난 뒤 같은 조건을 한 번 더 본다. 비교 연산자는 위쪽 체크와 똑같이 `>=`로
+    // 맞춘다 — 한쪽만 `>`로 두면 정확히 경계인 시각에서 두 체크의 판단이 갈린다.
+    // 재확인에서 break하면 truncated/pages/rows가 위쪽 time_budget break와 완전히 같은
+    // 상태로 수렴한다(지금까지 받은 부분 결과는 그대로 보존된다).
     if (pageDelayMs > 0 && pages > 0) {
       await sleep(pageDelayMs);
+      // 이 블록은 `pages > 0`일 때만 실행되므로 위쪽 체크의 `pages > 0` 조건은 이미 참이다.
+      if (now() - startedAt >= timeBudgetMs) {
+        truncated = "time_budget";
+        break;
+      }
     }
 
     let body;

--- a/mcp-trading/balance.js
+++ b/mcp-trading/balance.js
@@ -73,6 +73,11 @@ export async function fetchAllPaged(fetchPage, {
   let pages = 0;
   let truncated = null;
   const startedAt = now();
+  // 시간 예산 소진 판정. 루프 진입 시점과 pageDelayMs 대기 직후 두 곳이 같은 술어를
+  // 공유한다 — 판정을 복제해 두면 한쪽 경계 연산자만 바뀌었을 때 경과가 정확히
+  // timeBudgetMs인 시각에서 두 체크의 판단이 갈리는데, 그걸 주석 규약이 아니라 구조로
+  // 막는다. 대기 직후 지점은 `pages > 0`이 이미 참이므로 술어를 공유해도 의미가 같다.
+  const budgetExhausted = () => pages > 0 && now() - startedAt >= timeBudgetMs;
   // 지금까지 받아본 연속조회 커서 전체를 기억해 둔다. 직전 값하고만 비교하면
   // A,B,A,B처럼 주기 2 이상으로 순환하는 커서를 놓치고 상한까지 같은
   // 데이터를 계속 중복 조회하게 된다.
@@ -83,7 +88,7 @@ export async function fetchAllPaged(fetchPage, {
       truncated = "max_pages";
       break;
     }
-    if (pages > 0 && now() - startedAt >= timeBudgetMs) {
+    if (budgetExhausted()) {
       truncated = "time_budget";
       break;
     }
@@ -109,14 +114,12 @@ export async function fetchAllPaged(fetchPage, {
     // 바뀐 것은 "예산을 언제 보는가"다(이슈 #307). 위쪽 체크는 대기가 시작되기 전 시각을
     // 기준으로 하므로, 그 시점에는 예산이 남아 있었더라도 대기 중에 소진되면 예산이 끝난
     // 상태로 다음 요청이 나가고 그 응답까지 기다리게 된다(초과분 ≈ pageDelayMs). 그래서
-    // 대기가 끝난 뒤 같은 조건을 한 번 더 본다. 비교 연산자는 위쪽 체크와 똑같이 `>=`로
-    // 맞춘다 — 한쪽만 `>`로 두면 정확히 경계인 시각에서 두 체크의 판단이 갈린다.
-    // 재확인에서 break하면 truncated/pages/rows가 위쪽 time_budget break와 완전히 같은
-    // 상태로 수렴한다(지금까지 받은 부분 결과는 그대로 보존된다).
+    // 대기가 끝난 뒤 budgetExhausted를 한 번 더 본다. 재확인에서 break하면
+    // truncated/pages/rows가 위쪽 time_budget break와 완전히 같은 상태로 수렴한다
+    // (지금까지 받은 부분 결과는 그대로 보존된다).
     if (pageDelayMs > 0 && pages > 0) {
       await sleep(pageDelayMs);
-      // 이 블록은 `pages > 0`일 때만 실행되므로 위쪽 체크의 `pages > 0` 조건은 이미 참이다.
-      if (now() - startedAt >= timeBudgetMs) {
+      if (budgetExhausted()) {
         truncated = "time_budget";
         break;
       }

--- a/mcp-trading/tests/fetch-all-paged.test.js
+++ b/mcp-trading/tests/fetch-all-paged.test.js
@@ -10,6 +10,9 @@
  * 요청당 타임아웃 8초 + 기동 오버헤드 2초를 빼면 ~110초 헤드룸.
  * 90 + 8 + 2 = 100 < 120이므로 상한 안에 안전하게 들어온다.
  * 실제 페이지당 지연 측정치가 없어 이 값은 검증 불가 — 소스 주석과 PR에 명시.
+ *
+ * 예외: 시간 예산 경계를 다루는 테스트(이슈 #307)는 가짜 시계로 예산 소진 시점을
+ * 짚어야 해서 90초 대신 짧은 예산(timeBudgetMs 1000)을 테스트별 지역 상수로 쓴다.
  */
 
 import assert from "node:assert/strict";
@@ -422,6 +425,7 @@ test("fetchAllPaged: 대기 후 경과가 정확히 timeBudgetMs면 중단한다
   // 경계 케이스: 재확인을 `>`로 두면 정확히 예산과 같은 시각에서 요청이 한 번 더 나가
   // 루프 진입 시점 체크(`>=`)와 판단이 갈린다.
   const TIME_BUDGET = 1000;
+  const PAGE_DELAY = 990;
   let clock = 0;
   let callCount = 0;
   const sleep = async (ms) => {
@@ -445,7 +449,7 @@ test("fetchAllPaged: 대기 후 경과가 정확히 timeBudgetMs면 중단한다
     maxPages: MAX_PAGES,
     timeBudgetMs: TIME_BUDGET,
     now: () => clock,
-    pageDelayMs: 990,
+    pageDelayMs: PAGE_DELAY,
     sleep,
   });
 
@@ -461,6 +465,9 @@ test("fetchAllPaged: 대기 후 경과가 정확히 timeBudgetMs면 중단한다
 test("fetchAllPaged: 루프 진입 시점 체크로 중단되면 그 반복에서는 대기하지 않는다 (마지막 페이지 뒤 대기 없음)", async () => {
   // 재확인 로직을 넣은 뒤에도, 루프 진입 시점의 time_budget 체크로 빠져나가는 경로는
   // sleep 지점을 지나기 전에 break하므로 마지막 페이지 뒤에 대기가 붙지 않는다.
+  const TIME_BUDGET = 1000;
+  const PAGE_DELAY = 100;
+
   let clock = 0;
   let callCount = 0;
   const sleepCalls = [];
@@ -484,9 +491,9 @@ test("fetchAllPaged: 루프 진입 시점 체크로 중단되면 그 반복에�
 
   const result = await fetchAllPaged(fetchPage, {
     maxPages: MAX_PAGES,
-    timeBudgetMs: 1000,
+    timeBudgetMs: TIME_BUDGET,
     now: () => clock,
-    pageDelayMs: 100,
+    pageDelayMs: PAGE_DELAY,
     sleep,
   });
 

--- a/mcp-trading/tests/fetch-all-paged.test.js
+++ b/mcp-trading/tests/fetch-all-paged.test.js
@@ -358,3 +358,143 @@ test("fetchAllPaged: pageDelayMs가 0이면 sleep을 주입해도 호출되지 �
   assert.equal(result.truncated, "no_cursor");
   assert.equal(sleepCallCount, 0);
 });
+
+// ─── 이슈 #307: pageDelayMs 대기 후 시간 예산 재확인 ─────────────────────────
+
+test("fetchAllPaged: pageDelayMs 대기 중 시간 예산이 소진되면 다음 요청을 내보내지 않는다 (이슈 #307)", async () => {
+  // PR #264 리뷰가 가짜 시계로 재현한 시나리오 그대로: timeBudgetMs 1000,
+  // pageDelayMs 400, 요청당 10ms. 재확인이 없으면 예산이 끝난 t=1230에 4번째 요청이
+  // 나가 가상 경과가 1240ms(초과분 240ms)까지 늘어난다.
+  const TIME_BUDGET = 1000;
+  const PAGE_DELAY = 400;
+  const REQUEST_MS = 10;
+
+  let clock = 0;
+  let callCount = 0;
+  const callClocks = [];
+  const sleepCalls = [];
+  const sleep = async (ms) => {
+    sleepCalls.push(ms);
+    clock += ms;
+  };
+  const fetchPage = async () => {
+    callCount += 1;
+    callClocks.push(clock);
+    clock += REQUEST_MS;
+    return {
+      body: {
+        output1: [{ pdno: String(callCount).padStart(6, "0") }],
+        output2: callCount === 1 ? [{ tot: "1" }] : [],
+        // 시간 예산 경로를 타려면 커서가 계속 있어야 한다 (없으면 no_cursor가 먼저 걸림)
+        ctx_area_fk100: `FK${callCount}`,
+        ctx_area_nk100: `NK${callCount}`,
+      },
+      trCont: "F",
+    };
+  };
+
+  const result = await fetchAllPaged(fetchPage, {
+    maxPages: MAX_PAGES,
+    timeBudgetMs: TIME_BUDGET,
+    now: () => clock,
+    pageDelayMs: PAGE_DELAY,
+    sleep,
+  });
+
+  // 1회: t=0 요청 → t=10
+  // 대기 400 → t=410, 재확인 410 < 1000 → 2회: t=410 요청 → t=420
+  // 대기 400 → t=820, 재확인 820 < 1000 → 3회: t=820 요청 → t=830
+  // 대기 400 → t=1230, 재확인 1230 >= 1000 → 4번째 요청 없이 break
+  assert.equal(callCount, 3, "예산 소진 후 추가 요청이 나가면 안 된다");
+  assert.deepEqual(callClocks, [0, 410, 820]);
+  assert.equal(result.pages, 3);
+  assert.equal(result.truncated, "time_budget");
+  // 부분 결과 보존: 기존 time_budget break와 동일한 반환 계약
+  assert.equal(result.rows.length, 3);
+  assert.deepEqual(result.summary, { tot: "1" });
+  // 마지막 요청이 나가지 않았으므로 가상 경과는 1240ms가 아니라 1230ms에서 멈춘다
+  assert.equal(clock, 1230);
+  // 재확인 break 이후에는 대기가 추가되지 않는다
+  assert.deepEqual(sleepCalls, [400, 400, 400]);
+});
+
+test("fetchAllPaged: 대기 후 경과가 정확히 timeBudgetMs면 중단한다 (진입 체크와 같은 >= 경계)", async () => {
+  // 경계 케이스: 재확인을 `>`로 두면 정확히 예산과 같은 시각에서 요청이 한 번 더 나가
+  // 루프 진입 시점 체크(`>=`)와 판단이 갈린다.
+  const TIME_BUDGET = 1000;
+  let clock = 0;
+  let callCount = 0;
+  const sleep = async (ms) => {
+    clock += ms;
+  };
+  const fetchPage = async () => {
+    callCount += 1;
+    clock += 10;
+    return {
+      body: {
+        output1: [{ pdno: String(callCount).padStart(6, "0") }],
+        output2: [],
+        ctx_area_fk100: `FK${callCount}`,
+        ctx_area_nk100: `NK${callCount}`,
+      },
+      trCont: "F",
+    };
+  };
+
+  const result = await fetchAllPaged(fetchPage, {
+    maxPages: MAX_PAGES,
+    timeBudgetMs: TIME_BUDGET,
+    now: () => clock,
+    pageDelayMs: 990,
+    sleep,
+  });
+
+  // 1회: t=0 요청 → t=10. 대기 990 → t=1000.
+  // now() - startedAt === 1000 === timeBudgetMs 이므로 >= 에서 중단된다.
+  assert.equal(clock, 1000);
+  assert.equal(callCount, 1, "경계에서 요청이 한 번 더 나가면 안 된다");
+  assert.equal(result.pages, 1);
+  assert.equal(result.truncated, "time_budget");
+  assert.equal(result.rows.length, 1);
+});
+
+test("fetchAllPaged: 루프 진입 시점 체크로 중단되면 그 반복에서는 대기하지 않는다 (마지막 페이지 뒤 대기 없음)", async () => {
+  // 재확인 로직을 넣은 뒤에도, 루프 진입 시점의 time_budget 체크로 빠져나가는 경로는
+  // sleep 지점을 지나기 전에 break하므로 마지막 페이지 뒤에 대기가 붙지 않는다.
+  let clock = 0;
+  let callCount = 0;
+  const sleepCalls = [];
+  const sleep = async (ms) => {
+    sleepCalls.push(ms);
+    clock += ms;
+  };
+  const fetchPage = async () => {
+    callCount += 1;
+    clock += 600; // 요청 자체가 예산을 소진한다
+    return {
+      body: {
+        output1: [{ pdno: String(callCount).padStart(6, "0") }],
+        output2: [],
+        ctx_area_fk100: `FK${callCount}`,
+        ctx_area_nk100: `NK${callCount}`,
+      },
+      trCont: "F",
+    };
+  };
+
+  const result = await fetchAllPaged(fetchPage, {
+    maxPages: MAX_PAGES,
+    timeBudgetMs: 1000,
+    now: () => clock,
+    pageDelayMs: 100,
+    sleep,
+  });
+
+  // 1회: t=0 요청 → t=600. 진입 체크 600 < 1000 → 대기 100 → t=700,
+  //      재확인 700 < 1000 → 2회: t=700 요청 → t=1300.
+  // 진입 체크 1300 >= 1000 → sleep 지점을 지나기 전에 break.
+  assert.equal(callCount, 2);
+  assert.equal(result.truncated, "time_budget");
+  // 대기는 페이지 사이 1회(= pages - 1)뿐. 마지막 페이지 뒤에는 대기가 없다.
+  assert.deepEqual(sleepCalls, [100]);
+});


### PR DESCRIPTION
## 📝 개요

`fetchAllPaged`가 `pageDelayMs` 대기를 끝낸 뒤 시간 예산을 다시 확인하도록 고칩니다. 대기 중에 예산이 소진되면 다음 요청을 내보내지 않고 `truncated: "time_budget"`으로 끝납니다.

`DAILY_CCLD_PAGE_DELAY_MS`·`BALANCE_RLZ_PL_PAGE_DELAY_MS`가 모두 0이고 `fetchAllBalance`는 `pageDelayMs`를 아예 넘기지 않아 이 경로는 **현재 도달 불가**입니다. 런타임 동작 변화는 없고, 실측 값을 채우는 #210이 이 가드를 전제로 합니다.

## 🔍 발견된 문제

1. **예산 체크가 대기보다 앞에만 있다.** PR #264가 넣은 페이지 간 대기(`balance.js:104-106`)가 시간 예산 체크(`balance.js:86-89`) 뒤에 있어, 체크 시점에는 예산이 남아 있었더라도 대기 중에 소진되면 루프가 예산이 끝난 상태로 다음 페이지를 요청하고 그 응답까지 기다립니다. 초과분은 대략 `pageDelayMs`만큼입니다. PR #264 리뷰가 가짜 시계로 `timeBudgetMs: 1000`, `pageDelayMs: 400`, 요청당 10ms를 돌려 `pages=4`, 가상 경과 1240ms(초과분 240ms)를 확인했고 마지막 요청은 예산이 끝난 t=1000 이후인 t=1230에 나갔습니다.

2. **주석이 새 동작과 충돌한다.** `balance.js:91-103` 주석이 "대기 시간을 시간 예산 소진에서 일부러 빼지 않는다 … 이것이 의도한 동작이다"라며 현 동작을 명시적으로 방어하고 있어, 재확인 로직을 넣으면 코드와 모순됩니다.

## 🔧 문제 해결 방법

1. **`await sleep(pageDelayMs)` 직후 예산을 재확인**하고 초과 시 `truncated = "time_budget"`으로 break합니다.
   - **비교 연산자는 루프 진입 시점 체크와 똑같이 `>=`**로 맞췄습니다. 한쪽만 `>`로 두면 경과가 정확히 `timeBudgetMs`인 시각에서 두 체크의 판단이 갈립니다.
   - 재확인 break는 `truncated`/`pages`/`rows`가 **기존 `time_budget` break와 완전히 같은 상태로 수렴**하므로 부분 결과 보존이 깨지지 않습니다.
   - 이 블록은 `pages > 0`일 때만 실행되므로 진입 시점 체크의 `pages > 0` 조건은 이미 참이고, 별도 조건을 붙이지 않았습니다.

2. **주석을 새 동작에 맞춰 다시 썼습니다.** 재확인은 "대기 시간을 예산에서 뺀다"가 아니라 "대기 후 다시 본다"이므로, 무엇이 그대로이고 무엇이 바뀌었는지 갈라 적었습니다.
   - *그대로*: 대기 시간을 시간 예산에서 차감하지 않는다는 방침. 상위 호출자(`backend/services.py`의 `run_mcp_tool` 30초 하드컷, `diary_agent.yml`의 `timeout_sec: 120`)가 벽시계 시간으로 자르므로 대기를 예산에서 빼면 내부적으로는 예산 안이어도 실제 총 소요 시간이 상위 하드컷을 넘어설 수 있다는 근거까지 유지했습니다.
   - *바뀐 것*: "예산을 **언제** 보는가". 진입 시점 체크는 대기 시작 전 시각 기준이라 대기 중 소진을 놓친다는 점, 그래서 대기가 끝난 뒤 같은 조건을 한 번 더 본다는 점, 경계 연산자를 맞춘 이유를 적었습니다.
   - *불변식*: "마지막 페이지 이후에는 대기가 붙지 않는다"에 대해, 재확인 break는 대기가 이미 끝난 뒤에 걸리므로 **대기를 하나도 더 보태지 않는다**는 점과, 다만 이미 들어간 마지막 대기 자체는 되돌릴 수 없다(되돌리려면 아직 흐르지 않은 시간을 미리 차감하는 다른 설계가 된다)는 점을 함께 명시했습니다.

3. **테스트 3건 추가** (`tests/fetch-all-paged.test.js`, `now`/`sleep` 주입):
   - 리뷰 재현 시나리오 그대로(예산 1000 / 대기 400 / 요청 10ms) → `fetchPage` 호출 정확히 3회, 호출 시각 `[0, 410, 820]`, `pages=3`, `truncated="time_budget"`, `rows.length=3`, `summary` 보존, 가상 경과가 1240ms가 아닌 1230ms에서 정지, 대기 횟수 `[400,400,400]`(break 이후 추가 대기 없음).
   - 경계: 대기 후 경과가 정확히 `timeBudgetMs`(1000)일 때 중단 — `>` 였다면 요청이 한 번 더 나가 t=1010이 됩니다.
   - 불변식 고정: 루프 진입 시점 체크로 중단되는 경로는 sleep 지점을 지나기 전에 break하므로 대기 횟수가 `pages - 1`(1회)에 머물고 마지막 페이지 뒤에 대기가 붙지 않습니다.

## ✅ 검증

`cd mcp-trading && node --test tests/balance.test.js tests/fetch-all-paged.test.js`

**수정 후 (현재 HEAD)** — 기존 36건 포함 전부 통과:
```
ℹ tests 39
ℹ pass 39
ℹ fail 0
```

**뮤테이션 실측 A — 재확인 블록을 통째로 제거** (`await sleep(pageDelayMs);`만 남김): 새 테스트 2건이 빨간불.
```
✖ fetchAllPaged: pageDelayMs 대기 중 시간 예산이 소진되면 다음 요청을 내보내지 않는다 (이슈 #307)
  AssertionError: 예산 소진 후 추가 요청이 나가면 안 된다
    actual: 4, expected: 3
✖ fetchAllPaged: 대기 후 경과가 정확히 timeBudgetMs면 중단한다 (진입 체크와 같은 >= 경계)
  AssertionError: actual: 1010, expected: 1000
ℹ tests 39 / pass 37 / fail 2
```
`actual: 4`는 이슈에 적힌 재현 결과(`pages=4`)와 정확히 일치합니다.

**뮤테이션 실측 B — 재확인은 두되 `>=`를 `>`로** : 경계 테스트가 빨간불.
```
✖ fetchAllPaged: 대기 후 경과가 정확히 timeBudgetMs면 중단한다 (진입 체크와 같은 >= 경계)
  AssertionError: actual: 1010, expected: 1000
ℹ tests 39 / pass 38 / fail 1
```

**원복 후 재측정**: `tests 39 / pass 39 / fail 0`.

**런타임 동작 불변**: `DAILY_CCLD_PAGE_DELAY_MS = 0`, `BALANCE_RLZ_PL_PAGE_DELAY_MS = 0`이고 `fetchAllBalance`는 `fetchAllPaged`에 `pageDelayMs`를 넘기지 않으므로(`balance.js`) 새 재확인 블록은 현재 어느 프로덕션 경로에서도 실행되지 않습니다. 기존 `balance.test.js` 26건이 무변경으로 통과하는 것이 그 근거입니다.

**로컬에서 확인하지 못한 것**: `npm test` 전체는 `node_modules`가 필요해 이 환경에서 돌리지 못했습니다. 위 두 파일은 `node:*` 빌트인과 `../balance.js`만 import하고 `balance.js`는 외부 import가 없어 `node --test`로 단독 실행했습니다. 실제 KIS 연속조회에 대한 통합 검증도 없습니다(`pageDelayMs`가 0이라 이 경로 자체가 프로덕션에서 실행되지 않습니다).

## 🔗 관련 이슈

- Closes #307
- **#210의 선행 조건**입니다. #210이 `DAILY_CCLD_PAGE_DELAY_MS`·`BALANCE_RLZ_PL_PAGE_DELAY_MS`에 실측 값을 채우는 순간 이 경로가 도달 가능해지고, 그때 이 가드가 없으면 대기당 최대 `pageDelayMs`만큼 `diary_agent.yml`의 120초 하드컷 헤드룸을 갉아먹습니다.
- PR #264 리뷰 후속: https://github.com/FIN-US/fin-us/pull/264#pullrequestreview-4944220978
- 관련: PR #200
