### PR TITLE
fix: main 빨간불 복구 — #304 코드의 타입 오류 14건 (#292)

### DIFF
--- a/backend/filtered_signal_repo.py
+++ b/backend/filtered_signal_repo.py
@@ -7,10 +7,10 @@
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Callable, Optional, Sequence
+from typing import Any, Callable, Optional, Sequence, cast
 
-from sqlalchemy import delete, func
-from sqlmodel import Session, select
+from sqlalchemy import CursorResult, delete, func
+from sqlmodel import Session, col, select
 
 from .models import FilteredSignal
 
@@ -117,16 +117,18 @@ class SqliteFilteredSignalRepo:
         )
         with self._session_factory() as session:
             result = session.execute(
-                delete(FilteredSignal).where(FilteredSignal.created_at < cutoff),
+                delete(FilteredSignal).where(col(FilteredSignal.created_at) < cutoff),
                 # 세션에 이미 올라온 객체를 파이썬으로 재평가하지 않는다. 이 세션은
                 # 삭제 직후 버려지므로 동기화할 상태가 없고, 기본 전략("evaluate")은
                 # 조건을 파이썬에서 다시 계산하다 타입 차이로 죽을 수 있다.
                 execution_options={"synchronize_session": False},
             )
             session.commit()
+            # DML의 실행 결과는 CursorResult이지만 Session.execute의 선언 반환형은
+            # 그 상위인 Result라 rowcount가 보이지 않는다.
             # rowcount는 방언에 따라 -1("모름")일 수 있다. 로그 문구가 "-1건 삭제"가
             # 되지 않도록 0으로 눕힌다 — 삭제 자체는 이미 커밋됐다.
