### PR TITLE
feat: 영숫자·9자 종목코드 주문 가드를 플래그 뒤에서 완화한다 (#138)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,15 @@ KIS_ORDER_ENV=demo
 #  Docker를 쓰지 않는 로컬 실행에서는 mcp-trading이 .env를 직접 읽어 이미 적용됐습니다 — #129에서 통일)
 KIS_REAL_ORDER_ENABLED=false
 
+# 영숫자·9자 종목코드(ETN 7자, 신형우선주 0001A0, 펀드 F70100026 등) 주문 가드 완화(#138).
+# 미설정(기본값)이면 숫자 6~7자만 주문 대상입니다 — #73 정책 그대로입니다.
+# 주의: 모의투자 전용입니다. KIS Open API가 이 코드들을 order-cash TR에서 실제로
+# 수용하는지는 아직 미확인이고(ETN 7자만 문서 근거, #265), 실전에서 켜면 브로커
+# 응답으로만 판정이 납니다. #265 7장 실측 절차를 KIS_URL=openapivts... 환경에서
+# 돌릴 때만 켜세요. 정확히 "true" 문자열만 켠 것으로 인정합니다("True"는 꺼짐).
+# 값은 backend와 mcp-trading 두 계층이 함께 읽습니다(KIS_ 접두사로 자식 프로세스에 전달).
+# KIS_ALNUM_STOCK_ORDER_ENABLED=true
+
 # KIS OAuth 토큰 캐시(선택). 미설정 시 mcp-trading이 OS 임시 디렉터리(os.tmpdir())에
 # KIS_URL·API 키 해시별 JSON 파일을 만듭니다. 고정 경로가 필요할 때만 설정하세요.
 # 같은 디렉터리에 <이 경로>.lock 락 파일이 잠시 생겼다 사라집니다 - 동시에 뜬

--- a/backend/stock_code.py
+++ b/backend/stock_code.py
@@ -5,6 +5,7 @@ services.py와 telegram_commands.py가 각자 중복 구현하던 정규식과 �
 """
 import json
 import logging
+import os
 import re
 from pathlib import Path
 
@@ -75,7 +76,50 @@ _STOCK_CODE_RE = re.compile(r"\A(?:[0-9A-Z]{6,7}|[0-9A-Z]{9})\Z")
 #
 # `\d`는 파이썬에서 전각 숫자까지 매치하므로 JS의 ASCII 전용 `\d`와 어긋나지 않도록
 # `[0-9]`로 명시한다. 앵커를 패턴에 넣어 order.js와 형태를 맞춘다.
+#
+# 기본값(이 상수)은 유지한다 — KIS Open API가 영숫자 PDNO를 order-cash TR에서 실제로
+# 수용하는지는 #265 조사에서도 확정되지 않았다("ETN 7자는 order_cash.py 스펙 문구상
+# 근거 있음, 9자 펀드·영숫자 6자 신형우선주·신주인수권은 미확인, 전부 문서 근거일 뿐
+# 실호출 확인은 아님"). 실계좌 없이는 판정할 수 없으므로 가드를 무조건 열지 않고
+# KIS_ALNUM_STOCK_ORDER_ENABLED 플래그 뒤에 둔다 — 아래 is_orderable_stock_code()가
+# 실제 판정 진입점이며, 이 상수는 그 함수의 "플래그 꺼짐(기본값)" 분기에서만 쓰인다.
 _ORDERABLE_STOCK_CODE_RE = re.compile(r"\A[0-9]{6,7}\Z")
+
+# 플래그가 켜졌을 때(KIS_ALNUM_STOCK_ORDER_ENABLED=true) 허용하는 범위. _STOCK_CODE_RE
+# (입력이 코드 형태인지 판정하는 정규식)와 같은 길이 분포(6·7·9자, 8자는 마스터에
+# 0건이라 제외)를 쓴다. mcp-trading/order.js의 플래그 켜짐 분기와 형태를 맞춘다.
+_ORDERABLE_STOCK_CODE_ALNUM_RE = re.compile(r"\A(?:[0-9A-Z]{6,7}|[0-9A-Z]{9})\Z")
+
+
+def _alnum_stock_order_enabled() -> bool:
+    """영숫자·9자 코드 주문 가드 완화 플래그(#138).
+
+    매 호출 os.environ을 다시 읽는다 — 모듈 임포트 시점에 한 번만 굳히면 테스트가
+    monkeypatch.setenv로 설정해도 이미 굳은 값을 바꾸지 못한다.
+    mcp-trading/order.js의 `process.env.KIS_ALNUM_STOCK_ORDER_ENABLED === "true"`와
+    비교 방식을 맞춘다 — 정확히 "true" 문자열만 켠 것으로 인정하고 대소문자·공백은
+    관용하지 않는다. 두 계층이 같은 값에 같은 판정을 내려야 한쪽만 열리는 사고를
+    막을 수 있다.
+    """
+    return os.environ.get("KIS_ALNUM_STOCK_ORDER_ENABLED", "") == "true"
+
+
+def is_orderable_stock_code(code: str) -> bool:
+    """code(이미 upper() 정규화된 값)가 현재 정책상 주문 가능한 형태인지 판정합니다.
+
+    telegram_commands.py의 주문 준비 경로가 이 함수로 mcp-trading/order.js의
+    buildCashOrderBody() 가드를 미리 복제해, 조기 거절로 시세·잔고 조회와 60초 대기
+    슬롯 낭비를 막는다(#73).
+
+    ⚠️  결합 유지 필수: 이 함수와 mcp-trading/order.js:77-84(+ 플래그 분기)는 쌍을
+        이루므로 한쪽만 바꾸면 그 계층에서 조용히 계속 막힌다. 플래그를 켤 때는 두
+        계층에 같은 KIS_ALNUM_STOCK_ORDER_ENABLED 값을 넣어야 한다 — mcp-trading은
+        backend가 띄우는 자식 프로세스라 config._MCP_ENV_ALLOWED_PREFIXES의 KIS_
+        접두사 통과 목록을 통해 같은 값을 그대로 물려받는다.
+    """
+    if _alnum_stock_order_enabled():
+        return bool(_ORDERABLE_STOCK_CODE_ALNUM_RE.fullmatch(code))
+    return bool(_ORDERABLE_STOCK_CODE_RE.fullmatch(code))
 
 
 # ──────────────────────────────────────────────────────────────────────────

--- a/backend/stock_code.py
+++ b/backend/stock_code.py
@@ -82,12 +82,17 @@ _STOCK_CODE_RE = re.compile(r"\A(?:[0-9A-Z]{6,7}|[0-9A-Z]{9})\Z")
 # 근거 있음, 9자 펀드·영숫자 6자 신형우선주·신주인수권은 미확인, 전부 문서 근거일 뿐
 # 실호출 확인은 아님"). 실계좌 없이는 판정할 수 없으므로 가드를 무조건 열지 않고
 # KIS_ALNUM_STOCK_ORDER_ENABLED 플래그 뒤에 둔다 — 아래 is_orderable_stock_code()가
-# 실제 판정 진입점이며, 이 상수는 그 함수의 "플래그 꺼짐(기본값)" 분기에서만 쓰인다.
+# 텔레그램 주문 경로의 판정 진입점이며, 이 상수는 그 함수의 "플래그 꺼짐(기본값)"
+# 분기에서, 그리고 order_assist.check_orderable_code()에서 쓰인다. 후자는 플래그와
+# 무관하게 이 상수를 직접 참조한다(아래 ⚠️ 블록 3번째 복제본 항목 참조).
 _ORDERABLE_STOCK_CODE_RE = re.compile(r"\A[0-9]{6,7}\Z")
 
 # 플래그가 켜졌을 때(KIS_ALNUM_STOCK_ORDER_ENABLED=true) 허용하는 범위. _STOCK_CODE_RE
 # (입력이 코드 형태인지 판정하는 정규식)와 같은 길이 분포(6·7·9자, 8자는 마스터에
 # 0건이라 제외)를 쓴다. mcp-trading/order.js의 플래그 켜짐 분기와 형태를 맞춘다.
+# _STOCK_CODE_RE와 패턴이 바이트 단위로 같지만 의도적으로 분리해 둔다 — 하나는 "입력이
+# 코드 형태인가", 다른 하나는 "주문을 받을 범위인가"로 역할이 다르고, 한쪽이 바뀌어도
+# 다른 쪽이 따라갈 이유가 없다(별칭으로 묶으면 그 구분이 사라진다).
 _ORDERABLE_STOCK_CODE_ALNUM_RE = re.compile(r"\A(?:[0-9A-Z]{6,7}|[0-9A-Z]{9})\Z")
 
 
@@ -116,6 +121,14 @@ def is_orderable_stock_code(code: str) -> bool:
         계층에 같은 KIS_ALNUM_STOCK_ORDER_ENABLED 값을 넣어야 한다 — mcp-trading은
         backend가 띄우는 자식 프로세스라 config._MCP_ENV_ALLOWED_PREFIXES의 KIS_
         접두사 통과 목록을 통해 같은 값을 그대로 물려받는다.
+
+        3번째 복제본이 하나 더 있다: order_assist.check_orderable_code()가
+        _ORDERABLE_STOCK_CODE_RE를 직접 참조한다(자동 제안 경로의 하드 한도 판정).
+        이건 의도된 비대칭이다 — 플래그를 켜도 자동 제안은 숫자 6~7자만 낸다.
+        사람이 명시적으로 입력한 코드와 달리 봇이 스스로 고른 종목은 KIS 수용
+        여부가 확정될 때까지(#265 실측) 기존 범위에 묶어 둔다.
+        test_order_assist.py의 "플래그 켜짐에서도 제안 경로는 숫자만" 테스트가 이
+        비대칭을 고정한다.
     """
     if _alnum_stock_order_enabled():
         return bool(_ORDERABLE_STOCK_CODE_ALNUM_RE.fullmatch(code))

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -75,10 +75,10 @@ from .trading_orders import (
     order_reply_markup,
 )
 from .stock_code import (
-    _ORDERABLE_STOCK_CODE_RE,
     _STOCK_CODE_EXTRACT_RE,
     _is_unresolved_echo,
     extract_stock_name,
+    is_orderable_stock_code,
 )
 from .order_assist import ProposalTrigger, parse_current_price, run_order_assist
 
@@ -1321,10 +1321,11 @@ class TelegramCommandHandler:
                 )
                 return
             # 추출 성공 != 주문 가능. mcp-trading/order.js의 buildCashOrderBody()가
-            # 숫자 코드만 주문을 받으므로(#73에서 확정된 정책), 시세·잔고 조회와 60초
-            # 대기 슬롯을 쓰기 전에 여기서 끊는다. 이 검사가 없으면 /confirm 이후에야
-            # 같은 사유로 실패한다.
-            if not _ORDERABLE_STOCK_CODE_RE.fullmatch(stock_code):
+            # 기본값으로는 숫자 코드만 주문을 받으므로(#73에서 확정된 정책, #138에서
+            # KIS_ALNUM_STOCK_ORDER_ENABLED 플래그로 완화 가능해짐), 시세·잔고 조회와
+            # 60초 대기 슬롯을 쓰기 전에 여기서 끊는다. 이 검사가 없으면 /confirm
+            # 이후에야 같은 사유로 실패한다.
+            if not is_orderable_stock_code(stock_code):
                 # 사용자가 입력한 건 종목명인데 거절 사유는 종목코드 형태다.
                 # 코드를 함께 보여주지 않으면 인과가 보이지 않는다.
                 # 조사(은/는)는 코드 끝자리 받침에 따라 갈리므로 아예 쓰지 않는다.

--- a/backend/tests/test_order_assist.py
+++ b/backend/tests/test_order_assist.py
@@ -301,6 +301,28 @@ def test_plain_numeric_code_passes_when_not_blacklisted():
     assert check_orderable_code("005930", frozenset({"035420"})) is None
 
 
+def test_suggestion_path_stays_numeric_only_even_when_alnum_flag_is_on(monkeypatch):
+    """자동 제안 경로는 KIS_ALNUM_STOCK_ORDER_ENABLED=true에서도 숫자 코드만 낸다.
+
+    의도된 비대칭이다(#138) — 텔레그램 주문 경로는 stock_code.is_orderable_stock_code()를
+    거쳐 플래그를 따르지만, check_orderable_code()는 _ORDERABLE_STOCK_CODE_RE를 직접
+    참조해 봇이 스스로 고른 종목을 기존 범위(숫자 6~7자)에 묶어 둔다. KIS가 영숫자·9자
+    PDNO를 실제로 수용하는지 확정되기 전(#265 실측)까지 유지한다.
+    나중에 이 비대칭을 없앨 때는 이 테스트를 함께 지워야 한다 — 조용히 갈리지 않도록
+    여기서 고정한다.
+    """
+    monkeypatch.setenv("KIS_ALNUM_STOCK_ORDER_ENABLED", "true")
+
+    for code in ("0001A0", "F70100026", "Q500020"):
+        violation = check_orderable_code(code, frozenset())
+
+        assert violation is not None, f"{code}는 플래그 켜짐에서도 제안 경로에서 거절돼야 한다"
+        assert violation.code == "unorderable_code"
+
+    # 대조군: 숫자 코드는 플래그와 무관하게 통과한다(테스트가 전부를 거절하는 게 아님).
+    assert check_orderable_code("005930", frozenset()) is None
+
+
 # ---------------------------------------------------------------------------
 # 제안 / 스냅샷 파싱
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_stock_code.py
+++ b/backend/tests/test_stock_code.py
@@ -17,6 +17,7 @@ from backend.stock_code import (
     _is_unresolved_echo,
     _looks_like_stock_code,
     _master_stocks_path,
+    is_orderable_stock_code,
 )
 
 # 종목마스터 실제 데이터(4,353종 전수) — 판정 함수가 이름·별칭을 코드로 오인하지
@@ -198,6 +199,51 @@ class TestOrderableStockCodeRe:
         Python의 `\d`는 전각 숫자를 포함하므로 `[0-9]`로 명시한 이유를 고정한다.
         """
         assert not _ORDERABLE_STOCK_CODE_RE.fullmatch("００５９３０")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# is_orderable_stock_code — KIS_ALNUM_STOCK_ORDER_ENABLED 플래그 분기 (#138)
+# 미설정(기본값)은 _ORDERABLE_STOCK_CODE_RE와 동일해야 하고, "true"일 때만
+# mcp-trading/order.js의 확장 가드(영숫자 6~7자·9자)와 같은 범위를 허용해야 한다.
+# ──────────────────────────────────────────────────────────────────────────
+
+class TestIsOrderableStockCode:
+    """뮤테이션: 플래그 분기를 무력화(항상 확장 정규식 사용 등)하면
+    test_flag_unset_matches_default_policy가 red가 된다.
+    """
+
+    def test_flag_unset_matches_default_policy(self, monkeypatch):
+        """플래그 미설정 시 #73 정책(숫자 6~7자만)을 그대로 유지한다."""
+        monkeypatch.delenv("KIS_ALNUM_STOCK_ORDER_ENABLED", raising=False)
+        assert is_orderable_stock_code("005930")
+        assert is_orderable_stock_code("1234567")
+        assert not is_orderable_stock_code("0001A0")
+        assert not is_orderable_stock_code("F70100026")
+
+    def test_flag_false_matches_default_policy(self, monkeypatch):
+        monkeypatch.setenv("KIS_ALNUM_STOCK_ORDER_ENABLED", "false")
+        assert not is_orderable_stock_code("0001A0")
+        assert not is_orderable_stock_code("F70100026")
+
+    def test_flag_true_allows_alphanumeric_and_nine_char_codes(self, monkeypatch):
+        """플래그를 켜면 order.js 확장 가드와 같은 범위(6~7자 영숫자, 9자)를 연다."""
+        monkeypatch.setenv("KIS_ALNUM_STOCK_ORDER_ENABLED", "true")
+        assert is_orderable_stock_code("005930")
+        assert is_orderable_stock_code("1234567")
+        assert is_orderable_stock_code("0001A0")
+        assert is_orderable_stock_code("Q500020")
+        assert is_orderable_stock_code("F70100026")
+
+    def test_flag_true_still_rejects_eight_char(self, monkeypatch):
+        """8자는 종목마스터에 0건이라 플래그를 켜도 계속 거절한다(#140과 동일 근거)."""
+        monkeypatch.setenv("KIS_ALNUM_STOCK_ORDER_ENABLED", "true")
+        assert not is_orderable_stock_code("12345678")
+
+    def test_flag_value_must_match_exactly(self, monkeypatch):
+        """대소문자·공백을 관용하면 mcp-trading/order.js(`=== "true"`)와 판정이
+        갈릴 수 있다 — 정확히 "true"만 인정한다."""
+        monkeypatch.setenv("KIS_ALNUM_STOCK_ORDER_ENABLED", "True")
+        assert not is_orderable_stock_code("0001A0")
 
 
 # ──────────────────────────────────────────────────────────────────────────

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -1488,6 +1488,56 @@ async def test_order_command_rejects_unorderable_stock_code_before_quote_and_bal
     assert _orders(handler) == {}
 
 
+@pytest.mark.parametrize(
+    "stock_name, resolved, stock_code",
+    [
+        ("덕양에너젠", "덕양에너젠 (0001A0, KOSDAQ)", "0001A0"),
+        (
+            "한투글로벌넥스트웨이브1(A)",
+            "한투글로벌넥스트웨이브1(A) (F70100026, KOSPI)",
+            "F70100026",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_order_command_allows_alnum_stock_code_when_flag_enabled(
+    stock_name, resolved, stock_code, monkeypatch
+):
+    """KIS_ALNUM_STOCK_ORDER_ENABLED=true면 영숫자·9자 코드도 시세·잔고 조회까지 간다.
+
+    #138: KIS Open API의 실제 PDNO 수용 여부가 실계좌 없이는 확정되지 않아(#265),
+    기본값은 위 test_order_command_rejects_unorderable_stock_code_before_quote_and_balance가
+    고정하는 거절을 유지하고, 이 플래그를 켰을 때만 조회까지 통과함을 별도로 고정한다.
+    실제 주문 수용 여부는 mcp-trading/order.js의 buildCashOrderBody()·KIS 응답이
+    결정하므로 여기서는 백엔드가 더 이상 조기 차단하지 않는다는 것만 확인한다.
+    """
+    monkeypatch.setenv("KIS_ALNUM_STOCK_ORDER_ENABLED", "true")
+
+    async def mcp_runner(server_params, tool_name, arguments):
+        if tool_name == "resolve_stock_code":
+            return resolved
+        if tool_name == "get_stock_quote":
+            return "현재가: 1,000원"
+        if tool_name == "get_balance":
+            return "주문가능금액: 1,000,000원"
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": f"/buy {stock_name} 10"}}
+    )
+
+    assert _orders(handler)["123"].stock_code == stock_code
+    assert "주문 확인" in notifier.messages[-1]
+    assert "주문을 지원하지 않습니다" not in notifier.messages[-1]
+
+
 @pytest.mark.asyncio
 async def test_cancel_removes_pending_order():
     async def mcp_runner(server_params, tool_name, arguments):
@@ -1604,7 +1654,7 @@ async def test_buy_with_unresolved_echo_is_rejected(code):
     주문 경로만 통과하던 비대칭을 없앤다.
 
     뮤테이션: _is_unresolved_echo 가드를 지우면 999999가 대기 주문으로 등록돼 red가
-    된다(ZZZZ99·Q999999는 영숫자라 _ORDERABLE_STOCK_CODE_RE가 뒤에서 잡지만, 거절
+    된다(ZZZZ99·Q999999는 영숫자라 is_orderable_stock_code가 뒤에서 잡지만, 거절
     사유가 "ETN·펀드"로 바뀌므로 메시지 단정에서 red가 된다).
     """
 

--- a/mcp-trading/order.js
+++ b/mcp-trading/order.js
@@ -92,7 +92,12 @@ export function buildCashOrderBody({ accountNo, stockCode, quantity, price, orde
   if (isAlnumStockOrderEnabled()) {
     // 플래그 켜짐: 영숫자 6~7자·9자를 연다(8자는 종목마스터에 0건이라 제외, #140과
     // 같은 근거). KIS PDNO 실제 수용 여부는 이 가드를 통과한 뒤 KIS 응답으로 결정된다.
-    if (!/^(?:[0-9A-Z]{6,7}|[0-9A-Z]{9})$/i.test(code)) {
+    // `/i`를 달면 안 된다 — 짝인 backend/stock_code.py의 _ORDERABLE_STOCK_CODE_ALNUM_RE는
+    // IGNORECASE가 없어 소문자를 거절하므로, 여기만 관용하면 같은 값에 두 계층이 다른
+    // 판정을 내리고 소문자 그대로 PDNO에 실린다(index.js는 upper 정규화를 하지 않는다).
+    // 기본값 분기는 결정 가드가 /^\d{6,7}$/라 대소문자가 무의미했다 — 이 분기에서만
+    // 생기는 갈림이다.
+    if (!/^(?:[0-9A-Z]{6,7}|[0-9A-Z]{9})$/.test(code)) {
       throw new Error("stock_code는 6~7자 영숫자 또는 9자 코드여야 합니다.");
     }
   } else {

--- a/mcp-trading/order.js
+++ b/mcp-trading/order.js
@@ -30,6 +30,20 @@ function assertPositiveInteger(value, fieldName) {
   return number;
 }
 
+// 영숫자·9자 코드 주문 가드 완화 플래그(#138). KIS Open API가 영숫자 PDNO(ETN 7자·
+// 9자 펀드 등)를 order-cash TR에서 실제로 수용하는지는 docs/issue-138-alnum-stock-code.md
+// (#265)에서도 "ETN 7자는 문서 근거 있음, 나머지는 미확인, 전부 실호출 확인은 아님"으로
+// 결론났다 — 실계좌 없이는 확정할 수 없으므로 가드를 무조건 열지 않는다. 미설정 시
+// 현행(숫자 6~7자만) 유지, "true"로 설정하면 아래 buildCashOrderBody()가 영숫자·9자
+// 코드를 통과시켜 실계좌/모의투자에서 실측할 수 있게 한다.
+// backend/stock_code.py의 _alnum_stock_order_enabled()와 비교 방식을 맞춘다 — 정확히
+// "true" 문자열만 켠 것으로 인정한다(대소문자·공백 관용 없음). mcp-trading은 backend가
+// 띄우는 자식 프로세스라 config._MCP_ENV_ALLOWED_PREFIXES의 KIS_ 접두사 통과 목록을
+// 통해 같은 값을 그대로 물려받는다.
+function isAlnumStockOrderEnabled() {
+  return process.env.KIS_ALNUM_STOCK_ORDER_ENABLED === "true";
+}
+
 export function selectCashOrderTrId({ orderEnv, side }) {
   const env = normalizeOrderEnv(orderEnv);
   const normalizedSide = normalizeSide(side);
@@ -70,19 +84,28 @@ export function buildCashOrderBody({ accountNo, stockCode, quantity, price, orde
   if (account.length < 10) {
     throw new Error("KIS_ACCOUNT_NO가 올바르지 않습니다. 계좌번호 앞 8자리와 상품코드 2자리를 붙여 설정하세요.");
   }
-  // 아래 두 가드가 함께 "숫자 6~7자만 주문 가능"이라는 하나의 정책을 이룬다.
-  // 첫 번째는 영숫자 코드(0001A0 등)에 전용 메시지를 주기 위한 것이고, 실제로 범위를
-  // 확정하는 건 두 번째다. 9자 펀드코드(F70100026)는 첫 번째에 매치조차 되지 않고
-  // 두 번째에서 거절된다.
-  if (/^[0-9A-Z]{6,7}$/i.test(code) && !/^\d{6,7}$/.test(code)) {
-    throw new Error("이 종목은 현재 주문을 지원하지 않습니다.");
-  }
-  // 이 범위가 backend/stock_code.py의 _ORDERABLE_STOCK_CODE_RE(`\A[0-9]{6,7}\Z`)와
-  // 쌍을 이룬다. 백엔드가 같은 정책을 복제해 조기 거절하므로, 영숫자 코드 주문 지원을
-  // 검토할 때(#138) 위 두 가드와 백엔드 상수를 **모두** 함께 바꿔야 한다. 하나라도 남기면
-  // 그 계층에서 조용히 계속 막힌다.
-  if (!/^\d{6,7}$/.test(code)) {
-    throw new Error("stock_code는 6자리 또는 7자리 종목코드여야 합니다.");
+  // 이 범위가 backend/stock_code.py의 is_orderable_stock_code()(_ORDERABLE_STOCK_CODE_RE /
+  // _ORDERABLE_STOCK_CODE_ALNUM_RE)와 쌍을 이룬다. 백엔드가 같은 정책을 복제해 조기
+  // 거절하므로, 아래 두 분기(기본값·플래그 켜짐) 중 하나라도 단독으로 바꾸면 그 계층에서
+  // 조용히 계속 막힌다(#138) — KIS_ALNUM_STOCK_ORDER_ENABLED 값을 두 계층에 함께 넣어야
+  // 한다.
+  if (isAlnumStockOrderEnabled()) {
+    // 플래그 켜짐: 영숫자 6~7자·9자를 연다(8자는 종목마스터에 0건이라 제외, #140과
+    // 같은 근거). KIS PDNO 실제 수용 여부는 이 가드를 통과한 뒤 KIS 응답으로 결정된다.
+    if (!/^(?:[0-9A-Z]{6,7}|[0-9A-Z]{9})$/i.test(code)) {
+      throw new Error("stock_code는 6~7자 영숫자 또는 9자 코드여야 합니다.");
+    }
+  } else {
+    // 기본값(#73): 아래 두 가드가 함께 "숫자 6~7자만 주문 가능"이라는 하나의 정책을
+    // 이룬다. 첫 번째는 영숫자 코드(0001A0 등)에 전용 메시지를 주기 위한 것이고,
+    // 실제로 범위를 확정하는 건 두 번째다. 9자 펀드코드(F70100026)는 첫 번째에
+    // 매치조차 되지 않고 두 번째에서 거절된다.
+    if (/^[0-9A-Z]{6,7}$/i.test(code) && !/^\d{6,7}$/.test(code)) {
+      throw new Error("이 종목은 현재 주문을 지원하지 않습니다.");
+    }
+    if (!/^\d{6,7}$/.test(code)) {
+      throw new Error("stock_code는 6자리 또는 7자리 종목코드여야 합니다.");
+    }
   }
 
   return {

--- a/mcp-trading/tests/order.test.js
+++ b/mcp-trading/tests/order.test.js
@@ -179,6 +179,22 @@ test(
       }),
       /stock_code는 6~7자 영숫자 또는 9자 코드여야 합니다/,
     );
+    // 소문자는 플래그를 켜도 거절한다 — 짝인 backend/stock_code.py의
+    // _ORDERABLE_STOCK_CODE_ALNUM_RE가 IGNORECASE 없이 [0-9A-Z]만 받으므로, 여기서
+    // 관용하면 같은 값에 두 계층의 판정이 갈리고 소문자가 그대로 PDNO에 실린다.
+    for (const lowercased of ["0001a0", "f70100026", "q500020"]) {
+      assert.throws(
+        () => buildCashOrderBody({
+          accountNo: "1234567801",
+          stockCode: lowercased,
+          quantity: 1,
+          price: 10000,
+          orderType: "LIMIT",
+        }),
+        /stock_code는 6~7자 영숫자 또는 9자 코드여야 합니다/,
+        `${lowercased}는 플래그 켜짐에서도 거절해야 한다(backend와 짝맞춤)`,
+      );
+    }
   },
 );
 

--- a/mcp-trading/tests/order.test.js
+++ b/mcp-trading/tests/order.test.js
@@ -122,6 +122,91 @@ test("buildCashOrderBody rejects alphanumeric stock codes as unsupported order t
   );
 });
 
+test("buildCashOrderBody rejects nine-char fund codes as unsupported order targets", () => {
+  assert.throws(
+    () => buildCashOrderBody({
+      accountNo: "1234567801",
+      stockCode: "F70100026",
+      quantity: 1,
+      price: 10000,
+      orderType: "LIMIT",
+    }),
+    /stock_code는 6자리 또는 7자리 종목코드여야 합니다/,
+  );
+});
+
+test(
+  "buildCashOrderBody allows alphanumeric and nine-char codes when KIS_ALNUM_STOCK_ORDER_ENABLED=true (#138)",
+  (t) => {
+    const originalEnvValue = process.env.KIS_ALNUM_STOCK_ORDER_ENABLED;
+    t.after(() => {
+      if (originalEnvValue === undefined) {
+        delete process.env.KIS_ALNUM_STOCK_ORDER_ENABLED;
+      } else {
+        process.env.KIS_ALNUM_STOCK_ORDER_ENABLED = originalEnvValue;
+      }
+    });
+    process.env.KIS_ALNUM_STOCK_ORDER_ENABLED = "true";
+
+    assert.equal(
+      buildCashOrderBody({
+        accountNo: "1234567801",
+        stockCode: "0001A0",
+        quantity: 1,
+        price: 10000,
+        orderType: "LIMIT",
+      }).PDNO,
+      "0001A0",
+    );
+    assert.equal(
+      buildCashOrderBody({
+        accountNo: "1234567801",
+        stockCode: "F70100026",
+        quantity: 1,
+        price: 10000,
+        orderType: "LIMIT",
+      }).PDNO,
+      "F70100026",
+    );
+    // 8자는 종목마스터에 0건이라 플래그를 켜도 계속 거절한다(#140과 같은 근거).
+    assert.throws(
+      () => buildCashOrderBody({
+        accountNo: "1234567801",
+        stockCode: "12345678",
+        quantity: 1,
+        price: 10000,
+        orderType: "LIMIT",
+      }),
+      /stock_code는 6~7자 영숫자 또는 9자 코드여야 합니다/,
+    );
+  },
+);
+
+test("buildCashOrderBody keeps rejecting alphanumeric codes when the flag is not exactly \"true\"", (t) => {
+  const originalEnvValue = process.env.KIS_ALNUM_STOCK_ORDER_ENABLED;
+  t.after(() => {
+    if (originalEnvValue === undefined) {
+      delete process.env.KIS_ALNUM_STOCK_ORDER_ENABLED;
+    } else {
+      process.env.KIS_ALNUM_STOCK_ORDER_ENABLED = originalEnvValue;
+    }
+  });
+  // backend/stock_code.py의 _alnum_stock_order_enabled()와 비교 방식을 맞춘다 —
+  // 대소문자·공백을 관용하면 두 계층의 판정이 갈릴 수 있다.
+  process.env.KIS_ALNUM_STOCK_ORDER_ENABLED = "True";
+
+  assert.throws(
+    () => buildCashOrderBody({
+      accountNo: "1234567801",
+      stockCode: "0001A0",
+      quantity: 1,
+      price: 10000,
+      orderType: "LIMIT",
+    }),
+    /이 종목은 현재 주문을 지원하지 않습니다/,
+  );
+});
+
 test("formatOrderResult includes order number when present", () => {
   assert.equal(
     formatOrderResult({


### PR DESCRIPTION
## 배경 — 잔여 범위 판정

이슈 #138은 이미 PR #265(조사·설계 문서, 실행 코드 변경 0줄)로 1차 처리됐다. #265가 확인한 현재 상태:

- 차단 지점은 `mcp-trading/order.js:77`(영숫자 6~7자), `order.js:84`(9자 전체), `backend/stock_code.py`의 `_ORDERABLE_STOCK_CODE_RE`(#227/#140에서 `telegram_commands.py`에서 이동) 세 곳.
- 조회·추출 계층(`resolve_stock_code`, `_extract_stock_code`, `_looks_like_stock_code` 등)은 #135·#140·#151·#174를 거치며 이미 6·7·9자를 전부 통과시킨다. 남은 범위는 **주문 가능 판정 두 곳(order.js·stock_code.py)**뿐이다.
- 이슈 본문의 파일:줄, 776종목 분해(영숫자 6자 312 신형우선주 23건 포함, 영숫자 7자 389 ETN, 9자 75 = 펀드 69 + 신주인수권 6)는 #265가 이미 재확인·정정했다.

## KIS API 게이트 — #265 결론을 따름 (재조사하지 않음)

#265가 KIS 공식 저장소 원문에서 확인한 것:

- `order_cash.py`의 `PDNO` 스펙 문구: "종목코드(6자리), ETN의 경우 7자리 입력" → **ETN 7자(389종목)가 order-cash 대상이라는 문서 근거**.
- 9자 펀드, 영숫자 6자(신형우선주 23건 포함), 신주인수권 6건은 **미확인**.
- 모든 근거가 "문서 근거이며 실호출 확인은 아님". 공식 API 포털은 봇 차단으로 접근 불가.
- #265는 사람이 모의투자 환경에서 대표 코드 5종을 실제로 `order-cash` 호출해 `rt_cd`·`msg1`을 확인하는 절차를 다음 단계로 남겼고, 아직 실행되지 않았다.

**즉 수용 여부가 문서로 완전히 확정되지 않았다.** 방침대로 가드를 무조건 열지 않고 `KIS_ALNUM_STOCK_ORDER_ENABLED` 환경변수 뒤에 뒀다:

- **미설정(기본값)**: #73 정책 그대로 — 숫자 6~7자만 주문 가능. 기존 동작 100% 불변.
- **`KIS_ALNUM_STOCK_ORDER_ENABLED=true`**: 영숫자 6~7자·9자(8자는 종목마스터 0건이라 제외)가 주문 경로를 통과 — 모의투자에서 #265가 남긴 실측 절차를 코드 우회 없이 바로 실행할 수 있게 한다. 실제 KIS 수용 여부는 여전히 브로커 응답이 최종 결정한다.

이 접근을 기본으로 삼았다 — ETN 하나만 문서 근거가 있고 나머지 카테고리는 미확인이므로, 전체 기본값을 여는 것은 근거가 부족하다고 판단했다.

## 변경한 파일

- `backend/stock_code.py`: `is_orderable_stock_code()` 신설. 플래그 꺼짐(기본값)은 기존 `_ORDERABLE_STOCK_CODE_RE`(숫자 6~7자)를, 켜짐은 `_ORDERABLE_STOCK_CODE_ALNUM_RE`(영숫자 6~7자 또는 9자)를 쓴다. 값 비교는 `mcp-trading/order.js`와 맞춰 정확히 `"true"` 문자열만 인정한다.
- `backend/telegram_commands.py`: `_ORDERABLE_STOCK_CODE_RE` 직접 참조를 `is_orderable_stock_code()` 호출로 교체. `backend/order_assist.py`는 그대로 뒀다 — 여전히 raw 정규식을 참조하므로 자동 제안 트리거는 플래그와 무관하게 기존 정책(숫자만)을 유지한다. 이 비대칭은 의도된 것이며, 리뷰 반영으로 `stock_code.py` 결합 주석에 3번째 복제본으로 명시하고 `test_order_assist.py`에 고정 테스트 1건을 넣었다. 회귀 없음(전체 backend 테스트 통과).
- `mcp-trading/order.js`: `buildCashOrderBody()`에 `isAlnumStockOrderEnabled()` 분기 추가. `index.js`를 건드릴 수 없어(소유권 밖) `order.js`가 `process.env.KIS_ALNUM_STOCK_ORDER_ENABLED`를 직접 읽는다.
- `backend/tests/test_stock_code.py`, `backend/tests/test_telegram_commands.py`, `mcp-trading/tests/order.test.js`: 기존 `0001A0` 거절 회귀 테스트는 유지한 채, 플래그 미설정·`"true"`·값 불일치(`"True"`) 세 경우를 각각 새 테스트로 추가.

## 검증

- `cd mcp-trading && npm test` → **175 passed / 1 failed**. 실패는 `tests/mcp-server.test.js`가 `@modelcontextprotocol/sdk`를 못 찾는 `ERR_MODULE_NOT_FOUND`(node_modules 미설치)로, 이번 변경과 무관한 기존 환경 문제임을 이 브랜치의 변경분 없이도 동일하게 재현해 확인했다.
- 백엔드: 로컬 `uv run`이 정책상 차단돼 있어, scratchpad에 `uv venv --python 3.13`로 별도 venv를 만들고 `uv pip install`로 `backend/pyproject.toml`(dev 그룹 포함) 의존성을 설치해 직접 실행했다 — `pytest backend/` → **1061 passed, 3 skipped**(스킵은 기존 상태와 동일).

## 미확인 게이트

KIS Open API가 영숫자·9자 `PDNO`를 order-cash TR에서 실제로 수용하는지는 여전히 미확인이다(ETN 7자만 문서 근거). `.env.example`에는 리뷰 반영으로 플래그를 문서화했다(주석 처리 1줄 + 모의투자 전용 경고). 실측 시 `KIS_ALNUM_STOCK_ORDER_ENABLED=true`를 모의투자 환경(`KIS_URL=openapivts...`)에만 설정하고, #265 문서 7장 절차(대표 코드 5종 + 대조군 `005930`, 지정가·현재가보다 낮은 가격, 시장가 금지)를 따를 것을 권한다.

Refs #138
