### PR TITLE
feat: fetchAllPaged pageDelayMs 상수를 env로 설정 가능하게 만든다 (#210)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,16 @@ KIS_REAL_ORDER_ENABLED=false
 # KIS_TR_ID_BALANCE_RLZ_PL=TTTC8494R
 # KIS_TR_ID_PSBL_ORDER=TTTC8908R
 
+# 연속조회 페이지 간 대기(ms, 선택). 기본 0(대기 없음) — KIS 유량 제한의 실제 임계치를
+# 실계좌 없이 실측하지 못해 미확인이라 기본값을 두지 않았습니다(#210). EGW00201("초당
+# 거래건수 초과")이 실제로 관측되면 코드 변경 없이 여기서 값만 넣으면 됩니다.
+# 0 이상의 숫자여야 하고, 각 조회의 시간 예산(90000ms) 미만이어야 합니다 — 벗어나면
+# stderr에 경고를 남기고 기본값 0으로 되돌아갑니다.
+# FINUS_KIS_DAILY_CCLD_PAGE_DELAY_MS / FINUS_KIS_BALANCE_RLZ_PL_PAGE_DELAY_MS로도
+# 설정할 수 있습니다.
+# KIS_DAILY_CCLD_PAGE_DELAY_MS=0
+# KIS_BALANCE_RLZ_PL_PAGE_DELAY_MS=0
+
 #실전투자계좌일 경우
 #KIS_URL=https://openapi.koreainvestment.com:9443
 

--- a/mcp-trading/balance.js
+++ b/mcp-trading/balance.js
@@ -9,13 +9,49 @@
 // 숫자가 아니거나 음수면(PR #264 리뷰 지적) 설정 오류로 보고 fallback으로 되돌리며 stderr에
 // 경고를 남긴다 — 조용히 무시하면 오탈자 설정이 "지연 없음"으로 읽혀 유량 제한을 넘기는
 // 실패가 배포 후에야 드러난다.
-export function readPageDelayMsEnv(name, fallback) {
-  const raw = (process.env[`KIS_${name}`] || process.env[`FINUS_KIS_${name}`] || "").trim();
+//
+// 두 접두사는 "trim 후 비어 있지 않은 첫 키"로 고른다. `KIS_ || FINUS_KIS_`로 쓰면 KIS_ 쪽이
+// 공백만인 값일 때 truthy로 통과해 FINUS_KIS_ 값을 가린 채 "숫자가 아님" 경고만 남긴다.
+// (KIS_TR_ID_* 오버라이드에도 같은 성질이 남아 있지만 그쪽은 이 PR 범위가 아니다.)
+// 경고에는 name이 아니라 실제로 읽은 키 전체(KIS_.../FINUS_KIS_...)를 찍는다 — 운영자가
+// 설정한 문자열과 로그의 문자열이 같아야 grep으로 찾을 수 있다.
+export const SET_TIMEOUT_MAX_MS = 2_147_483_647;
+
+// 상한(maxMs)을 넘는 값도 설정 오류로 보고 fallback으로 되돌린다. 두 갈래로 "지연을 늘리려던
+// 설정"이 정반대로 동작하기 때문이다.
+// (a) 호출 루프의 시간 예산 이상이면 첫 페이지 직후 budgetExhausted()가 걸려 항상 1페이지만
+//     돌아온다(truncated="time_budget"). 유량 제한을 위해 늘린 값이 연속조회 자체를 없앤다.
+// (b) Node setTimeout은 2^31-1ms를 넘는 지연을 오버플로 경고와 함께 1ms로 접는다. 즉 지연이
+//     사실상 사라진다 — (a)와 정반대 방향이지만 결과는 똑같이 의도와 어긋난다.
+// 그래서 호출자는 자기 루프의 timeBudgetMs를 maxMs로 넘긴다(index.js). maxMs를 넘기지 않는
+// 호출자에게도 (b)만은 항상 걸리도록 기본값을 setTimeout 상한으로 둔다. 경계는 `>= maxMs`다 —
+// 예산과 정확히 같은 지연은 (a)를 그대로 일으키고, setTimeout 상한과 정확히 같은 값은
+// 실무상 의미가 없어 굳이 두 연산자를 섞지 않는다.
+// 상한 초과를 clamp가 아니라 fallback으로 되돌리는 이유: 조용히 잘라 쓰면 로그의 값과 실제
+// 동작이 갈라진다. NaN·음수와 같은 취급(경고 + 기본값)으로 통일한다.
+export function readPageDelayMsEnv(name, fallback, { maxMs = SET_TIMEOUT_MAX_MS } = {}) {
+  let key = null;
+  let raw = "";
+  for (const candidate of [`KIS_${name}`, `FINUS_KIS_${name}`]) {
+    const value = (process.env[candidate] || "").trim();
+    if (value) {
+      key = candidate;
+      raw = value;
+      break;
+    }
+  }
   if (!raw) return fallback;
+
   const parsed = Number(raw);
   if (!Number.isFinite(parsed) || parsed < 0) {
     console.error(
-      `${name} 환경변수 값이 올바르지 않습니다(${JSON.stringify(raw)}) — 0 이상의 숫자여야 합니다. 기본값 ${fallback}ms를 사용합니다.`,
+      `${key} 환경변수 값이 올바르지 않습니다(${JSON.stringify(raw)}) — 0 이상의 숫자여야 합니다. 기본값 ${fallback}ms를 사용합니다.`,
+    );
+    return fallback;
+  }
+  if (parsed >= maxMs) {
+    console.error(
+      `${key} 환경변수 값이 너무 큽니다(${JSON.stringify(raw)}) — ${maxMs}ms 미만이어야 합니다. 기본값 ${fallback}ms를 사용합니다.`,
     );
     return fallback;
   }

--- a/mcp-trading/balance.js
+++ b/mcp-trading/balance.js
@@ -1,3 +1,27 @@
+// 이슈 #210: fetchAllPaged의 pageDelayMs(페이지 간 대기)를 env로 설정 가능하게 만드는
+// 공용 파서. index.js가 아니라 여기 두는 이유는 index.js 상단 주석과 같다 — index.js는
+// import 시점에 StdioServerTransport를 연결하는 부작용이 있어 단독 유닛 테스트로
+// import할 수 없다(tests/mcp-server.test.js가 자식 프로세스로만 접근하는 이유이기도
+// 하다). KIS_TR_ID_*(index.js) 오버라이드와 같은 두 접두사(KIS_/FINUS_KIS_) 관례를 쓴다.
+// 미설정·빈 문자열이면 fallback을 그대로 쓴다 — 즉 아무것도 설정하지 않으면 이전과 동일한
+// 동작이다(기본값 자체는 index.js가 0으로 넘긴다 — fetchAllBalance/daily-ccld/balance-rlz-pl
+// 세 루프 모두 이 PR 전과 동일하게 동작해야 한다는 PR #200 수용 기준을 승계). 값이 있는데
+// 숫자가 아니거나 음수면(PR #264 리뷰 지적) 설정 오류로 보고 fallback으로 되돌리며 stderr에
+// 경고를 남긴다 — 조용히 무시하면 오탈자 설정이 "지연 없음"으로 읽혀 유량 제한을 넘기는
+// 실패가 배포 후에야 드러난다.
+export function readPageDelayMsEnv(name, fallback) {
+  const raw = (process.env[`KIS_${name}`] || process.env[`FINUS_KIS_${name}`] || "").trim();
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    console.error(
+      `${name} 환경변수 값이 올바르지 않습니다(${JSON.stringify(raw)}) — 0 이상의 숫자여야 합니다. 기본값 ${fallback}ms를 사용합니다.`,
+    );
+    return fallback;
+  }
+  return parsed;
+}
+
 // 연속조회 페이지 상한. inquire-balance-rlz-pl 등 다른 조회의 BALANCE_RLZ_PL_MAX_PAGES(mcp-trading/index.js)
 // 명명 관례를 따른다. 실제로는 아래 BALANCE_TIME_BUDGET_MS가 먼저 걸리는 경우가 대부분이며,
 // 이 값은 KIS가 tr_cont를 계속 "F"/"M"으로 응답하는 이상 상황에 대한 2차 안전장치다.

--- a/mcp-trading/index.js
+++ b/mcp-trading/index.js
@@ -8,7 +8,13 @@ import axios from "axios";
 import dotenv from "dotenv";
 import { z } from "zod";
 import { formatBalanceRlzPlReport } from "./balance-rlz-pl-report.js";
-import { buildBalanceParams, fetchAllBalance, fetchAllPaged, formatBalanceReport } from "./balance.js";
+import {
+  buildBalanceParams,
+  fetchAllBalance,
+  fetchAllPaged,
+  formatBalanceReport,
+  readPageDelayMsEnv,
+} from "./balance.js";
 import {
   formatPercent,
   formatQuantity,
@@ -61,11 +67,32 @@ const DAILY_CCLD_MAX_PAGES = 50;
 // 100 < 120이므로 상한 안에 안전하게 들어온다. 90초 초과가 이상 상황이라고 판단하기에
 // 충분하다고 본다. 실제 페이지당 지연 측정치가 확보되면 이 값을 재조정해야 한다.
 const DAILY_CCLD_TIME_BUDGET_MS = 90_000;
-// 이슈 #210: 페이지 간 대기(fetchAllPaged의 pageDelayMs). 값을 0으로 비워둔다 — KIS
-// 유량 제한의 실제 임계(초당 호출 수)를 아직 측정하지 못했다. backend/telegram_commands.py의
-// `/watch list`가 종목당 1.1초를 쓰지만 그 값의 근거도 확인되지 않았고, 애초에 다른 TR이라
-// 그대로 가져다 쓸 근거가 안 된다. 측정치가 나오면 이 값을 채운다(이슈 #210 조사 항목).
-const DAILY_CCLD_PAGE_DELAY_MS = 0;
+// 이슈 #210: 페이지 간 대기(fetchAllPaged의 pageDelayMs)를 env로 열어둔다 — 값이 코드에
+// 박혀 있으면 실측 자체가 매번 코드 변경 + 배포를 요구한다(PR #264 리뷰). 기본값은 0(대기
+// 없음) — KIS 유량 제한의 실제 임계(초당 호출 수)를 실계좌 없이는 실측할 수 없어 미확인이며,
+// 미확인 상태에서 기본값을 바꾸면 PR #200이 정한 "fetchAllBalance뿐 아니라 이 루프들의
+// 관측 가능한 동작도 조용히 바뀌면 안 된다"는 전제를 깬다.
+//
+// 공식 문서 조사(#210) 결과:
+// - 한국투자증권 공식 GitHub(koreainvestment/open-trading-api) README가 오류 코드
+//   EGW00201("초당 거래건수 초과")의 존재를 명시하고, "모의투자 계좌는 REST API 호출
+//   제한이 낮으니 연속 호출이 많으면 실전투자 계좌를 권장"한다고 정성적으로만 밝힌다 —
+//   공식 출처이나 구체적 TPS 수치는 없음.
+// - 같은 README가 접근토큰 재발급은 "1분당 1회"로 제한된다고 명시한다(공식, 수치 확인됨).
+//   페이지 간 대기와는 별개 제한이지만 토큰 캐시(token-cache.js)가 이미 이 제한을
+//   전제로 설계돼 있다는 근거다.
+// - 실전투자 "표준 20 TPS"라는 수치는 언론 보도(서울경제 영문판, KIS의 Open API 완화
+//   캠페인 관련 기사)에서만 확인했고 apiportal.koreainvestment.com 원문에서 직접
+//   인용하지 못했다 — 반공식, 페이지 간 대기 기본값을 바꿀 근거로 쓰기엔 부족하다고 판단.
+// - 모의투자의 구체적 TPS 수치, 제한 단위(계좌/앱키/TR ID 중 무엇인지)는 공식 문서에서
+//   끝내 확인하지 못했다 — 미확인.
+// backend/telegram_commands.py의 `/watch list`가 종목당 1.1초를 쓰지만 git blame(742fa8a,
+// 커밋 메시지·코드 모두)에도 그 값의 산출 근거가 없어 그대로 가져다 쓸 근거가 못 된다
+// (다른 TR이기도 하다) — 이 값도 미확인으로 남긴다.
+//
+// 결론: 근거가 정성적 수준이라 기본값 0을 유지한다. 실측치(또는 확정 TPS 문서)가 나오면
+// 이 env로 값만 바꿔 넣으면 된다(재배포는 여전히 필요하지만 코드 변경은 불필요).
+const DAILY_CCLD_PAGE_DELAY_MS = readPageDelayMsEnv("DAILY_CCLD_PAGE_DELAY_MS", 0);
 const BALANCE_RLZ_PL_PATH = "/uapi/domestic-stock/v1/trading/inquire-balance-rlz-pl";
 const BALANCE_RLZ_PL_TR_ID = (() => {
   const override = (process.env.KIS_TR_ID_BALANCE_RLZ_PL || process.env.FINUS_KIS_TR_ID_BALANCE_RLZ_PL || "").trim();
@@ -76,8 +103,8 @@ const BALANCE_RLZ_PL_MAX_PAGES = 50;
 // inquire-balance-rlz-pl 연속조회 전체 시간 예산. DAILY_CCLD_TIME_BUDGET_MS와 같은 근거.
 // 두 TR의 호출자·상한·요청당 타임아웃이 동일하므로 동일한 값을 쓴다.
 const BALANCE_RLZ_PL_TIME_BUDGET_MS = 90_000;
-// 이슈 #210: DAILY_CCLD_PAGE_DELAY_MS와 같은 이유로 0. 실측 전까지 비워둔다.
-const BALANCE_RLZ_PL_PAGE_DELAY_MS = 0;
+// 이슈 #210: DAILY_CCLD_PAGE_DELAY_MS와 같은 이유로 기본값 0, 같은 env 패턴으로 오버라이드.
+const BALANCE_RLZ_PL_PAGE_DELAY_MS = readPageDelayMsEnv("BALANCE_RLZ_PL_PAGE_DELAY_MS", 0);
 const PSBL_ORDER_PATH = "/uapi/domestic-stock/v1/trading/inquire-psbl-order";
 // 매수가능조회 TR ID. 연속조회가 없는 단건 조회라 페이지 상한·시간 예산이 없다.
 // 오버라이드 이름은 KIS_TR_ID_DAILY_CCLD / KIS_TR_ID_BALANCE_RLZ_PL과 같은 관례를 따른다

--- a/mcp-trading/index.js
+++ b/mcp-trading/index.js
@@ -92,7 +92,11 @@ const DAILY_CCLD_TIME_BUDGET_MS = 90_000;
 //
 // 결론: 근거가 정성적 수준이라 기본값 0을 유지한다. 실측치(또는 확정 TPS 문서)가 나오면
 // 이 env로 값만 바꿔 넣으면 된다(재배포는 여전히 필요하지만 코드 변경은 불필요).
-const DAILY_CCLD_PAGE_DELAY_MS = readPageDelayMsEnv("DAILY_CCLD_PAGE_DELAY_MS", 0);
+// 상한은 이 루프의 시간 예산이다 — 예산 이상의 지연은 첫 페이지 직후 예산을 소진시켜
+// 연속조회를 항상 1페이지로 잘라버린다(readPageDelayMsEnv 주석 (a)).
+const DAILY_CCLD_PAGE_DELAY_MS = readPageDelayMsEnv("DAILY_CCLD_PAGE_DELAY_MS", 0, {
+  maxMs: DAILY_CCLD_TIME_BUDGET_MS,
+});
 const BALANCE_RLZ_PL_PATH = "/uapi/domestic-stock/v1/trading/inquire-balance-rlz-pl";
 const BALANCE_RLZ_PL_TR_ID = (() => {
   const override = (process.env.KIS_TR_ID_BALANCE_RLZ_PL || process.env.FINUS_KIS_TR_ID_BALANCE_RLZ_PL || "").trim();
@@ -104,7 +108,9 @@ const BALANCE_RLZ_PL_MAX_PAGES = 50;
 // 두 TR의 호출자·상한·요청당 타임아웃이 동일하므로 동일한 값을 쓴다.
 const BALANCE_RLZ_PL_TIME_BUDGET_MS = 90_000;
 // 이슈 #210: DAILY_CCLD_PAGE_DELAY_MS와 같은 이유로 기본값 0, 같은 env 패턴으로 오버라이드.
-const BALANCE_RLZ_PL_PAGE_DELAY_MS = readPageDelayMsEnv("BALANCE_RLZ_PL_PAGE_DELAY_MS", 0);
+const BALANCE_RLZ_PL_PAGE_DELAY_MS = readPageDelayMsEnv("BALANCE_RLZ_PL_PAGE_DELAY_MS", 0, {
+  maxMs: BALANCE_RLZ_PL_TIME_BUDGET_MS,
+});
 const PSBL_ORDER_PATH = "/uapi/domestic-stock/v1/trading/inquire-psbl-order";
 // 매수가능조회 TR ID. 연속조회가 없는 단건 조회라 페이지 상한·시간 예산이 없다.
 // 오버라이드 이름은 KIS_TR_ID_DAILY_CCLD / KIS_TR_ID_BALANCE_RLZ_PL과 같은 관례를 따른다

--- a/mcp-trading/tests/page-delay-env-wiring.test.js
+++ b/mcp-trading/tests/page-delay-env-wiring.test.js
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { spawn } from "node:child_process";
+
+// 이슈 #210: 파서(readPageDelayMsEnv)의 계약은 tests/page-delay-ms-env.test.js가 합성
+// 이름으로 검증한다. 그 테스트는 index.js가 실제로 배선한 이름을 전혀 보지 않으므로,
+// KIS_DAILY_CCLD_PAGE_DELAY_MS 같은 "운영자가 실제로 설정하는 문자열"이 오타로 바뀌어도
+// 아무도 못 잡는다(.env.example만 맞고 코드가 다른 이름을 읽는 상태도 마찬가지다).
+//
+// 여기서는 소스 텍스트를 grep하는 대신 실제 서버 프로세스에 그 키를 설정해 배선을 끝까지
+// 확인한다 — 잘못된 값을 넣으면 index.js가 import 시점에 readPageDelayMsEnv를 호출하고,
+// 그 경고에 실제로 읽은 키 이름이 그대로 찍힌다. 이름이 어긋나면 env가 무시되어 경고가
+// 아예 나오지 않으므로 테스트가 실패한다.
+//
+// index.js를 직접 import할 수 없어(StdioServerTransport 연결 부작용) 자식 프로세스로
+// 접근한다 — tests/mcp-server.test.js와 같은 이유다. stdin을 닫으면 stdio 트랜스포트가
+// 끝나 프로세스가 정상 종료(exit 0)한다.
+const SPAWN_TIMEOUT_MS = 20_000;
+
+function runServerWithEnv(env) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ["index.js"], {
+      cwd: process.cwd(),
+      env: { ...process.env, ...env },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stderr = "";
+    let stdout = "";
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    const timer = setTimeout(() => {
+      child.kill();
+      reject(new Error(`server did not exit within ${SPAWN_TIMEOUT_MS}ms; stderr: ${stderr}`));
+    }, SPAWN_TIMEOUT_MS);
+    child.on("error", (error) => { clearTimeout(timer); reject(error); });
+    child.on("close", (code) => { clearTimeout(timer); resolve({ code, stderr, stdout }); });
+    child.stdin.end();
+  });
+}
+
+// 배선된 두 이름. index.js의 상수 이름이 아니라 운영자가 .env에 적는 키 그대로다.
+for (const key of ["KIS_DAILY_CCLD_PAGE_DELAY_MS", "KIS_BALANCE_RLZ_PL_PAGE_DELAY_MS"]) {
+  test(`index.js reads ${key} (env name wiring guard)`, async () => {
+    const { code, stderr } = await runServerWithEnv({ [key]: "not-a-number" });
+
+    assert.equal(code, 0, `server should exit cleanly; stderr: ${stderr}`);
+    assert.ok(
+      stderr.includes(key),
+      `index.js must read the env var operators actually set (${key}); ` +
+        `a typo in the wiring makes the value silently ignored. stderr was: ${stderr}`,
+    );
+  });
+
+  test(`index.js accepts the FINUS_ prefixed alias for ${key}`, async () => {
+    const aliasKey = key.replace(/^KIS_/, "FINUS_KIS_");
+    const { code, stderr } = await runServerWithEnv({ [aliasKey]: "not-a-number" });
+
+    assert.equal(code, 0, `server should exit cleanly; stderr: ${stderr}`);
+    assert.ok(
+      stderr.includes(aliasKey),
+      `index.js must also honor ${aliasKey}. stderr was: ${stderr}`,
+    );
+  });
+}
+
+test("index.js rejects a page delay at or above the loop's time budget", async () => {
+  // 상한(maxMs)이 실제 호출부에 배선돼 있는지 — 파서에만 있고 index.js가 안 넘기면
+  // 90초 지연이 그대로 통과해 연속조회가 항상 1페이지로 잘린다.
+  const { code, stderr } = await runServerWithEnv({ KIS_DAILY_CCLD_PAGE_DELAY_MS: "90000" });
+
+  assert.equal(code, 0, `server should exit cleanly; stderr: ${stderr}`);
+  assert.ok(
+    stderr.includes("KIS_DAILY_CCLD_PAGE_DELAY_MS") && stderr.includes("너무 큽니다"),
+    `a delay at the time budget must be rejected with a warning. stderr was: ${stderr}`,
+  );
+});
+
+test("index.js accepts a valid page delay without warning", async () => {
+  // 역방향 가드: 위 테스트들이 "항상 경고가 난다"로 통과하는 상태가 아님을 확인한다.
+  const { code, stderr } = await runServerWithEnv({ KIS_DAILY_CCLD_PAGE_DELAY_MS: "150" });
+
+  assert.equal(code, 0, `server should exit cleanly; stderr: ${stderr}`);
+  assert.ok(
+    !stderr.includes("KIS_DAILY_CCLD_PAGE_DELAY_MS"),
+    `a valid delay must not warn. stderr was: ${stderr}`,
+  );
+});

--- a/mcp-trading/tests/page-delay-ms-env.test.js
+++ b/mcp-trading/tests/page-delay-ms-env.test.js
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { readPageDelayMsEnv } from "../balance.js";
+import { SET_TIMEOUT_MAX_MS, readPageDelayMsEnv } from "../balance.js";
 
 // 이슈 #210: readPageDelayMsEnv는 fetchAllPaged의 pageDelayMs를 재배포 없이 실측치로
 // 채울 수 있도록 KIS_<name>/FINUS_KIS_<name> env를 읽는 공용 파서다(balance.js). 여기서는
@@ -29,6 +29,24 @@ function withEnv(t, values) {
       }
     }
   });
+}
+
+// console.error/log를 가로채고 t.after로 되돌린다. 경고는 stderr로만 나가야 한다 —
+// console.log(stdout)는 MCP stdio JSON-RPC 채널이라 한 줄만 새도 프로토콜이 깨진다.
+function captureConsole(t) {
+  const originalConsoleError = console.error;
+  const originalConsoleLog = console.log;
+  const errorCalls = [];
+  console.error = (...args) => errorCalls.push(args.join(" "));
+  console.log = (...args) => {
+    originalConsoleError("unexpected console.log:", ...args);
+    assert.fail("readPageDelayMsEnv must not write to console.log (MCP stdio JSON-RPC channel)");
+  };
+  t.after(() => {
+    console.error = originalConsoleError;
+    console.log = originalConsoleLog;
+  });
+  return errorCalls;
 }
 
 test("readPageDelayMsEnv returns the fallback when neither env var is set (regression guard: unset must not change behavior)", (t) => {
@@ -93,4 +111,69 @@ test("readPageDelayMsEnv rejects a negative value and falls back to the default"
 test("readPageDelayMsEnv rejects Infinity/NaN-producing input", (t) => {
   withEnv(t, { [KIS_KEY]: "Infinity" });
   assert.equal(readPageDelayMsEnv(TEST_ENV_NAME, 5), 5);
+});
+
+test("readPageDelayMsEnv does not let a whitespace-only KIS_ value mask the FINUS_KIS_ override", (t) => {
+  // `KIS_ || FINUS_KIS_`로 고르면 공백만인 KIS_ 값이 truthy라 FINUS_KIS_를 가린 채
+  // trim 결과가 빈 문자열이 되어 fallback으로 떨어진다(빈 문자열일 때는 통과한다).
+  withEnv(t, { [KIS_KEY]: "   ", [FINUS_KIS_KEY]: "70" });
+  assert.equal(readPageDelayMsEnv(TEST_ENV_NAME, 0), 70);
+});
+
+test("readPageDelayMsEnv names the KIS_-prefixed key in the warning, not the bare name", (t) => {
+  // 운영자가 설정한 문자열과 로그의 문자열이 같아야 grep으로 찾을 수 있다.
+  withEnv(t, { [KIS_KEY]: "nope" });
+  const errorCalls = captureConsole(t);
+  assert.equal(readPageDelayMsEnv(TEST_ENV_NAME, 0), 0);
+  assert.equal(errorCalls.length, 1);
+  assert.ok(
+    errorCalls[0].includes(KIS_KEY),
+    `warning must name the resolved key ${KIS_KEY}, got: ${errorCalls[0]}`,
+  );
+});
+
+test("readPageDelayMsEnv names the FINUS_KIS_-prefixed key in the warning when that is the one it read", (t) => {
+  withEnv(t, { [FINUS_KIS_KEY]: "nope" });
+  const errorCalls = captureConsole(t);
+  assert.equal(readPageDelayMsEnv(TEST_ENV_NAME, 0), 0);
+  assert.equal(errorCalls.length, 1);
+  assert.ok(
+    errorCalls[0].includes(FINUS_KIS_KEY),
+    `warning must name the resolved key ${FINUS_KIS_KEY}, got: ${errorCalls[0]}`,
+  );
+});
+
+test("readPageDelayMsEnv rejects a delay equal to maxMs and falls back (would truncate every fetch to one page)", (t) => {
+  // 시간 예산 이상의 지연은 첫 페이지 직후 budgetExhausted()를 걸어 연속조회를 항상
+  // 1페이지로 잘라버린다 — 유량 제한을 위해 늘린 값이 정반대로 동작한다.
+  withEnv(t, { [KIS_KEY]: "90000" });
+  const errorCalls = captureConsole(t);
+  assert.equal(readPageDelayMsEnv(TEST_ENV_NAME, 0, { maxMs: 90_000 }), 0);
+  assert.equal(errorCalls.length, 1);
+  assert.ok(errorCalls[0].includes(KIS_KEY), errorCalls[0]);
+  assert.match(errorCalls[0], /90000ms/);
+});
+
+test("readPageDelayMsEnv rejects a delay above maxMs and falls back", (t) => {
+  withEnv(t, { [KIS_KEY]: "120000" });
+  const errorCalls = captureConsole(t);
+  assert.equal(readPageDelayMsEnv(TEST_ENV_NAME, 0, { maxMs: 90_000 }), 0);
+  assert.equal(errorCalls.length, 1);
+});
+
+test("readPageDelayMsEnv accepts a delay just below maxMs", (t) => {
+  withEnv(t, { [KIS_KEY]: "89999" });
+  const errorCalls = captureConsole(t);
+  assert.equal(readPageDelayMsEnv(TEST_ENV_NAME, 0, { maxMs: 90_000 }), 89_999);
+  assert.equal(errorCalls.length, 0);
+});
+
+test("readPageDelayMsEnv rejects setTimeout-overflowing values even without an explicit maxMs", (t) => {
+  // Node setTimeout은 2^31-1ms를 넘는 지연을 오버플로 경고와 함께 1ms로 접는다 —
+  // 상한이 없으면 "지연을 크게 키운" 설정이 사실상 "지연 없음"이 된다.
+  withEnv(t, { [KIS_KEY]: String(SET_TIMEOUT_MAX_MS + 1) });
+  const errorCalls = captureConsole(t);
+  assert.equal(readPageDelayMsEnv(TEST_ENV_NAME, 0), 0);
+  assert.equal(errorCalls.length, 1);
+  assert.ok(errorCalls[0].includes(KIS_KEY), errorCalls[0]);
 });

--- a/mcp-trading/tests/page-delay-ms-env.test.js
+++ b/mcp-trading/tests/page-delay-ms-env.test.js
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readPageDelayMsEnv } from "../balance.js";
+
+// 이슈 #210: readPageDelayMsEnv는 fetchAllPaged의 pageDelayMs를 재배포 없이 실측치로
+// 채울 수 있도록 KIS_<name>/FINUS_KIS_<name> env를 읽는 공용 파서다(balance.js). 여기서는
+// index.js의 두 상수(DAILY_CCLD_PAGE_DELAY_MS, BALANCE_RLZ_PL_PAGE_DELAY_MS)가 실제로
+// 쓰는 이름 대신 테스트 전용 이름을 써서, 이 파일이 index.js를 import하지 않고도(부작용
+// 없이) 파서 자체의 계약을 단독 검증한다.
+const TEST_ENV_NAME = "TEST_PAGE_DELAY_MS_FOR_ENV_PARSER_TEST";
+const KIS_KEY = `KIS_${TEST_ENV_NAME}`;
+const FINUS_KIS_KEY = `FINUS_KIS_${TEST_ENV_NAME}`;
+
+function withEnv(t, values) {
+  const originals = new Map();
+  for (const key of [KIS_KEY, FINUS_KIS_KEY]) {
+    originals.set(key, process.env[key]);
+    delete process.env[key];
+  }
+  for (const [key, value] of Object.entries(values)) {
+    process.env[key] = value;
+  }
+  t.after(() => {
+    for (const [key, original] of originals) {
+      if (original === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = original;
+      }
+    }
+  });
+}
+
+test("readPageDelayMsEnv returns the fallback when neither env var is set (regression guard: unset must not change behavior)", (t) => {
+  withEnv(t, {});
+  assert.equal(readPageDelayMsEnv(TEST_ENV_NAME, 0), 0);
+  assert.equal(readPageDelayMsEnv(TEST_ENV_NAME, 250), 250);
+});
+
+test("readPageDelayMsEnv returns the fallback when the env var is empty or whitespace-only", (t) => {
+  withEnv(t, { [KIS_KEY]: "" });
+  assert.equal(readPageDelayMsEnv(TEST_ENV_NAME, 0), 0);
+
+  withEnv(t, { [KIS_KEY]: "   " });
+  assert.equal(readPageDelayMsEnv(TEST_ENV_NAME, 0), 0);
+});
+
+test("readPageDelayMsEnv parses a valid KIS_-prefixed override, trimming whitespace", (t) => {
+  withEnv(t, { [KIS_KEY]: "  120  " });
+  assert.equal(readPageDelayMsEnv(TEST_ENV_NAME, 0), 120);
+});
+
+test("readPageDelayMsEnv falls back to the FINUS_KIS_-prefixed override when KIS_ is unset", (t) => {
+  withEnv(t, { [FINUS_KIS_KEY]: "80" });
+  assert.equal(readPageDelayMsEnv(TEST_ENV_NAME, 0), 80);
+});
+
+test("readPageDelayMsEnv prefers the KIS_-prefixed override over FINUS_KIS_ when both are set", (t) => {
+  withEnv(t, { [KIS_KEY]: "50", [FINUS_KIS_KEY]: "999" });
+  assert.equal(readPageDelayMsEnv(TEST_ENV_NAME, 0), 50);
+});
+
+test("readPageDelayMsEnv accepts 0 as an explicit valid override", (t) => {
+  withEnv(t, { [KIS_KEY]: "0" });
+  assert.equal(readPageDelayMsEnv(TEST_ENV_NAME, 999), 0);
+});
+
+test("readPageDelayMsEnv rejects a non-numeric value and falls back, logging a warning to stderr (not stdout)", (t) => {
+  withEnv(t, { [KIS_KEY]: "not-a-number" });
+  const originalConsoleError = console.error;
+  const originalConsoleLog = console.log;
+  const errorCalls = [];
+  const logCalls = [];
+  console.error = (...args) => errorCalls.push(args.join(" "));
+  console.log = (...args) => logCalls.push(args.join(" "));
+  t.after(() => {
+    console.error = originalConsoleError;
+    console.log = originalConsoleLog;
+  });
+
+  assert.equal(readPageDelayMsEnv(TEST_ENV_NAME, 42), 42);
+  assert.equal(logCalls.length, 0, "invalid input must not be logged via console.log (would break MCP stdio JSON-RPC)");
+  assert.equal(errorCalls.length, 1);
+  assert.match(errorCalls[0], /TEST_PAGE_DELAY_MS_FOR_ENV_PARSER_TEST/);
+  assert.match(errorCalls[0], /42ms/);
+});
+
+test("readPageDelayMsEnv rejects a negative value and falls back to the default", (t) => {
+  withEnv(t, { [KIS_KEY]: "-10" });
+  assert.equal(readPageDelayMsEnv(TEST_ENV_NAME, 0), 0);
+});
+
+test("readPageDelayMsEnv rejects Infinity/NaN-producing input", (t) => {
+  withEnv(t, { [KIS_KEY]: "Infinity" });
+  assert.equal(readPageDelayMsEnv(TEST_ENV_NAME, 5), 5);
+});


### PR DESCRIPTION
## 배경 — 선행 PR 이력과 잔여 범위 판정

- PR #200(#147): 세 루프를 `fetchAllPaged`로 통합, 시간 예산 90초·페이지 상한 50·커서 가드 도입. `fetchAllBalance`의 관측 가능한 동작 불변이 수용 기준.
- PR #264(#210 1차): `fetchAllPaged`에 `pageDelayMs`/`sleep` 인자 경로를 추가하고 `index.js`의 두 루프(daily-ccld, balance-rlz-pl)에 배선. 두 상수(`DAILY_CCLD_PAGE_DELAY_MS`, `BALANCE_RLZ_PL_PAGE_DELAY_MS`)는 코드에 **0으로 하드코딩**돼 런타임 동작은 이전과 동일.
- PR #312(#307): `fetchAllPaged`가 `pageDelayMs` 대기 후 시간 예산을 재확인하도록 가드 추가(당시 `pageDelayMs`가 항상 0이라 도달 불가 경로였음).
- 이슈 #210 본문 코멘트(katalsye)로 잔여 범위를 재확인: PR #264 리뷰에서 지적된 두 가지 — **(1)** 상수를 env로 열어 실측값을 코드 변경 없이 넣을 수 있게 할 것, NaN·음수 입력 검증을 함께 넣을 것, **(2)** 루프 내 지연 하나로는 계정 단위 유량 제한 문제가 완전히 닫히지 않을 수 있다는 점(다른 호출 경로와의 겹침) — 이 남아 있었음.

이번 PR은 (1)을 구현한다. (2)는 실계좌 기반 실측 설계가 필요해 이 PR 범위 밖으로 남긴다.

## 변경 내용

- `mcp-trading/balance.js`: `readPageDelayMsEnv(name, fallback)`를 새로 추가해 export. `KIS_<name>` → `FINUS_KIS_<name>` 순으로 env를 읽고(기존 `KIS_TR_ID_*` 오버라이드와 동일한 두 접두사 관례), 미설정·빈 문자열이면 fallback을 그대로 쓴다. 값이 있는데 `Number.isFinite`가 아니거나 음수면 fallback으로 되돌리며 `console.error`(stderr)로 경고한다. `index.js`가 아니라 `balance.js`에 둔 이유는 `index.js`가 import 시점에 `StdioServerTransport`를 연결하는 부작용이 있어 단독 유닛 테스트로 import할 수 없기 때문(기존 `fetchAllPaged`/`fetchAllBalance`도 같은 이유로 여기 있음).
- `mcp-trading/index.js`: `DAILY_CCLD_PAGE_DELAY_MS`, `BALANCE_RLZ_PL_PAGE_DELAY_MS`를 하드코딩 `0`에서 `readPageDelayMsEnv("...", 0)`로 교체. **기본값은 그대로 0** — env를 아무것도 설정하지 않으면 이전과 완전히 동일하게 동작한다. `fetchAllBalance`는 이 PR에서도 손대지 않았고 여전히 `pageDelayMs`를 넘기지 않는다(PR #200 수용 기준 승계).

## 게이트 — KIS 유량 제한 문서 조사 결과 (미확인 포함)

실계좌가 없어 실측은 이 PR에서도 불가능하다. `document-specialist` 서브에이전트로 공식 문서를 조사했다:

- **확인(공식)**: 한국투자증권 공식 GitHub([koreainvestment/open-trading-api](https://github.com/koreainvestment/open-trading-api) README)에 오류 코드 `EGW00201`("초당 거래건수 초과")이 명시돼 있다. 같은 문서가 "모의투자 계좌는 REST API 호출 제한이 낮으니 연속 호출이 많으면 실전투자 계좌를 권장"한다고 정성적으로 밝힌다. 접근토큰 재발급은 "1분당 1회"로 제한된다고도 명시(수치 확인됨, 페이지 지연과는 별개 제한).
- **반공식**: 실전투자 "표준 20 TPS" 수치는 언론 보도(서울경제 영문판, KIS의 Open API 완화 캠페인 기사)에서만 확인했고 apiportal.koreainvestment.com 원문에서 직접 인용하지 못했다.
- **미확인**: 모의투자의 구체적 TPS 수치, 제한 단위(계좌/앱키/TR ID 중 무엇인지)는 공식 문서에서 끝내 확인하지 못했다.
- **미확인**: `backend/telegram_commands.py`의 `WATCH_LIST_QUOTE_DELAY_SECONDS = 1.1`(`/watch list` 종목당 지연)의 산출 근거. git blame으로 도입 커밋(`742fa8a`, "fix: 관심종목 현재가 조회 간격 추가")까지 추적했으나 커밋 메시지·코드 어디에도 1.1초의 근거가 없다. 다른 TR(시세 조회)이기도 해 조회 연속조회(`inquire-daily-ccld`/`inquire-balance-rlz-pl`)에 그대로 가져다 쓸 근거도 못 된다.

**결론**: 근거가 정성적 수준(공식 문서에 구체 TPS 수치 없음)이라 이번 PR에서 기본값을 바꾸지 않는다. 근거는 `mcp-trading/index.js`의 `DAILY_CCLD_PAGE_DELAY_MS` 주석에 그대로 남겼다. 실측치 또는 확정 TPS 문서가 나오면 코드 변경 없이 env만 설정하면 된다.

## 검증

```
cd mcp-trading && npm install && npm test
```

결과: **183 passed, 0 failed**(기존 174 + 신규 9). 신규 테스트(`tests/page-delay-ms-env.test.js`): 미설정/빈 문자열 시 fallback 유지(회귀 가드), `KIS_`/`FINUS_KIS_` 두 접두사와 우선순위, `0` 허용, NaN·음수·`Infinity` 거부 후 fallback 복귀, 경고가 `console.error`(stderr)로만 나가고 `console.log`(stdout, MCP JSON-RPC 채널)로 새지 않는지 검증.

기존 `fetchAllBalance` 회귀 가드 테스트("regression guard for issues #210, #306", `balance.test.js`)도 그대로 통과 — 이번 PR도 `fetchAllBalance`를 건드리지 않아 동작 불변.

## 잔여 범위

- 실측 자체(KIS 유량 제한 임계값 확정)는 실계좌가 필요해 여전히 불가능. 이 env 경로가 준비돼 있으니 실계좌 접근이 생기면 코드 변경 없이 값만 넣고 배포하면 된다.
- 이슈 코멘트가 지적한 "루프 내 지연 하나로는 계정 단위 유량 제한이 완전히 닫히지 않을 수 있다"(다른 호출 경로와의 시간적 겹침) 문제는 이 PR 범위 밖으로 남긴다.

`Refs #210` — 실측이 남아 있어 이슈를 완결하지 않는다.