### PR TITLE
feat: 걸러진 신호의 점수 분포를 구조화해 남긴다 (#304)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,13 @@ DB_ECHO=false
 # 기사별 점수의 표준편차가 이 값 이상이면 텔레그램 알림에 "기사 간 평가 엇갈림"을 표시합니다.
 # SIGNAL_UNCERTAINTY_ALERT_THRESHOLD=1.0
 
+# 걸러진 신호 채점 기록 보존 기간 (#304)
+# 임계값에 못 미쳐 상세 분석까지 가지 않은 신호의 점수를 며칠 보관할지 정합니다.
+# 감시 루프가 종목·소스마다 10분 주기로 돌아 행이 빠르게 쌓이므로, 매일 04:10(KST)에
+# 이 기간이 지난 행을 지웁니다. 1~365 범위 밖이거나 숫자가 아니면 기본값 30으로 되돌립니다.
+# 점수 구간별 건수는 GET /api/v1/db/filtered-signals/histogram 으로 확인합니다.
+# FILTERED_SIGNAL_RETENTION_DAYS=30
+
 # Redis
 # docker compose의 redis는 호스트 루프백에만 게시되므로(#285) 호스트에서 백엔드를
 # 직접 띄울 때는 아래 값이 그대로 맞습니다. 게시가 IPv4 전용이라 `localhost`가 아니라

--- a/backend/config.py
+++ b/backend/config.py
@@ -131,6 +131,16 @@ def _float_env(name: str, default: float) -> float:
 SIGNAL_UNCERTAINTY_ALERT_THRESHOLD = _float_env("SIGNAL_UNCERTAINTY_ALERT_THRESHOLD", 1.0)
 
 
+# 임계값 미만으로 걸러진 신호의 채점 기록(models.FilteredSignal, #304)을 며칠 보관할지.
+# 감시 루프가 종목·소스마다 10분 주기로 돌아 행이 빠르게 쌓이므로 무기한 보관하지
+# 않는다. 기본 30일은 임계값을 한 번 조정하고 그 효과를 관찰하는 주기를 덮으면서도
+# SQLite 한 파일이 감당할 수 있는 크기다.
+# 상한 365일: 그보다 오래 보관해야 할 이유가 생겼다면 SQLite가 아니라 별도 저장소를
+# 검토할 시점이라는 뜻이다. 하한 1일: 0을 허용하면 기록하자마자 지워져 기능이 조용히
+# 꺼진다 — _int_env_in_range가 임계값에서 배격한 것과 같은 실패 유형이다.
+FILTERED_SIGNAL_RETENTION_DAYS = _int_env_in_range("FILTERED_SIGNAL_RETENTION_DAYS", 30, 1, 365)
+
+
 # Redis cache/lock settings for scheduler state.
 # 기본값이 `localhost`가 아닌 것은 compose의 redis 게시가 루프백 IPv4 전용이기
 # 때문이다(#285). `localhost`가 `::1`로 먼저 풀리는 호스트에서 주소 폴백에 기대지

--- a/backend/filtered_signal_repo.py
+++ b/backend/filtered_signal_repo.py
@@ -1,0 +1,195 @@
+"""임계값 미만으로 걸러진 신호의 채점 기록 저장·정리·집계 (#304).
+
+저장·정리는 감시 루프(scheduler)가 자기 세션으로 쓰므로 세션 팩토리를 받는 repo
+클래스가 맡고, 집계는 요청 세션 위에서 도는 API가 쓰므로 세션을 인자로 받는 함수로
+둔다 — /api/v1/db/* 라우트들이 이미 요청 세션에 직접 질의하는 방식과 맞춘다.
+"""
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Optional, Sequence
+
+from sqlalchemy import delete, func
+from sqlmodel import Session, select
+
+from .models import FilteredSignal
+
+
+def _as_utc_naive(value: datetime) -> datetime:
+    """tz-aware 값을 UTC로 옮기고 tzinfo를 떼어 낸다.
+
+    SQLite의 DATETIME 컬럼은 오프셋을 저장하지 않는다 — SQLAlchemy가 bind 시점에
+    tzinfo를 버리므로, 저장된 created_at은 UTC 벽시계 시각의 naive 값이다. 비교 대상을
+    같은 모양으로 맞추지 않으면 SQLAlchemy가 조건을 파이썬으로 평가하는 경로에서
+    "can't compare offset-naive and offset-aware datetimes"로 죽는다.
+    """
+    if value.tzinfo is None:
+        # 이미 naive라면 UTC로 간주한다. 이 모듈에 들어오는 값은 전부 UTC 계약이다.
+        return value
+    return value.astimezone(timezone.utc).replace(tzinfo=None)
+
+
+def _as_utc_aware(value: Optional[datetime]) -> Optional[datetime]:
+    """읽어 온 naive UTC 값에 tzinfo를 도로 붙인다 (응답에 오프셋을 실어 보내려고)."""
+    if value is None or value.tzinfo is not None:
+        return value
+    return value.replace(tzinfo=timezone.utc)
+
+
+@dataclass(frozen=True)
+class ScoreBucket:
+    score: int
+    count: int
+
+
+@dataclass(frozen=True)
+class FilteredSignalHistogram:
+    """점수 구간별 건수 집계 결과.
+
+    ``buckets``는 실제로 기록된 점수만 담는다 — 건수 0인 점수 칸을 지어내지 않는다.
+    표시할 축이 필요한 쪽(사람이 읽는 표)에서 -3~+3을 채우는 편이, 여기서 채워
+    "0건인 칸"과 "그 점수를 본 적 없음"을 뭉개는 것보다 낫다.
+    """
+
+    total: int
+    buckets: tuple[ScoreBucket, ...]
+    # 이 구간에 섞여 있는 기록 시점 임계값들. 값이 둘 이상이면 집계 구간 중간에
+    # 임계값이 바뀌었다는 뜻이고, 그때는 구간 전체를 한 분포로 읽으면 안 된다.
+    thresholds: tuple[int, ...]
+    oldest: Optional[datetime]
+    newest: Optional[datetime]
+
+
+class SqliteFilteredSignalRepo:
+    def __init__(self, session_factory: Callable[[], Session]):
+        self._session_factory = session_factory
+
+    async def record(
+        self,
+        *,
+        stock_name: str,
+        source: str,
+        score: Optional[int],
+        threshold: int,
+        reason: Optional[str] = None,
+        uncertainty: Optional[float] = None,
+    ) -> Optional[FilteredSignal]:
+        """걸러진 신호 한 건의 채점 결과를 남긴다. ``score``가 None이면 남기지 않는다.
+
+        점수 없이 걸러지는 경로가 실제로 있다 — 본문이 비었거나 직전과 같은 signal은
+        LLM을 부르지도 않고 걸러진다(services._SKIPPED_SIGNAL_SCORE). 그런 행을 남기면
+        점수 분포에 보탤 정보는 0인데, 감시 루프가 종목·소스마다 10분 주기로 도는 탓에
+        "이번 주기에도 새 소식이 없었다"는 행만 테이블을 가득 채운다. 그래서 여기 남는
+        행은 전부 "모델이 실제로 채점했고 그 점수가 임계값에 못 미쳤다"는 뜻이다.
+        """
+        if score is None:
+            return None
+
+        with self._session_factory() as session:
+            row = FilteredSignal(
+                stock_name=stock_name,
+                source=source,
+                score=score,
+                threshold=threshold,
+                reason=reason,
+                uncertainty=uncertainty,
+            )
+            session.add(row)
+            session.commit()
+            session.refresh(row)
+            return row
+
+    async def purge_expired(
+        self,
+        retention_days: int,
+        *,
+        now: Optional[datetime] = None,
+    ) -> int:
+        """보존 기간이 지난 행을 지우고 삭제 건수를 돌려준다.
+
+        행 단위로 세션에 실어 지우지 않고 한 문장으로 지운다 — 정리 대상은 수만 건일
+        수 있고, 그걸 전부 파이썬 객체로 올릴 이유가 없다.
+
+        워커가 여럿이어도 안전하다: 같은 조건으로 두 번 지우면 두 번째는 0건이다.
+        """
+        cutoff = _as_utc_naive(
+            (now or datetime.now(timezone.utc)) - timedelta(days=retention_days)
+        )
+        with self._session_factory() as session:
+            result = session.execute(
+                delete(FilteredSignal).where(FilteredSignal.created_at < cutoff),
+                # 세션에 이미 올라온 객체를 파이썬으로 재평가하지 않는다. 이 세션은
+                # 삭제 직후 버려지므로 동기화할 상태가 없고, 기본 전략("evaluate")은
+                # 조건을 파이썬에서 다시 계산하다 타입 차이로 죽을 수 있다.
+                execution_options={"synchronize_session": False},
+            )
+            session.commit()
+            # rowcount는 방언에 따라 -1("모름")일 수 있다. 로그 문구가 "-1건 삭제"가
+            # 되지 않도록 0으로 눕힌다 — 삭제 자체는 이미 커밋됐다.
+            return max(result.rowcount or 0, 0)
+
+
+def score_histogram(
+    session: Session,
+    *,
+    source: Optional[str] = None,
+    stock_name: Optional[str] = None,
+    since: Optional[datetime] = None,
+) -> FilteredSignalHistogram:
+    """걸러진 신호를 점수별로 세어 돌려준다.
+
+    ``since``는 UTC 기준으로 넘긴다. created_at을 UTC로 저장하므로(models 참고)
+    다른 시간대의 값을 그대로 넘기면 구간이 어긋난다.
+    """
+    filters = []
+    if source is not None:
+        filters.append(FilteredSignal.source == source)
+    if stock_name is not None:
+        filters.append(FilteredSignal.stock_name == stock_name)
+    if since is not None:
+        filters.append(FilteredSignal.created_at >= _as_utc_naive(since))
+
+    bucket_query = select(FilteredSignal.score, func.count()).group_by(
+        FilteredSignal.score
+    ).order_by(FilteredSignal.score)
+    summary_query = select(
+        func.count(),
+        func.min(FilteredSignal.created_at),
+        func.max(FilteredSignal.created_at),
+    )
+    threshold_query = select(FilteredSignal.threshold).distinct().order_by(
+        FilteredSignal.threshold
+    )
+    for condition in filters:
+        bucket_query = bucket_query.where(condition)
+        summary_query = summary_query.where(condition)
+        threshold_query = threshold_query.where(condition)
+
+    buckets = tuple(
+        ScoreBucket(score=score, count=count)
+        for score, count in session.exec(bucket_query).all()
+    )
+    total, oldest, newest = session.exec(summary_query).one()
+    thresholds = tuple(session.exec(threshold_query).all())
+
+    return FilteredSignalHistogram(
+        total=total or 0,
+        buckets=buckets,
+        thresholds=thresholds,
+        oldest=_as_utc_aware(oldest),
+        newest=_as_utc_aware(newest),
+    )
+
+
+def fill_score_axis(
+    buckets: Sequence[ScoreBucket], low: int, high: int
+) -> tuple[ScoreBucket, ...]:
+    """``low``~``high`` 전 구간을 0으로 메운 축을 만든다 (사람이 읽는 표·그래프용).
+
+    집계 자체는 본 적 없는 점수를 지어내지 않는다. 축이 필요한 표시 계층만 이 함수를
+    거친다.
+    """
+    counts = {bucket.score: bucket.count for bucket in buckets}
+    return tuple(
+        ScoreBucket(score=score, count=counts.get(score, 0))
+        for score in range(low, high + 1)
+    )

--- a/backend/filtered_signal_repo.py
+++ b/backend/filtered_signal_repo.py
@@ -4,6 +4,7 @@
 클래스가 맡고, 집계는 요청 세션 위에서 도는 API가 쓰므로 세션을 인자로 받는 함수로
 둔다 — /api/v1/db/* 라우트들이 이미 요청 세션에 직접 질의하는 방식과 맞춘다.
 """
+import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Callable, Optional, Sequence
@@ -12,6 +13,8 @@ from sqlalchemy import delete, func
 from sqlmodel import Session, select
 
 from .models import FilteredSignal
+
+logger = logging.getLogger(__name__)
 
 
 def _as_utc_naive(value: datetime) -> datetime:
@@ -72,7 +75,7 @@ class SqliteFilteredSignalRepo:
         threshold: int,
         reason: Optional[str] = None,
         uncertainty: Optional[float] = None,
-    ) -> Optional[FilteredSignal]:
+    ) -> None:
         """걸러진 신호 한 건의 채점 결과를 남긴다. ``score``가 None이면 남기지 않는다.
 
         점수 없이 걸러지는 경로가 실제로 있다 — 본문이 비었거나 직전과 같은 signal은
@@ -82,7 +85,7 @@ class SqliteFilteredSignalRepo:
         행은 전부 "모델이 실제로 채점했고 그 점수가 임계값에 못 미쳤다"는 뜻이다.
         """
         if score is None:
-            return None
+            return
 
         with self._session_factory() as session:
             row = FilteredSignal(
@@ -95,8 +98,6 @@ class SqliteFilteredSignalRepo:
             )
             session.add(row)
             session.commit()
-            session.refresh(row)
-            return row
 
     async def purge_expired(
         self,
@@ -187,7 +188,21 @@ def fill_score_axis(
 
     집계 자체는 본 적 없는 점수를 지어내지 않는다. 축이 필요한 표시 계층만 이 함수를
     거친다.
+
+    축 밖의 점수는 표시할 자리가 없어 버려지는데, 그러면 응답의 total과 buckets의 합이
+    어긋난다. 지금은 채점이 -3~+3으로 clamp되어(services._coerce_signal_score) 도달할
+    수 없는 상태지만, 그 clamp가 사라지면 무증상으로 깨지므로 버릴 때 로그를 남긴다.
     """
+    out_of_axis = [bucket for bucket in buckets if not low <= bucket.score <= high]
+    if out_of_axis:
+        logger.warning(
+            "점수 축(%d~%d) 밖의 집계 %d건을 표시에서 제외했습니다 — total과 buckets의 합이 "
+            "어긋납니다: %s",
+            low,
+            high,
+            len(out_of_axis),
+            [(bucket.score, bucket.count) for bucket in out_of_axis],
+        )
     counts = {bucket.score: bucket.count for bucket in buckets}
     return tuple(
         ScoreBucket(score=score, count=counts.get(score, 0))

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,12 +1,22 @@
 import os
 import logging
 from contextlib import asynccontextmanager
-from datetime import date
+from datetime import date, datetime, timedelta, timezone
 from fastapi import FastAPI, HTTPException, Query, Depends, Request, WebSocket, WebSocketDisconnect, Body
 from fastapi.middleware.cors import CORSMiddleware
 from sqlmodel import Session, select
 
-from .config import NEWS_MCP_PARAMS, TRADING_MCP_PARAMS, DART_MCP_PARAMS, ALLOW_ORIGINS
+from .config import (
+    NEWS_MCP_PARAMS,
+    TRADING_MCP_PARAMS,
+    DART_MCP_PARAMS,
+    ALLOW_ORIGINS,
+    FILTERED_SIGNAL_RETENTION_DAYS,
+    SIGNAL_SCORE_MAX,
+    SIGNAL_SCORE_MIN,
+    SIGNAL_SCORE_THRESHOLD,
+)
+from .filtered_signal_repo import fill_score_axis, score_histogram
 from .ws_manager import manager
 from .scheduler import start_scheduler, stop_scheduler
 from .telegram_commands import start_telegram_commands, stop_telegram_commands
@@ -331,6 +341,66 @@ async def get_db_catalysts(
         "status": "success",
         "data": rows[:limit],
         "message": "truncated" if truncated else None,
+    }
+
+
+@app.get(
+    "/api/v1/db/filtered-signals/histogram",
+    response_model=CommonResponse,
+    tags=["Database"],
+)
+async def get_filtered_signal_histogram(
+    source: str | None = Query(
+        None, min_length=1, description="신호 출처 정확 일치 필터 (news | disclosure). 생략 시 전체."
+    ),
+    stock_name: str | None = Query(
+        None, min_length=1, description="종목명 정확 일치 필터. 생략 시 전체 종목."
+    ),
+    days: int | None = Query(
+        None,
+        ge=1,
+        le=365,
+        description="최근 N일(UTC 기준)만 집계. 생략 시 보관 중인 전체 구간.",
+    ),
+    session: Session = Depends(get_session),
+):
+    """임계값 미만으로 걸러진 신호를 점수 구간별로 집계합니다 (#304).
+
+    임계값(SIGNAL_SCORE_THRESHOLD)을 조정할 때 "지금 값에서 걸러지고 있는 신호가
+    점수대별로 몇 건인지"를 로그 grep 없이 확인하는 경로다. 통과한 쪽의 점수는 이
+    테이블이 아니라 AgentReport.signal_score에 있다.
+
+    buckets는 -3~+3 전 구간을 0으로 채워 돌려준다. 이 응답은 사람이 임계값을 정하려고
+    읽는 표라서, "그 점수를 한 건도 못 봤다"가 빈 칸이 아니라 0으로 보여야 한다.
+
+    recorded_thresholds에 값이 둘 이상이면 집계 구간 중간에 임계값이 바뀐 것이다.
+    그때 buckets는 서로 다른 설정에서 걸러진 신호가 섞인 분포이므로 한 덩어리로
+    읽으면 안 된다 — days를 좁혀 다시 조회해야 한다.
+    """
+    since = (
+        datetime.now(timezone.utc) - timedelta(days=days) if days is not None else None
+    )
+    histogram = score_histogram(
+        session, source=source, stock_name=stock_name, since=since
+    )
+    return {
+        "status": "success",
+        "data": {
+            "threshold": SIGNAL_SCORE_THRESHOLD,
+            "retention_days": FILTERED_SIGNAL_RETENTION_DAYS,
+            "window_days": days,
+            "since": since.isoformat() if since is not None else None,
+            "total": histogram.total,
+            "buckets": [
+                {"score": bucket.score, "count": bucket.count}
+                for bucket in fill_score_axis(
+                    histogram.buckets, SIGNAL_SCORE_MIN, SIGNAL_SCORE_MAX
+                )
+            ],
+            "recorded_thresholds": list(histogram.thresholds),
+            "oldest": histogram.oldest,
+            "newest": histogram.newest,
+        },
     }
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,6 +2,7 @@ import os
 import logging
 from contextlib import asynccontextmanager
 from datetime import date, datetime, timedelta, timezone
+from typing import Literal
 from fastapi import FastAPI, HTTPException, Query, Depends, Request, WebSocket, WebSocketDisconnect, Body
 from fastapi.middleware.cors import CORSMiddleware
 from sqlmodel import Session, select
@@ -344,14 +345,24 @@ async def get_db_catalysts(
     }
 
 
+# 걸러진 신호 조회의 출처 필터가 받는 값. scheduler.SIGNAL_SOURCES의 name과 같아야
+# 하며, 어긋나면 test_filtered_signal.py의 드리프트 테스트가 깨진다. 자유 문자열로 두면
+# 오타가 422가 아니라 "total: 0"인 정상 응답으로 돌아와, 임계값 조정 근거를 읽는 쪽에서
+# "걸러진 게 없다"와 "필터를 잘못 썼다"가 구분되지 않는다.
+#
+# 저장 컬럼(FilteredSignal.source)은 좁히지 않는다. 출처 목록이 나중에 바뀌어도 이미
+# 쌓인 행은 그대로 남아야 하고, 그 행들을 읽는 것은 필터 없는 전체 조회로 가능하다.
+SignalSourceName = Literal["news", "disclosure"]
+
+
 @app.get(
     "/api/v1/db/filtered-signals/histogram",
     response_model=CommonResponse,
     tags=["Database"],
 )
 async def get_filtered_signal_histogram(
-    source: str | None = Query(
-        None, min_length=1, description="신호 출처 정확 일치 필터 (news | disclosure). 생략 시 전체."
+    source: SignalSourceName | None = Query(
+        None, description="신호 출처 필터 (news | disclosure). 생략 시 전체."
     ),
     stock_name: str | None = Query(
         None, min_length=1, description="종목명 정확 일치 필터. 생략 시 전체 종목."

--- a/backend/models.py
+++ b/backend/models.py
@@ -131,3 +131,58 @@ class CatalystEvent(SQLModel, table=True):
         default_factory=lambda: datetime.now(timezone.utc),
         description="생성 일시",
     )
+
+
+class FilteredSignal(SQLModel, table=True):
+    """임계값 미만이라 상세 분석까지 가지 않은 신호의 채점 결과 (#304).
+
+    AgentReport에는 |score| >= SIGNAL_SCORE_THRESHOLD인 신호만 남는다 — 미만이면
+    스케줄러가 상세 분석 자체를 건너뛰므로 리포트 행이 생기지 않는다. 임계값을
+    조정하려면 "지금 값에서 걸러지고 있는 쪽"의 분포가 필요한데, 그 데이터는
+    scheduler의 "유의미한 변화 없음(score=...)" 로그에만 있어 grep은 되지만 집계가
+    안 됐다. 이 테이블이 그 분포를 구조화해 남긴다.
+
+    AgentReport에 "분석 미실행" 행을 섞지 않고 별도 테이블로 둔 이유: 저쪽은
+    "행이 있다 = 상세 분석을 돌렸다"가 불변식이다. 분석 없는 행을 섞으면 그 테이블을
+    읽는 모든 경로(/api/v1/db/reports, 프론트, 텔레그램 트렌드 집계)가 그것을 걸러
+    내도록 바뀌어야 하고, 한 곳만 빠뜨려도 summary·decision이 빈 행이 리포트로
+    노출된다. 스키마도 갈라진다 — 저쪽의 provider/summary/reason은 여기서 채울 값이
+    없어 전부 빈 문자열이 된다.
+
+    signal 본문 원문은 남기지 않는다 (#304의 명시적 결정). 보존 비용과 개인정보 범위가
+    커지는 데 비해, 이 테이블의 목적인 점수 분포 집계에는 필요하지 않다. 본문이 필요한
+    작업(프롬프트 조정)은 평가셋(backend/scripts/build_signal_eval_set.py)의 몫이다.
+    """
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    # 감시 루프는 종목 코드를 모른 채 종목명으로 돈다. 코드를 채우려면 종목당 조회가
+    # 한 번씩 더 붙는데, 걸러진 신호는 알림도 리포트도 만들지 않는 값이라 그 비용을
+    # 낼 이유가 없다.
+    stock_name: str = Field(index=True, description="감시 대상 종목명")
+    source: str = Field(index=True, description="신호 출처 (news | disclosure)")
+    # AgentReport.signal_score와 달리 NOT NULL이다. 저쪽의 null은 "채점하지 못했다"
+    # (fail-open)인데, fail-open한 신호는 유의미로 통과해 상세 분석까지 가므로 애초에
+    # 이 테이블에 오지 않는다. 즉 여기 남는 행은 전부 "모델이 실제로 매긴 점수"이며,
+    # 그래서 집계에 null 분기가 필요 없다.
+    score: int = Field(index=True, description="신호 영향도 점수 (-3~+3 정수)")
+    # 기록 시점에 적용된 임계값. 이 값을 남기지 않으면 나중에 임계값을 바꾼 뒤
+    # 과거 행이 "왜 걸러졌는지"를 설명할 수 없다 — 같은 1점이 임계값 2에서는 걸러진
+    # 신호이고 1에서는 통과한 신호다.
+    threshold: int = Field(description="기록 시점의 SIGNAL_SCORE_THRESHOLD")
+    reason: Optional[str] = Field(
+        default=None, description="점수 근거 한 줄. 모델이 근거를 주지 않았으면 null."
+    )
+    uncertainty: Optional[float] = Field(
+        default=None,
+        description=(
+            "기사별 점수의 표준편차. 기사가 2건 미만이면 흩어짐을 정의할 수 없으므로 null "
+            "(0.0이 아니다 — 0.0은 '기사들이 완전히 일치했다'는 뜻)."
+        ),
+    )
+    # 보존 기간 정리(FILTERED_SIGNAL_RETENTION_DAYS)와 구간 집계가 모두 이 컬럼을
+    # 기준으로 도므로 인덱스를 건다. UTC로 저장한다.
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        index=True,
+        description="기록 일시 (UTC)",
+    )

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -7,16 +7,19 @@ from typing import Any, Callable
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from sqlmodel import Session, select
 from .catalyst_repo import CatalystEventInput, SqliteCatalystEventRepo
+from .filtered_signal_repo import SqliteFilteredSignalRepo
 from .ws_manager import manager
 from .database import engine
 from .config import (
     NEWS_MCP_PARAMS,
     TRADING_MCP_PARAMS,
     DART_MCP_PARAMS,
+    FILTERED_SIGNAL_RETENTION_DAYS,
     SIGNAL_SCORE_THRESHOLD,
 )
 from .redis_state import RedisSchedulerState, signal_hash, redis_state
 from .services import (
+    SignalScore,
     perform_stock_analysis,
     run_mcp_tool,
     score_signal,
@@ -99,6 +102,11 @@ def _default_watchlist_repo() -> SqliteWatchlistRepo:
 
 def _default_catalyst_repo() -> SqliteCatalystEventRepo:
     return SqliteCatalystEventRepo(lambda: Session(engine))
+
+
+def _default_filtered_signal_repo() -> SqliteFilteredSignalRepo:
+    return SqliteFilteredSignalRepo(lambda: Session(engine))
+
 
 # "- 종목명 (코드) ..." 형식의 잔고 종목 줄을 검증하는 정규식.
 # 줄에 "(코드)" 그룹이 없는 경우(예: "- 삼성전자 · 3주")를 계약 위반으로 거부한다.
@@ -570,7 +578,10 @@ async def catalyst_calendar_task(
         level=level or DEFAULT_TELEGRAM_USER_LEVEL,
     )
 
-async def monitor_market_task(watchlist_repo: SqliteWatchlistRepo | None = None):
+async def monitor_market_task(
+    watchlist_repo: SqliteWatchlistRepo | None = None,
+    filtered_signal_repo: SqliteFilteredSignalRepo | None = None,
+):
     """
     주기적으로 시장 상황을 모니터링합니다.
     """
@@ -584,7 +595,7 @@ async def monitor_market_task(watchlist_repo: SqliteWatchlistRepo | None = None)
 
             fallback_to_memory = False
             try:
-                await _monitor_market_task(state, watchlist_repo)
+                await _monitor_market_task(state, watchlist_repo, filtered_signal_repo)
             finally:
                 try:
                     await state.release_lock(state.keys.scheduler_lock("market_monitoring"), scheduler_token)
@@ -599,12 +610,13 @@ async def monitor_market_task(watchlist_repo: SqliteWatchlistRepo | None = None)
             "Redis 스케줄러 상태를 사용할 수 없어 인메모리 fallback으로 시장 모니터링을 실행합니다: %s",
             e,
         )
-        await _monitor_market_task(None, watchlist_repo)
+        await _monitor_market_task(None, watchlist_repo, filtered_signal_repo)
 
 
 async def _monitor_market_task(
     state: RedisSchedulerState | None,
     watchlist_repo: SqliteWatchlistRepo | None = None,
+    filtered_signal_repo: SqliteFilteredSignalRepo | None = None,
 ):
     global _balance_failure_streak, _last_balance_error
 
@@ -739,7 +751,9 @@ async def _monitor_market_task(
         with Session(engine) as session:
             for stock in stocks_to_monitor:
                 for source in SIGNAL_SOURCES:
-                    await _monitor_signal(stock, source, session, state)
+                    await _monitor_signal(
+                        stock, source, session, state, filtered_signal_repo
+                    )
                     
     except Exception as e:
         logger.error(f"모니터링 태스크 시작 중 오류: {e}")
@@ -768,11 +782,47 @@ async def _send_telegram_alert_if_needed(
         logger.error("[%s:%s] Telegram 알림 처리 중 오류: %s", source, stock, e)
 
 
+async def _record_filtered_signal(
+    repo: SqliteFilteredSignalRepo | None,
+    stock: str,
+    source: str,
+    signal_score: SignalScore,
+) -> None:
+    """걸러진 신호의 채점 결과를 남긴다 (#304). 실패해도 감시는 계속한다.
+
+    로그 한 줄로는 grep만 되고 집계가 안 돼서 임계값을 조정할 근거가 없었다. 기록이
+    실패했다고 감시 루프를 멈추지는 않는다 — 이 값은 사후 분석용이고, 여기서 예외를
+    올리면 DB 문제 하나가 다음 종목·소스의 감시까지 통째로 건너뛰게 만든다.
+    """
+    if signal_score.score is None:
+        # 채점 자체가 없었던 경로(빈 본문·직전과 동일). repo.record도 같은 조건에서
+        # 걸러 내지만, 여기서 먼저 끊어 세션을 열지도 않는다.
+        return
+    try:
+        await (repo or _default_filtered_signal_repo()).record(
+            stock_name=stock,
+            source=source,
+            score=signal_score.score,
+            threshold=SIGNAL_SCORE_THRESHOLD,
+            reason=signal_score.reason,
+            uncertainty=signal_score.uncertainty,
+        )
+    except Exception as e:
+        logger.error(
+            "[%s:%s] 걸러진 신호 점수 기록 실패(score=%s): %s",
+            source,
+            stock,
+            signal_score.score,
+            e,
+        )
+
+
 async def _monitor_signal(
     stock: str,
     source: SignalSource,
     session: Session,
     state: RedisSchedulerState | None,
+    filtered_signal_repo: SqliteFilteredSignalRepo | None = None,
 ):
     analysis_token = None
     try:
@@ -829,6 +879,9 @@ async def _monitor_signal(
                 stock,
                 signal_score.score,
                 SIGNAL_SCORE_THRESHOLD,
+            )
+            await _record_filtered_signal(
+                filtered_signal_repo, stock, source.name, signal_score
             )
             return
 
@@ -932,6 +985,36 @@ async def morning_briefing_task(
         logger.error("모닝 브리핑 작업 중 오류: %s", e)
 
 
+async def purge_filtered_signals_task(
+    filtered_signal_repo: SqliteFilteredSignalRepo | None = None,
+) -> None:
+    """보존 기간이 지난 걸러진 신호 기록을 정리한다 (#304).
+
+    감시 루프가 종목·소스마다 10분 주기로 돌아 행이 빠르게 쌓이므로, 보존 정책을
+    두지 않으면 이 테이블이 SQLite 파일을 조용히 불린다. 하루 한 번 잘라 낸다.
+
+    monitor_market_task와 달리 Redis 스케줄러 락을 잡지 않는다. 워커가 둘 다 같은
+    조건으로 지우면 늦게 도착한 쪽이 0건을 지울 뿐이라 락으로 지킬 상태가 없다.
+    """
+    repo = filtered_signal_repo or _default_filtered_signal_repo()
+    try:
+        deleted = await repo.purge_expired(FILTERED_SIGNAL_RETENTION_DAYS)
+    except Exception as e:
+        # 정리 실패는 다음 주기에 다시 시도된다. 재시도하면 같은 조건으로 지우므로
+        # 이번에 못 지운 행도 함께 정리된다.
+        logger.error(
+            "걸러진 신호 기록 정리 실패 (보존 %d일): %s",
+            FILTERED_SIGNAL_RETENTION_DAYS,
+            e,
+        )
+        return
+    logger.info(
+        "걸러진 신호 기록 정리 완료: %d건 삭제 (보존 %d일)",
+        deleted,
+        FILTERED_SIGNAL_RETENTION_DAYS,
+    )
+
+
 def start_scheduler():
     """스케줄러를 시작하고 작업을 등록합니다."""
     if not scheduler.running:
@@ -961,6 +1044,15 @@ def start_scheduler():
             hour=8,
             minute=30,
             id="morning_briefing",
+        )
+        # 걸러진 신호 기록 정리 (#304). 장 시작 전 한산한 시각에 돌려 감시 주기와
+        # DB 접근이 겹치지 않게 한다.
+        scheduler.add_job(
+            purge_filtered_signals_task,
+            "cron",
+            hour=4,
+            minute=10,
+            id="purge_filtered_signals",
         )
         
         scheduler.start()

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -95,6 +95,17 @@ CATALYST_EVENT_LABELS = {
 _balance_failure_streak = 0
 _last_balance_error: str | None = None
 
+# 걸러진 신호 기록(#304)의 연속 실패 횟수. 위 잔고 카운터와 같은 문제를 같은 방식으로
+# 막는다 — 다만 이쪽이 더 시끄럽다. 잔고는 한 주기에 한 번 실패하지만 기록은
+# (종목 × 소스)마다 시도하므로, 억제가 없으면 DB 장애 한 번에 한 주기당 수십 건의
+# 동일한 error가 쌓인다. 주기(6회)로 세면 여전히 주기마다 여러 번 남으므로 20회로
+# 잡는다 — 종목 10개·소스 2개 기준으로 대략 한 주기에 한 번꼴이다.
+# 카운터는 프로세스마다 별개이고 정확도가 로그 억제에만 쓰이므로 동기화가 필요 없다.
+_filtered_signal_failure_streak = 0
+_last_filtered_signal_error: str | None = None
+# 첫 실패·원인 변경 이후로는 이 횟수마다 한 번만 error로 올린다.
+_FILTERED_SIGNAL_ERROR_LOG_PERIOD = 20
+
 
 def _default_watchlist_repo() -> SqliteWatchlistRepo:
     return SqliteWatchlistRepo(lambda: Session(engine))
@@ -794,6 +805,8 @@ async def _record_filtered_signal(
     실패했다고 감시 루프를 멈추지는 않는다 — 이 값은 사후 분석용이고, 여기서 예외를
     올리면 DB 문제 하나가 다음 종목·소스의 감시까지 통째로 건너뛰게 만든다.
     """
+    global _filtered_signal_failure_streak, _last_filtered_signal_error
+
     if signal_score.score is None:
         # 채점 자체가 없었던 경로(빈 본문·직전과 동일). repo.record도 같은 조건에서
         # 걸러 내지만, 여기서 먼저 끊어 세션을 열지도 않는다.
@@ -808,13 +821,43 @@ async def _record_filtered_signal(
             uncertainty=signal_score.uncertainty,
         )
     except Exception as e:
-        logger.error(
-            "[%s:%s] 걸러진 신호 점수 기록 실패(score=%s): %s",
-            source,
-            stock,
-            signal_score.score,
-            e,
+        signature = f"{type(e).__name__}:{e}"
+        _filtered_signal_failure_streak += 1
+        if (
+            _filtered_signal_failure_streak == 1
+            or signature != _last_filtered_signal_error
+            or _filtered_signal_failure_streak % _FILTERED_SIGNAL_ERROR_LOG_PERIOD == 0
+        ):
+            logger.error(
+                "[%s:%s] 걸러진 신호 점수 기록 실패(score=%s, %d건 연속): %s",
+                source,
+                stock,
+                signal_score.score,
+                _filtered_signal_failure_streak,
+                e,
+            )
+        else:
+            # 같은 원인의 반복 실패는 debug로 내린다. 기록이 비는 구간 자체는 위의
+            # error와 아래 복구 로그의 집계로 드러난다.
+            logger.debug(
+                "[%s:%s] 걸러진 신호 점수 기록 실패가 %d건 연속됩니다: %s",
+                source,
+                stock,
+                _filtered_signal_failure_streak,
+                e,
+            )
+        _last_filtered_signal_error = signature
+        return
+
+    if _filtered_signal_failure_streak:
+        # 복구 보고. 놓친 건수를 남기지 않으면 분포에 구멍이 뚫린 구간을 나중에
+        # 알아볼 방법이 없다 — 기록되지 않은 신호는 어디에도 흔적이 없기 때문이다.
+        logger.warning(
+            "걸러진 신호 점수 기록이 복구되었습니다. 직전까지 %d건을 기록하지 못했습니다.",
+            _filtered_signal_failure_streak,
         )
+        _filtered_signal_failure_streak = 0
+        _last_filtered_signal_error = None
 
 
 async def _monitor_signal(

--- a/backend/schema_docs.md
+++ b/backend/schema_docs.md
@@ -45,6 +45,16 @@ erDiagram
         string content "일지 내용"
         datetime created_at "작성 일시"
     }
+    FilteredSignal {
+        int id PK
+        string stock_name "감시 대상 종목명"
+        string source "신호 출처 (news | disclosure)"
+        int score "신호 영향도 -3~+3 (NOT NULL, #304)"
+        int threshold "기록 시점의 SIGNAL_SCORE_THRESHOLD"
+        string reason "점수 근거 한 줄 (모델이 안 주면 null)"
+        float uncertainty "기사별 점수의 표준편차 (기사 2건 미만이면 null)"
+        datetime created_at "기록 일시 (UTC)"
+    }
 ```
 
 ## 테이블 설명
@@ -53,3 +63,8 @@ erDiagram
 - **TradeHistory**: 사용자의 매매 이력을 기록합니다.
 - **AgentReport**: AI 에이전트가 생성한 종목 분석 결과 및 투자 의견을 저장합니다.
 - **Diary**: 사용자의 개인적인 투자 생각이나 일지를 기록합니다.
+- **FilteredSignal**: 2차 필터가 채점했지만 임계값(`SIGNAL_SCORE_THRESHOLD`)에 못 미쳐 상세 분석까지 가지 않은 신호를 남깁니다(#304). AgentReport에는 임계값 이상만 남으므로, 임계값을 조정하려면 걸러낸 쪽의 분포가 필요합니다.
+  - signal 본문 원문은 저장하지 않습니다 — 보존 비용과 개인정보 범위가 커지는 데 비해 점수 분포 집계에는 필요하지 않습니다.
+  - `score`는 NOT NULL입니다. 채점에 실패한 신호는 fail-open으로 통과해 상세 분석까지 가므로 이 테이블에 오지 않고, 본문이 비었거나 직전과 같아 채점을 건너뛴 신호는 기록하지 않습니다.
+  - `FILTERED_SIGNAL_RETENTION_DAYS`(기본 30일)가 지난 행은 매일 04:10(KST) `purge_filtered_signals` 잡이 지웁니다.
+  - 점수 구간별 건수는 `GET /api/v1/db/filtered-signals/histogram`으로 조회합니다(`source`·`stock_name`·`days` 필터).

--- a/backend/tests/test_filtered_signal.py
+++ b/backend/tests/test_filtered_signal.py
@@ -1,5 +1,7 @@
 """걸러진 신호 채점 기록의 저장·정리·집계 (#304)."""
+import logging
 from datetime import datetime, timedelta, timezone
+from typing import get_args
 
 import pytest
 from fastapi.testclient import TestClient
@@ -70,7 +72,7 @@ async def test_record_persists_score_and_threshold(repo, session: Session):
     임계값을 남기지 않으면 나중에 설정을 바꾼 뒤 과거 행이 왜 걸러졌는지 설명할 수
     없다 — 같은 1점이 임계값 2에서는 걸러진 신호이고 1에서는 통과한 신호다.
     """
-    saved = await repo.record(
+    await repo.record(
         stock_name="SK하이닉스",
         source="disclosure",
         score=-1,
@@ -79,7 +81,6 @@ async def test_record_persists_score_and_threshold(repo, session: Session):
         uncertainty=0.5,
     )
 
-    assert saved is not None
     rows = session.exec(select(FilteredSignal)).all()
     assert len(rows) == 1
     assert rows[0].stock_name == "SK하이닉스"
@@ -97,11 +98,8 @@ async def test_record_skips_unscored_signal(repo, session: Session):
     점수가 없는 행은 분포에 보탤 정보가 0인데, 감시 루프가 종목·소스마다 10분 주기로
     도는 탓에 그런 행만으로 테이블이 가득 찬다.
     """
-    saved = await repo.record(
-        stock_name="삼성전자", source="news", score=None, threshold=2
-    )
+    await repo.record(stock_name="삼성전자", source="news", score=None, threshold=2)
 
-    assert saved is None
     assert session.exec(select(FilteredSignal)).all() == []
 
 
@@ -260,3 +258,36 @@ def test_histogram_endpoint_rejects_out_of_range_days(client: TestClient):
         ).status_code
         == 422
     )
+
+
+def test_fill_score_axis_warns_when_dropping_out_of_axis_buckets(caplog):
+    """축 밖 점수를 버리면 total과 buckets의 합이 어긋난다 — 조용히 버리지 않는다.
+
+    지금은 채점이 -3~+3으로 clamp되어 도달할 수 없지만, 그 clamp가 사라지면
+    무증상으로 깨지는 자리다.
+    """
+    with caplog.at_level(logging.WARNING, logger="backend.filtered_signal_repo"):
+        filled = fill_score_axis(
+            (ScoreBucket(score=1, count=3), ScoreBucket(score=7, count=2)), -3, 3
+        )
+
+    assert [bucket.count for bucket in filled] == [0, 0, 0, 0, 3, 0, 0]
+    assert len(caplog.records) == 1
+    assert "7" in caplog.records[0].getMessage()
+
+
+def test_source_filter_matches_signal_sources():
+    """조회 필터가 받는 값이 실제 감시 출처와 어긋나면 조회가 조용히 빈다."""
+    from ..main import SignalSourceName
+    from ..scheduler import SIGNAL_SOURCES
+
+    assert set(get_args(SignalSourceName)) == {source.name for source in SIGNAL_SOURCES}
+
+
+def test_histogram_endpoint_rejects_unknown_source(client: TestClient):
+    """오타 난 출처는 "걸러진 게 없다"(total 0)가 아니라 422로 돌아와야 한다."""
+    response = client.get(
+        "/api/v1/db/filtered-signals/histogram", params={"source": "newz"}
+    )
+
+    assert response.status_code == 422

--- a/backend/tests/test_filtered_signal.py
+++ b/backend/tests/test_filtered_signal.py
@@ -1,0 +1,262 @@
+"""걸러진 신호 채점 기록의 저장·정리·집계 (#304)."""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session, SQLModel, create_engine, select
+from sqlmodel.pool import StaticPool
+
+from ..filtered_signal_repo import (
+    ScoreBucket,
+    SqliteFilteredSignalRepo,
+    fill_score_axis,
+    score_histogram,
+)
+from ..config import SIGNAL_SCORE_THRESHOLD
+from ..main import app, get_session
+from ..models import FilteredSignal
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    engine = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+
+
+@pytest.fixture(name="repo")
+def repo_fixture(session: Session):
+    """테스트 세션을 그대로 쓰는 repo.
+
+    repo는 세션 팩토리를 with로 열고 닫는다. 인메모리 DB에서 그 세션이 닫히면
+    테스트가 결과를 확인할 방법이 사라지므로, 닫히지 않는 래퍼를 돌려준다.
+    """
+
+    class _KeepOpenSession:
+        def __enter__(inner):
+            return session
+
+        def __exit__(inner, *exc):
+            return False
+
+    return SqliteFilteredSignalRepo(lambda: _KeepOpenSession())
+
+
+@pytest.fixture(name="client")
+def client_fixture(session: Session):
+    app.dependency_overrides[get_session] = lambda: session
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.clear()
+
+
+def _add(session: Session, **kwargs) -> FilteredSignal:
+    defaults = dict(stock_name="삼성전자", source="news", score=1, threshold=2)
+    defaults.update(kwargs)
+    row = FilteredSignal(**defaults)
+    session.add(row)
+    session.commit()
+    session.refresh(row)
+    return row
+
+
+@pytest.mark.asyncio
+async def test_record_persists_score_and_threshold(repo, session: Session):
+    """점수·근거·흩어짐과 함께 그 시점의 임계값이 남아야 한다.
+
+    임계값을 남기지 않으면 나중에 설정을 바꾼 뒤 과거 행이 왜 걸러졌는지 설명할 수
+    없다 — 같은 1점이 임계값 2에서는 걸러진 신호이고 1에서는 통과한 신호다.
+    """
+    saved = await repo.record(
+        stock_name="SK하이닉스",
+        source="disclosure",
+        score=-1,
+        threshold=2,
+        reason="단순 정정 공시",
+        uncertainty=0.5,
+    )
+
+    assert saved is not None
+    rows = session.exec(select(FilteredSignal)).all()
+    assert len(rows) == 1
+    assert rows[0].stock_name == "SK하이닉스"
+    assert rows[0].source == "disclosure"
+    assert rows[0].score == -1
+    assert rows[0].threshold == 2
+    assert rows[0].reason == "단순 정정 공시"
+    assert rows[0].uncertainty == 0.5
+
+
+@pytest.mark.asyncio
+async def test_record_skips_unscored_signal(repo, session: Session):
+    """채점이 없었던 신호(빈 본문·직전과 동일)는 행을 만들지 않는다.
+
+    점수가 없는 행은 분포에 보탤 정보가 0인데, 감시 루프가 종목·소스마다 10분 주기로
+    도는 탓에 그런 행만으로 테이블이 가득 찬다.
+    """
+    saved = await repo.record(
+        stock_name="삼성전자", source="news", score=None, threshold=2
+    )
+
+    assert saved is None
+    assert session.exec(select(FilteredSignal)).all() == []
+
+
+@pytest.mark.asyncio
+async def test_purge_expired_removes_only_old_rows(repo, session: Session):
+    now = datetime(2026, 8, 28, 12, 0, tzinfo=timezone.utc)
+    # id는 삭제 전에 읽어 둔다. 커밋으로 만료된 속성을 삭제 후에 읽으면 SQLAlchemy가
+    # 사라진 행을 다시 읽으려다 ObjectDeletedError로 죽는다.
+    fresh_id = _add(session, created_at=now - timedelta(days=29, hours=23)).id
+    stale_id = _add(session, created_at=now - timedelta(days=31)).id
+
+    deleted = await repo.purge_expired(30, now=now)
+
+    assert deleted == 1
+    remaining = {row.id for row in session.exec(select(FilteredSignal)).all()}
+    assert remaining == {fresh_id}
+    assert stale_id not in remaining
+
+
+@pytest.mark.asyncio
+async def test_purge_expired_is_idempotent(repo, session: Session):
+    """두 번째 정리는 0건이어야 한다 — 워커가 둘이어도 서로를 망가뜨리지 않는다."""
+    now = datetime(2026, 8, 28, 12, 0, tzinfo=timezone.utc)
+    _add(session, created_at=now - timedelta(days=40))
+
+    assert await repo.purge_expired(30, now=now) == 1
+    assert await repo.purge_expired(30, now=now) == 0
+
+
+def test_score_histogram_counts_by_score(session: Session):
+    _add(session, score=1)
+    _add(session, score=1)
+    _add(session, score=0)
+    _add(session, score=-1)
+
+    histogram = score_histogram(session)
+
+    assert histogram.total == 4
+    assert histogram.buckets == (
+        ScoreBucket(score=-1, count=1),
+        ScoreBucket(score=0, count=1),
+        ScoreBucket(score=1, count=2),
+    )
+    assert histogram.thresholds == (2,)
+
+
+def test_score_histogram_filters_by_source_and_stock(session: Session):
+    _add(session, source="news", stock_name="삼성전자", score=1)
+    _add(session, source="disclosure", stock_name="삼성전자", score=1)
+    _add(session, source="news", stock_name="NAVER", score=0)
+
+    by_source = score_histogram(session, source="news")
+    assert by_source.total == 2
+
+    by_stock = score_histogram(session, source="news", stock_name="NAVER")
+    assert by_stock.total == 1
+    assert by_stock.buckets == (ScoreBucket(score=0, count=1),)
+
+
+def test_score_histogram_filters_by_since(session: Session):
+    now = datetime(2026, 8, 28, 12, 0, tzinfo=timezone.utc)
+    _add(session, score=1, created_at=now - timedelta(days=10))
+    _add(session, score=0, created_at=now - timedelta(days=1))
+
+    recent = score_histogram(session, since=now - timedelta(days=7))
+
+    assert recent.total == 1
+    assert recent.buckets == (ScoreBucket(score=0, count=1),)
+
+
+def test_score_histogram_reports_mixed_thresholds(session: Session):
+    """구간에 임계값이 둘 이상 섞였다면 그 사실이 드러나야 한다.
+
+    임계값이 바뀐 지점을 걸쳐 집계하면 서로 다른 설정에서 걸러진 신호가 한 분포로
+    보인다. 그걸 모른 채 읽으면 임계값 조정 근거가 오염된다.
+    """
+    _add(session, score=1, threshold=2)
+    _add(session, score=2, threshold=3)
+
+    assert score_histogram(session).thresholds == (2, 3)
+
+
+def test_score_histogram_on_empty_table(session: Session):
+    histogram = score_histogram(session)
+
+    assert histogram.total == 0
+    assert histogram.buckets == ()
+    assert histogram.thresholds == ()
+    assert histogram.oldest is None
+    assert histogram.newest is None
+
+
+def test_fill_score_axis_fills_unseen_scores_with_zero():
+    filled = fill_score_axis((ScoreBucket(score=1, count=3),), -3, 3)
+
+    assert [bucket.score for bucket in filled] == [-3, -2, -1, 0, 1, 2, 3]
+    assert [bucket.count for bucket in filled] == [0, 0, 0, 0, 3, 0, 0]
+
+
+def test_histogram_endpoint_returns_full_axis(client: TestClient, session: Session):
+    _add(session, score=1)
+    _add(session, score=1)
+    _add(session, score=-1)
+
+    response = client.get("/api/v1/db/filtered-signals/histogram")
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["total"] == 3
+    # 응답의 threshold는 지금 적용 중인 설정값이다 (기록 시점의 값은 recorded_thresholds).
+    assert data["threshold"] == SIGNAL_SCORE_THRESHOLD
+    assert data["recorded_thresholds"] == [2]
+    assert data["window_days"] is None
+    assert data["since"] is None
+    assert [bucket["score"] for bucket in data["buckets"]] == [-3, -2, -1, 0, 1, 2, 3]
+    assert [bucket["count"] for bucket in data["buckets"]] == [0, 0, 1, 0, 2, 0, 0]
+
+
+def test_histogram_endpoint_filters(client: TestClient, session: Session):
+    _add(session, source="news", stock_name="삼성전자", score=1)
+    _add(session, source="disclosure", stock_name="삼성전자", score=0)
+
+    response = client.get(
+        "/api/v1/db/filtered-signals/histogram",
+        params={"source": "news", "stock_name": "삼성전자"},
+    )
+
+    data = response.json()["data"]
+    assert data["total"] == 1
+    assert [bucket["count"] for bucket in data["buckets"]] == [0, 0, 0, 0, 1, 0, 0]
+
+
+def test_histogram_endpoint_days_window(client: TestClient, session: Session):
+    now = datetime.now(timezone.utc)
+    _add(session, score=1, created_at=now - timedelta(days=45))
+    _add(session, score=0, created_at=now - timedelta(hours=1))
+
+    response = client.get("/api/v1/db/filtered-signals/histogram", params={"days": 7})
+
+    data = response.json()["data"]
+    assert data["total"] == 1
+    assert data["window_days"] == 7
+    assert data["since"] is not None
+
+
+def test_histogram_endpoint_rejects_out_of_range_days(client: TestClient):
+    assert (
+        client.get(
+            "/api/v1/db/filtered-signals/histogram", params={"days": 0}
+        ).status_code
+        == 422
+    )
+    assert (
+        client.get(
+            "/api/v1/db/filtered-signals/histogram", params={"days": 366}
+        ).status_code
+        == 422
+    )

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -2300,10 +2300,11 @@ class FakeFilteredSignalRepo:
         self._fail = fail
 
     async def record(self, **kwargs):
+        # 진짜 repo와 같이 아무것도 돌려주지 않는다 — 반환값에 기대는 호출부가
+        # 생기면 fake만 통과하고 프로덕션에서 None이 되는 차이가 난다.
         if self._fail:
             raise RuntimeError("filtered signal db unavailable")
         self.recorded.append(kwargs)
-        return kwargs
 
     async def purge_expired(self, retention_days, *, now=None):
         if self._fail:
@@ -2557,3 +2558,130 @@ def test_start_scheduler_registers_purge_job(monkeypatch):
     scheduler_module.start_scheduler()
 
     assert "purge_filtered_signals" in registered
+
+
+@pytest.mark.asyncio
+async def test_monitor_signal_records_through_real_repo(monkeypatch):
+    """덕타이핑 fake가 아니라 실제 repo에 넣어 행이 실제로 생기는지 본다 (#304 리뷰).
+
+    _record_filtered_signal은 기록 실패를 삼키고 로그만 남긴다. 그래서 호출 계약이
+    어긋나면(키워드 이름 하나만 달라져도 TypeError다) fake만 쓰는 테스트는 초록인 채
+    프로덕션만 조용히 무기록이 된다. 이 테스트만 그 간극을 덮는다.
+    """
+    from sqlmodel import SQLModel, Session, create_engine, select
+    from sqlmodel.pool import StaticPool
+
+    from ..config import SIGNAL_SCORE_THRESHOLD
+    from ..filtered_signal_repo import SqliteFilteredSignalRepo
+    from ..models import FilteredSignal
+    from ..scheduler import SignalSource, monitor_market_task
+
+    engine = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    SQLModel.metadata.create_all(engine)
+    repo = SqliteFilteredSignalRepo(lambda: Session(engine))
+
+    state = RedisSchedulerState(FakeRedis())
+
+    @asynccontextmanager
+    async def fake_redis_state():
+        yield state
+
+    async def mock_run_mcp_tool(params, name, args):
+        if name == "get_balance":
+            return "[보유 종목 리스트]\n- 삼성전자 (005930): 10주"
+        return "삼성전자 관련 뉴스"
+
+    async def mock_score_signal(stock, current, last, *, source, provider):
+        return _filtered_scored(1, reason="단순 시황 나열", uncertainty=0.5)
+
+    monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
+    monkeypatch.setattr(
+        "backend.scheduler.SIGNAL_SOURCES",
+        [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
+    )
+    monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast_mock())
+    monkeypatch.setattr(
+        "backend.scheduler._sync_portfolio_from_balance",
+        lambda balance_text, session, **kwargs: None,
+    )
+
+    await monitor_market_task(
+        watchlist_repo=FakeWatchlistRepo(), filtered_signal_repo=repo
+    )
+
+    with Session(engine) as session:
+        rows = session.exec(select(FilteredSignal)).all()
+    assert len(rows) == 1
+    assert rows[0].stock_name == "삼성전자"
+    assert rows[0].source == "news"
+    assert rows[0].score == 1
+    assert rows[0].threshold == SIGNAL_SCORE_THRESHOLD
+    assert rows[0].reason == "단순 시황 나열"
+    assert rows[0].uncertainty == 0.5
+
+
+@pytest.mark.asyncio
+async def test_repeated_recording_failures_are_logged_once_per_period(monkeypatch, caplog):
+    """같은 원인의 기록 실패는 첫 건과 주기마다만 error로 남는다 (#304 리뷰).
+
+    기록은 (종목 × 소스)마다 시도하므로, 억제가 없으면 DB 장애 하나가 한 주기에
+    수십 건의 동일한 error를 쌓아 정작 중요한 장애를 묻는다 — 잔고 조회 실패(#185)가
+    이미 같은 이유로 카운터를 두고 있다.
+    """
+    import logging
+
+    from .. import scheduler as scheduler_module
+    from ..scheduler import _record_filtered_signal
+
+    monkeypatch.setattr(scheduler_module, "_filtered_signal_failure_streak", 0)
+    monkeypatch.setattr(scheduler_module, "_last_filtered_signal_error", None)
+
+    repo = FakeFilteredSignalRepo(fail=True)
+    scored = _filtered_scored(1, reason="중립")
+
+    with caplog.at_level(logging.DEBUG, logger="backend.scheduler"):
+        for _ in range(scheduler_module._FILTERED_SIGNAL_ERROR_LOG_PERIOD):
+            await _record_filtered_signal(repo, "삼성전자", "news", scored)
+
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    # 첫 실패 1건 + 주기(20회)째 1건.
+    assert len(errors) == 2
+    assert scheduler_module._filtered_signal_failure_streak == (
+        scheduler_module._FILTERED_SIGNAL_ERROR_LOG_PERIOD
+    )
+
+
+@pytest.mark.asyncio
+async def test_recording_recovery_reports_missed_count(monkeypatch, caplog):
+    """복구되면 그동안 몇 건을 놓쳤는지 남긴다.
+
+    기록되지 않은 신호는 어디에도 흔적이 없다. 놓친 건수를 남기지 않으면 나중에
+    분포에 구멍이 뚫린 구간을 알아볼 방법이 없다.
+    """
+    import logging
+
+    from .. import scheduler as scheduler_module
+    from ..scheduler import _record_filtered_signal
+
+    monkeypatch.setattr(scheduler_module, "_filtered_signal_failure_streak", 0)
+    monkeypatch.setattr(scheduler_module, "_last_filtered_signal_error", None)
+
+    scored = _filtered_scored(1, reason="중립")
+    for _ in range(3):
+        await _record_filtered_signal(
+            FakeFilteredSignalRepo(fail=True), "삼성전자", "news", scored
+        )
+
+    with caplog.at_level(logging.WARNING, logger="backend.scheduler"):
+        await _record_filtered_signal(
+            FakeFilteredSignalRepo(), "삼성전자", "news", scored
+        )
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "3건" in warnings[0].getMessage()
+    assert scheduler_module._filtered_signal_failure_streak == 0

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -2289,3 +2289,271 @@ async def test_monitor_signal_passes_none_when_scoring_fails_open(monkeypatch):
     assert passed is not None
     assert passed.is_significant is True
     assert passed.score is None
+
+
+class FakeFilteredSignalRepo:
+    """걸러진 신호 기록을 메모리에 모으는 repo (#304)."""
+
+    def __init__(self, fail: bool = False):
+        self.recorded = []
+        self.purged = []
+        self._fail = fail
+
+    async def record(self, **kwargs):
+        if self._fail:
+            raise RuntimeError("filtered signal db unavailable")
+        self.recorded.append(kwargs)
+        return kwargs
+
+    async def purge_expired(self, retention_days, *, now=None):
+        if self._fail:
+            raise RuntimeError("filtered signal db unavailable")
+        self.purged.append(retention_days)
+        return 7
+
+
+def _filtered_scored(score: int, reason: str | None = None, uncertainty=None) -> SignalScore:
+    """임계값 미만으로 걸러진 채점 결과."""
+    return SignalScore(
+        score=score,
+        reason=reason,
+        uncertainty=uncertainty,
+        headline_scores=(),
+        is_significant=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_monitor_signal_records_filtered_score(monkeypatch):
+    """임계값 미만으로 걸러진 신호의 점수가 구조화돼 남아야 한다 (#304).
+
+    이 값이 로그에만 남으면 grep은 되지만 집계가 안 돼 임계값을 조정할 근거가 없다.
+    """
+    from ..config import SIGNAL_SCORE_THRESHOLD
+    from ..scheduler import SignalSource, monitor_market_task
+
+    state = RedisSchedulerState(FakeRedis())
+
+    @asynccontextmanager
+    async def fake_redis_state():
+        yield state
+
+    async def mock_run_mcp_tool(params, name, args):
+        if name == "get_balance":
+            return "[보유 종목 리스트]\n- 삼성전자 (005930): 10주"
+        return "삼성전자 관련 뉴스"
+
+    async def mock_score_signal(stock, current, last, *, source, provider):
+        return _filtered_scored(1, reason="단순 시황 나열", uncertainty=0.5)
+
+    mock_perform_analysis = MagicMock()
+    monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
+    monkeypatch.setattr(
+        "backend.scheduler.SIGNAL_SOURCES",
+        [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
+    )
+    monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
+    monkeypatch.setattr("backend.scheduler.perform_stock_analysis", mock_perform_analysis)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast_mock())
+    monkeypatch.setattr(
+        "backend.scheduler._sync_portfolio_from_balance",
+        lambda balance_text, session, **kwargs: None,
+    )
+
+    repo = FakeFilteredSignalRepo()
+    await monitor_market_task(
+        watchlist_repo=FakeWatchlistRepo(), filtered_signal_repo=repo
+    )
+
+    assert mock_perform_analysis.call_count == 0
+    assert repo.recorded == [
+        {
+            "stock_name": "삼성전자",
+            "source": "news",
+            "score": 1,
+            "threshold": SIGNAL_SCORE_THRESHOLD,
+            "reason": "단순 시황 나열",
+            "uncertainty": 0.5,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_monitor_signal_does_not_record_passing_score(monkeypatch):
+    """통과한 신호는 이 테이블이 아니라 AgentReport에 남는다 — 두 번 세면 안 된다."""
+    from ..scheduler import SignalSource, monitor_market_task
+
+    state = RedisSchedulerState(FakeRedis())
+
+    @asynccontextmanager
+    async def fake_redis_state():
+        yield state
+
+    async def mock_run_mcp_tool(params, name, args):
+        if name == "get_balance":
+            return "[보유 종목 리스트]\n- 삼성전자 (005930): 10주"
+        return "삼성전자 대형 수주"
+
+    async def mock_score_signal(stock, current, last, *, source, provider):
+        return _scored(True, score=3)
+
+    mock_perform_analysis = MagicMock(return_value=asyncio.Future())
+    mock_perform_analysis.return_value.set_result({"summary": "Mocked"})
+
+    monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
+    monkeypatch.setattr(
+        "backend.scheduler.SIGNAL_SOURCES",
+        [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
+    )
+    monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
+    monkeypatch.setattr("backend.scheduler.perform_stock_analysis", mock_perform_analysis)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast_mock())
+    monkeypatch.setattr(
+        "backend.scheduler._sync_portfolio_from_balance",
+        lambda balance_text, session, **kwargs: None,
+    )
+
+    repo = FakeFilteredSignalRepo()
+    await monitor_market_task(
+        watchlist_repo=FakeWatchlistRepo(), filtered_signal_repo=repo
+    )
+
+    assert mock_perform_analysis.call_count == 1
+    assert repo.recorded == []
+
+
+@pytest.mark.asyncio
+async def test_monitor_signal_does_not_record_unscored_signal(monkeypatch):
+    """채점 자체가 없었던 신호(빈 본문·직전과 동일)는 기록하지 않는다.
+
+    점수 없는 행은 분포에 보탤 정보가 없는데, 감시 루프가 10분마다 도는 탓에
+    그런 행만으로 테이블이 가득 찬다.
+    """
+    from ..scheduler import SignalSource, monitor_market_task
+
+    state = RedisSchedulerState(FakeRedis())
+
+    @asynccontextmanager
+    async def fake_redis_state():
+        yield state
+
+    async def mock_run_mcp_tool(params, name, args):
+        if name == "get_balance":
+            return "[보유 종목 리스트]\n- 삼성전자 (005930): 10주"
+        return "삼성전자 관련 뉴스"
+
+    async def mock_score_signal(stock, current, last, *, source, provider):
+        return _scored(False)
+
+    monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
+    monkeypatch.setattr(
+        "backend.scheduler.SIGNAL_SOURCES",
+        [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
+    )
+    monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast_mock())
+    monkeypatch.setattr(
+        "backend.scheduler._sync_portfolio_from_balance",
+        lambda balance_text, session, **kwargs: None,
+    )
+
+    repo = FakeFilteredSignalRepo()
+    await monitor_market_task(
+        watchlist_repo=FakeWatchlistRepo(), filtered_signal_repo=repo
+    )
+
+    assert repo.recorded == []
+
+
+@pytest.mark.asyncio
+async def test_monitor_signal_continues_when_recording_fails(monkeypatch):
+    """기록이 실패해도 감시는 다음 종목까지 계속돼야 한다.
+
+    이 값은 사후 분석용이다. 여기서 예외가 올라오면 DB 문제 하나가 그 주기의 감시를
+    통째로 멈춘다 — 놓침 방지(REQ-04)와 정면으로 충돌한다.
+    """
+    from ..scheduler import SignalSource, monitor_market_task
+
+    state = RedisSchedulerState(FakeRedis())
+
+    @asynccontextmanager
+    async def fake_redis_state():
+        yield state
+
+    monitored_stocks = []
+
+    async def mock_run_mcp_tool(params, name, args):
+        if name == "get_balance":
+            return "[보유 종목 리스트]\n- 삼성전자 (005930): 10주"
+        monitored_stocks.append(args["stock_name"])
+        return f"{args['stock_name']} 관련 뉴스"
+
+    async def mock_score_signal(stock, current, last, *, source, provider):
+        return _filtered_scored(0, reason="중립")
+
+    monkeypatch.setattr("backend.scheduler.redis_state", fake_redis_state)
+    monkeypatch.setattr(
+        "backend.scheduler.SIGNAL_SOURCES",
+        [SignalSource(name="news", mcp_params=object(), tool_name="get_market_news")],
+    )
+    monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
+    monkeypatch.setattr("backend.scheduler.score_signal", mock_score_signal)
+    monkeypatch.setattr("backend.scheduler.manager.broadcast", _resolved_broadcast_mock())
+    monkeypatch.setattr(
+        "backend.scheduler._sync_portfolio_from_balance",
+        lambda balance_text, session, **kwargs: None,
+    )
+
+    await monitor_market_task(
+        watchlist_repo=FakeWatchlistRepo(["NAVER"]),
+        filtered_signal_repo=FakeFilteredSignalRepo(fail=True),
+    )
+
+    assert monitored_stocks == ["삼성전자", "NAVER"]
+
+
+@pytest.mark.asyncio
+async def test_purge_filtered_signals_task_deletes_expired_rows():
+    from ..config import FILTERED_SIGNAL_RETENTION_DAYS
+    from ..scheduler import purge_filtered_signals_task
+
+    repo = FakeFilteredSignalRepo()
+
+    await purge_filtered_signals_task(filtered_signal_repo=repo)
+
+    assert repo.purged == [FILTERED_SIGNAL_RETENTION_DAYS]
+
+
+@pytest.mark.asyncio
+async def test_purge_filtered_signals_task_swallows_failure():
+    """정리 실패가 스케줄러 잡을 죽이지 않는다 — 다음 주기에 같은 조건으로 다시 지운다."""
+    from ..scheduler import purge_filtered_signals_task
+
+    await purge_filtered_signals_task(
+        filtered_signal_repo=FakeFilteredSignalRepo(fail=True)
+    )
+
+
+def test_start_scheduler_registers_purge_job(monkeypatch):
+    """정리 잡이 등록되지 않으면 보존 정책이 조용히 사라진다."""
+    from .. import scheduler as scheduler_module
+
+    registered = []
+
+    class FakeScheduler:
+        running = False
+        timezone = scheduler_module.scheduler.timezone
+
+        def add_job(self, func, trigger, **kwargs):
+            registered.append(kwargs.get("id"))
+
+        def start(self):
+            pass
+
+    monkeypatch.setattr(scheduler_module, "scheduler", FakeScheduler())
+    scheduler_module.start_scheduler()
+
+    assert "purge_filtered_signals" in registered

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -2476,7 +2476,14 @@ async def test_monitor_signal_continues_when_recording_fails(monkeypatch):
     이 값은 사후 분석용이다. 여기서 예외가 올라오면 DB 문제 하나가 그 주기의 감시를
     통째로 멈춘다 — 놓침 방지(REQ-04)와 정면으로 충돌한다.
     """
+    from .. import scheduler as scheduler_module
     from ..scheduler import SignalSource, monitor_market_task
+
+    # 이 테스트는 기록을 실패시키므로 연속 실패 카운터를 올린다. monkeypatch로 깔아 두면
+    # 종료 시 원래 값으로 되돌아가, 뒤에 도는 억제·복구 테스트가 이 테스트의 잔재를
+    # 물려받지 않는다 (실행 순서에 의존하는 상태를 남기지 않는다).
+    monkeypatch.setattr(scheduler_module, "_filtered_signal_failure_streak", 0)
+    monkeypatch.setattr(scheduler_module, "_last_filtered_signal_error", None)
 
     state = RedisSchedulerState(FakeRedis())
 

--- a/backend/tests/test_schema_migrations.py
+++ b/backend/tests/test_schema_migrations.py
@@ -618,3 +618,40 @@ def test_nullable_recreation_preserves_signal_scoring_columns(tmp_path, monkeypa
 
     assert col_info["decision"][3] == 0, "재생성이 수행되지 않았다 (decision이 여전히 NOT NULL)"
     assert row == [(-2, "수주 취소 공시", 1.25)], "재생성이 신호 점수 값을 잃었다"
+
+
+def test_init_db_creates_filtered_signal_table_on_existing_db(tmp_path, monkeypatch):
+    """#304: 이미 쓰고 있던 DB 파일에도 filteredsignal 테이블이 생겨야 한다.
+
+    새 테이블은 create_all()이 만들어 주므로 _PENDING_COLUMN_MIGRATIONS에 넣을
+    필요가 없다 — 하지만 그 전제가 깨지면 기록 경로가 조용히 실패하고(로그만 남고)
+    임계값 조정 근거는 계속 없는 상태가 된다. 전제를 여기서 못박는다.
+    """
+    db_path = tmp_path / "existing.db"
+    _create_old_schema_agentreport(str(db_path))
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("DROP TABLE IF EXISTS filteredsignal")
+    conn.commit()
+    conn.close()
+
+    test_engine = create_engine(
+        f"sqlite:///{db_path}", connect_args={"check_same_thread": False}
+    )
+    monkeypatch.setattr(database, "engine", test_engine)
+
+    database.init_db()
+
+    conn = sqlite3.connect(str(db_path))
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(filteredsignal)")}
+    conn.close()
+    assert columns == {
+        "id",
+        "stock_name",
+        "source",
+        "score",
+        "threshold",
+        "reason",
+        "uncertainty",
+        "created_at",
+    }


### PR DESCRIPTION
## 📝 개요

임계값에 못 미쳐 걸러진 신호의 채점 결과를 전용 테이블에 남기고, 점수 구간별 건수를 조회 한 번으로 셀 수 있게 했다. 보존 기간이 지난 기록은 매일 한 번 정리한다.

범위 밖: 실제 감시 루프를 돌려 기록되는 것까지는 확인하지 않았다(뉴스 MCP와 경량 LLM에 의존). 스케줄러 경로는 테스트에서 몽키패치로 덮었다.

## 🔍 발견된 문제

1. 걸러진 신호의 점수가 로그 한 줄로만 남아 grep은 되지만 집계가 안 됐다. 임계값을 조정하려면 걸러낸 쪽의 분포가 필요한데 그 데이터가 구조화된 형태로 없었다.
2. 걸러진 신호는 상세 분석을 돌리지 않으므로 분석 리포트 행 자체가 생기지 않는다. 기본 임계값에서 0이나 ±1점인 신호는 저장된 어디에도 구조적으로 존재할 수 없었다.
3. 감시 루프가 종목·소스마다 10분 주기로 돌기 때문에, 기록을 남기기 시작하면 행이 빠르게 쌓인다. 보존 정책 없이 남기면 로컬 SQLite 파일이 조용히 커진다.

## 🔧 문제 해결 방법

1. 채점 결과를 전용 테이블에 남긴다. 종목·출처·점수·근거·흩어짐·시각에 더해 기록 시점의 임계값을 함께 남겨, 설정을 바꾼 뒤에도 과거 행이 왜 걸러졌는지 설명된다. signal 본문 원문은 남기지 않고, 채점하지 못했거나 채점을 건너뛴 신호도 남기지 않는다 — 분포에 보탤 정보 없이 행만 늘린다.
2. 분석 리포트 테이블에 "분석 미실행" 행을 섞지 않고 테이블을 나눴다. 저쪽은 "행이 있다 = 분석했다"가 불변식이라, 섞으면 그 테이블을 읽는 모든 경로가 그것을 걸러 내도록 바뀌어야 하고 한 곳만 빠뜨려도 빈 리포트가 노출된다. 조회는 점수 구간별 건수를 돌려주는 엔드포인트 하나로 연다.
3. 보존 기간을 설정값(기본 30일, 1~365)으로 두고 매일 04:10(KST)에 지난 행을 지운다. 기록 실패는 로그만 남기고 감시 루프를 멈추지 않는다 — 사후 분석용 값이라 DB 문제 하나가 그 주기의 감시를 통째로 건너뛰게 둘 수 없다.

## ✅ 검증

- 임계값 조정 근거는 `GET /api/v1/db/filtered-signals/histogram`으로 본다(`source`·`stock_name`·`days` 필터). 응답의 `recorded_thresholds`에 값이 둘 이상이면 집계 구간 중간에 임계값이 바뀐 것이므로 한 분포로 읽으면 안 된다.
- 정리 조건에 tz-aware 시각을 그대로 넘기면 SQLAlchemy가 삭제 조건을 파이썬으로 재평가하는 경로에서 `TypeError: can't compare offset-naive and offset-aware datetimes`로 죽는 것을 재현했다. SQLite DATETIME이 오프셋을 저장하지 않아 읽어 온 값이 naive UTC이기 때문이다. 비교 직전 naive UTC로 맞추고 세션 동기화를 꺼서 해소했고 회귀 테스트로 고정했다.

## 🔗 관련 이슈

- Closes #304