-            return max(result.rowcount or 0, 0)
+            return max(cast(CursorResult[Any], result).rowcount or 0, 0)
 
 
 def score_histogram(
@@ -141,24 +143,26 @@ def score_histogram(
     ``since``는 UTC 기준으로 넘긴다. created_at을 UTC로 저장하므로(models 참고)
     다른 시간대의 값을 그대로 넘기면 구간이 어긋난다.
     """
+    # 조건도 정렬도 col()로 컬럼을 명시한다. 모델 필드를 그대로 쓰면 체커에는
+    # 파이썬 값의 비교(bool)로 보여 SQL 표현식 자리에 들어가지 못한다.
     filters = []
     if source is not None:
-        filters.append(FilteredSignal.source == source)
+        filters.append(col(FilteredSignal.source) == source)
     if stock_name is not None:
-        filters.append(FilteredSignal.stock_name == stock_name)
+        filters.append(col(FilteredSignal.stock_name) == stock_name)
     if since is not None:
-        filters.append(FilteredSignal.created_at >= _as_utc_naive(since))
+        filters.append(col(FilteredSignal.created_at) >= _as_utc_naive(since))
 
     bucket_query = select(FilteredSignal.score, func.count()).group_by(
-        FilteredSignal.score
-    ).order_by(FilteredSignal.score)
+        col(FilteredSignal.score)
+    ).order_by(col(FilteredSignal.score))
     summary_query = select(
         func.count(),
         func.min(FilteredSignal.created_at),
         func.max(FilteredSignal.created_at),
     )
     threshold_query = select(FilteredSignal.threshold).distinct().order_by(
-        FilteredSignal.threshold
+        col(FilteredSignal.threshold)
     )
     for condition in filters:
         bucket_query = bucket_query.where(condition)

--- a/backend/tests/test_filtered_signal.py
+++ b/backend/tests/test_filtered_signal.py
@@ -1,7 +1,7 @@
 """걸러진 신호 채점 기록의 저장·정리·집계 (#304)."""
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import get_args
+from typing import Any, Callable, get_args, cast
 
 import pytest
 from fastapi.testclient import TestClient
@@ -38,13 +38,16 @@ def repo_fixture(session: Session):
     """
 
     class _KeepOpenSession:
-        def __enter__(inner):
+        def __enter__(self):
             return session
 
-        def __exit__(inner, *exc):
+        def __exit__(self, *exc):
             return False
 
-    return SqliteFilteredSignalRepo(lambda: _KeepOpenSession())
+    # 아래 cast는 이 대역 때문이다. 주입 지점의 선언 타입이 구체 클래스(Session)라
+    # 대역이 그대로는 타입 검사를 통과하지 못한다. Protocol로 좁혀 cast를 걷어내는
+    # 것은 #319가 추적한다.
+    return SqliteFilteredSignalRepo(cast(Callable[[], Session], lambda: _KeepOpenSession()))
 
 
 @pytest.fixture(name="client")
@@ -56,7 +59,11 @@ def client_fixture(session: Session):
 
 
 def _add(session: Session, **kwargs) -> FilteredSignal:
-    defaults = dict(stock_name="삼성전자", source="news", score=1, threshold=2)
+    # 값 타입이 섞여 있어 선언이 없으면 dict[str, str | int]로 추론되고, 그러면
+    # **defaults 전개가 FilteredSignal의 필드 타입을 하나도 만족하지 못한다.
+    defaults: dict[str, Any] = dict(
+        stock_name="삼성전자", source="news", score=1, threshold=2
+    )
     defaults.update(kwargs)
     row = FilteredSignal(**defaults)
     session.add(row)


### PR DESCRIPTION
## 📝 개요

**main이 빨간불이라 복구한다.** #292의 타입 체크 잡(PR #318)과 #304(PR #317)이 3분 차이로 머지됐는데, #317은 잡이 생기기 전에 분기해 PR CI에 그 잡이 없었다. main에 올라온 뒤 처음 검사받으며 14건이 드러났다.

## 🔍 발견된 문제

1. **`backend/filtered_signal_repo.py` 5건.** 모델 필드를 SQL 표현식 자리에 그대로 썼다 — `delete(...).where(FilteredSignal.created_at < cutoff)`, `group_by(FilteredSignal.score)`, `order_by(FilteredSignal.score)`, `order_by(FilteredSignal.threshold)`. 체커에는 파이썬 값의 비교(`bool`)나 `int`로 보여 표현식 자리에 들어가지 못한다. 레포의 다른 SQLModel 질의(`catalyst_repo`, `main`, `watchlist_repo`)는 이미 `col()`로 맞춰져 있어 이 파일만 기준이 갈렸다.

2. **`result.rowcount` 1건.** `Session.execute`의 선언 반환형은 `Result`인데 `rowcount`는 DML의 실제 반환 타입인 `CursorResult`에만 있다.

3. **`backend/tests/test_filtered_signal.py` 8건 + 경고 2건.** `_add`의 `defaults = dict(...)`가 `dict[str, str | int]`로 추론돼 `**defaults` 전개가 `FilteredSignal`의 어떤 필드 타입도 만족하지 못했고(8건), `_KeepOpenSession`이 `Session` 자리에 들어가지 못했다. `__enter__`/`__exit__`의 첫 인자를 `inner`로 둔 것은 경고 2건이었다.

## 🔧 문제 해결 방법

1. `filtered_signal_repo.py` — 조건·`group_by`·`order_by`를 전부 `col()`로 감쌌다. 플래그되지 않은 `filters` 세 줄도 함께 맞춰 파일 안의 기준을 통일했다.
2. `rowcount` — `cast(CursorResult[Any], result)`로 좁히고 왜 필요한지 주석에 적었다. `-1`을 `0`으로 눕히는 기존 동작은 그대로다.
3. 테스트 — `defaults: dict[str, Any]` 선언, 세션 대역 주입 지점의 `cast`(#319가 추적하는 그 부채와 같은 유형이라 같은 주석 형식으로 달았다), 첫 인자 이름을 `self`로.

동작을 바꾸는 수정은 없다. `col()`·`cast()`·인자 이름 변경 모두 런타임 등가다.

## ✅ 검증

<!-- CI가 잡지 않는 것만. 수동 재현, 실측 수치, 로컬에서만 확인한 것. -->
- `origin/main`(`2491171`)에서 그대로 재현했다 — **14 errors, 2 warnings**. 수정 후 **0 errors, 0 warnings**.
- `uv run --project backend pytest backend/tests/` → **910 passed, 3 skipped**.

## 🔗 관련 이슈
- #292 (타입 체크 잡 도입, PR #318), #304 (걸러진 신호 기록, PR #317)
- 관련: #319 — 이 PR이 추가한 세션 대역 `cast`도 거기서 함께 걷어낸다
