### PR TITLE
refactor(backend): Portfolio 동기화를 stock_code 기준 upsert로 전환 (#196 선행 조건)

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -8,10 +8,24 @@ class Portfolio(SQLModel, table=True):
     증권사 API(SSOT)의 데이터를 기반으로 동기화됩니다.
     """
     id: Optional[int] = Field(default=None, primary_key=True)
+    # unique=True가 아직 없다 (#196). scheduler._sync_portfolio_from_balance는
+    # stock_code 기준 upsert이므로 논리적으로는 코드당 1행이 불변식이고, 그 함수가
+    # 중복 행을 발견하면 한 행으로 수렴시킨다 — upsert의 정확성은 이 제약에
+    # 의존하지 않는다.
+    #
+    # 제약을 켜려면 스키마 마이그레이션이 필요하다: 이미 배포된 SQLite 파일에는
+    # 비유일 인덱스 ix_portfolio_stock_code가 이미 있고 create_all()은 기존
+    # 인덱스를 바꾸지 않으므로, DROP INDEX → 중복 행 정리 → CREATE UNIQUE INDEX
+    # 순서가 필요하다. database.py의 _PENDING_COLUMN_MIGRATIONS는 컬럼 추가
+    # 전용이라 이 형태를 담지 못한다. 중복 행을 지우지 않은 채 유니크 인덱스를
+    # 만들면 부팅이 영구 실패하므로, 별도 이슈에서 다룬다.
     stock_code: str = Field(index=True, description="종목 코드")
     stock_name: str = Field(description="종목명")
     quantity: int = Field(default=0, description="보유 수량")
     avg_price: float = Field(default=0.0, description="평균 매입가")
+    # 이 값을 채우는 프로덕션 경로는 아직 없다 — get_balance(inquire-balance,
+    # TTTC8434R) output1에 현재가 필드가 있는지가 실계좌 실측 전까지 미확인이다(#196).
+    # 경로가 생긴 뒤에도 잔고 동기화는 이 필드를 덮지 않는다(위 upsert 참고).
     current_price: Optional[float] = Field(default=None, description="현재가")
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="최근 업데이트 시간")
 

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -240,7 +240,7 @@ _BALANCE_TRUNCATION_MARKER = "조회가 중단되어"
 # 항상 출력한다. 따라서 이 마커가 없다는 것은 "보유 0건"이 아니라 "응답을 읽지 못함"이다.
 # run_mcp_tool은 MCP content가 비면 예외 대신 빈 문자열을 반환하므로(services.py),
 # 이 경로는 실재한다. _sync_portfolio_from_balance가 이 마커 부재를 계약 위반으로
-# 처리해 전량 교체를 막는다.
+# 처리해, 보유 0건으로 오인한 전 종목 삭제를 막는다.
 _BALANCE_HOLDINGS_MARKER = "[보유 종목 리스트]"
 
 
@@ -370,16 +370,27 @@ def _sync_portfolio_from_balance(
 ) -> int | None:
     """get_balance 응답을 바탕으로 Portfolio 테이블을 동기화합니다.
 
-    전략: 전량 교체 (기존 행 전체 삭제 후 신규 삽입). 매 잔고 조회마다 실행되어
-    보유하지 않게 된 종목을 자동으로 제거합니다.
+    전략: stock_code 기준 upsert (#196). 잔고에 있는 종목은 기존 행을 갱신하고,
+    없던 종목만 새로 삽입하며, 보유하지 않게 된 종목의 행은 삭제합니다. 매 잔고
+    조회마다 실행되므로 "잔고에서 사라진 종목은 제거된다"는 동작은 전량 교체
+    시절과 동일합니다.
 
-    잔고가 잘린 경우(is_balance_truncated) 전량 교체를 수행하면 아직 파악되지 않은
+    upsert여야 하는 이유는 **잔고 응답에 없는 필드를 보존**하기 위해서입니다.
+    전량 교체(DELETE + INSERT)는 그런 필드를 매 주기 기본값으로 되돌립니다.
+    지금은 current_price가 항상 null이라 관측되는 차이가 없지만, 이 이슈(#196)가
+    시세 조회를 붙이는 순간 10분 주기마다 값이 null로 덮여, PR #204가 도입한
+    price_known 플래그가 "시세를 채웠는데도 모름"으로 잘못 나가는 회귀가 됩니다.
+
+    잔고가 잘린 경우(is_balance_truncated) 동기화를 수행하면 아직 파악되지 않은
     보유 종목이 삭제될 수 있으므로, 동기화를 건너뛰고 기존 데이터를 보존합니다.
 
-    current_price는 get_balance(inquire-balance, TTTC8434R) output1에 현재가 필드가
-    없어 항상 null로 둡니다. null 수익률이 "실제 0%"와 혼동되지 않도록
-    /api/v1/portfolio 응답에서 return_rate: null로 구분됩니다(이슈 #122).
-    current_price 확보 방안은 후속 이슈를 참고하세요.
+    current_price는 이 함수가 **읽지도 쓰지도 않습니다.** get_balance(inquire-balance,
+    TTTC8434R) output1에 현재가 필드가 있는지가 **미확인**이기 때문입니다 — 실계좌
+    실측이 필요하며 저장소 안의 근거(balance-rlz-pl-report.js의 row.prpr)는 다른
+    TR(TTTC8494R)의 응답이라 증명이 되지 못합니다(#196). 그래서 신규 행은 모델
+    기본값 그대로 null이고, 기존 행의 값은 손대지 않은 채 보존됩니다.
+    null 수익률이 "실제 0%"와 혼동되지 않도록 /api/v1/portfolio 응답에서
+    return_rate: null로 구분됩니다(이슈 #122).
 
     holdings: 호출처에서 이미 _parse_balance_holdings를 실행한 경우 그 결과를 전달하면
     재파싱을 건너뜁니다. None이면 balance_text에서 직접 파싱합니다.
@@ -401,8 +412,9 @@ def _sync_portfolio_from_balance(
     # 마커가 없으면 "보유 0건"이 아니라 "응답을 읽지 못함"이다.
     # balance.js는 보유 종목이 없어도 마커와 "보유 종목이 없습니다."를 항상 출력한다
     # (balance.js:273-274). run_mcp_tool은 MCP content가 비면 예외 대신 ""를
-    # 반환하므로(services.py) 이 경로는 실재한다. 전량 교체는 되돌릴 수 없으므로
-    # 기존 데이터를 보존하고 error 로그로 운영자에게 알린다.
+    # 반환하므로(services.py) 이 경로는 실재한다. upsert로 바뀐 뒤에도 "잔고에 없는
+    # 종목은 삭제"는 그대로라 빈 응답으로 동기화하면 전 종목이 지워지고 되돌릴 수
+    # 없다. 기존 데이터를 보존하고 error 로그로 운영자에게 알린다.
     if _BALANCE_HOLDINGS_MARKER not in balance_text:
         logger.error(
             "잔고 응답에서 %r 섹션을 찾지 못해 Portfolio 동기화를 건너뜁니다 "
@@ -417,25 +429,64 @@ def _sync_portfolio_from_balance(
     if holdings is None:
         holdings = _parse_balance_holdings(balance_text)
 
-    # 전량 교체: 기존 행 전체 삭제
-    existing = session.exec(select(Portfolio)).all()
-    for row in existing:
-        session.delete(row)
-    session.flush()
+    # stock_code 기준 upsert (#196). 기존 행을 코드별로 모은다.
+    #
+    # dict[str, list[Portfolio]]인 이유: Portfolio.stock_code에 유일성 제약이 없어
+    # (models.py는 index=True만 선언한다) 같은 코드의 행이 둘 이상 존재할 수
+    # 있는 상태를 스키마가 막아주지 않는다. 첫 행만 갱신 대상으로 남기고 나머지는
+    # 아래에서 삭제해, 동기화가 돌 때마다 테이블이 "코드당 1행"으로 수렴한다.
+    # 이 정리가 없으면 upsert가 중복 중 어느 행을 갱신했는지에 따라 API 응답이
+    # 달라져 비결정적이 된다.
+    existing: dict[str, list[Portfolio]] = {}
+    for row in session.exec(select(Portfolio)).all():
+        existing.setdefault(row.stock_code, []).append(row)
 
-    # 신규 삽입
     now = datetime.now(timezone.utc)
+    seen: set[str] = set()
     for h in holdings:
-        session.add(Portfolio(
-            stock_code=h.code,
-            stock_name=h.name,
-            quantity=h.quantity,
-            avg_price=h.avg_price,
-            current_price=None,
-            updated_at=now,
-        ))
+        rows = existing.get(h.code)
+        if rows:
+            row = rows[0]
+            # 잔고 응답에서 온 필드만 갱신한다. current_price는 여기에 없으므로
+            # **건드리지 않는다** — 이것이 전량 교체 대신 upsert를 쓰는 이유다.
+            # 전량 교체였다면 이 이슈(#196)가 붙일 시세 조회 결과가 10분 주기마다
+            # null로 되돌아가고, PR #204가 도입한 price_known 플래그가 "시세를
+            # 채웠는데도 모름"으로 잘못 나가는 회귀가 된다.
+            row.stock_name = h.name
+            row.quantity = h.quantity
+            row.avg_price = h.avg_price
+        else:
+            # 신규 행. current_price를 넘기지 않으므로 모델 기본값 None이 된다 —
+            # 전량 교체 시절 명시적으로 current_price=None을 넘기던 것과 결과가 같다.
+            row = Portfolio(
+                stock_code=h.code,
+                stock_name=h.name,
+                quantity=h.quantity,
+                avg_price=h.avg_price,
+            )
+            session.add(row)
+            # 방금 만든 행도 existing에 등록한다. 한 응답 안에 같은 코드가 두 번
+            # 나오면(KIS output1은 pdno가 키라 정상 응답에서는 없는 일이지만
+            # 스키마가 막아주지 않는다) 등록하지 않을 경우 두 번째 항목이 또 하나의
+            # 새 행을 만들어, 이 함수가 스스로 중복을 만들어 낸다.
+            existing[h.code] = [row]
+        # updated_at은 값 변화와 무관하게 매번 갱신한다 — 전량 교체 시절과 같은
+        # 의미("잔고를 마지막으로 확인한 시각")를 유지하기 위해서다.
+        row.updated_at = now
+        seen.add(h.code)
 
+    # 보유하지 않게 된 종목 제거 + 코드 중복 행 정리(위 주석 참고).
+    # 전량 교체 시절의 "잔고에 없는 종목은 사라진다" 동작을 그대로 유지한다.
+    for code, rows in existing.items():
+        stale = rows if code not in seen else rows[1:]
+        for row in stale:
+            session.delete(row)
+
+    # 커밋 경계는 전량 교체 시절과 동일하다 — 한 동기화가 한 트랜잭션이고,
+    # 갱신·삽입·삭제가 함께 커밋되거나 함께 롤백된다.
     session.commit()
+    # 반환값은 동기화한 보유 종목 수(len(holdings))로 유지한다. 갱신/삽입을 나눠
+    # 세면 호출처(#229의 PORTFOLIO_UPDATE holdings_count)가 보는 값이 바뀐다.
     logger.info("Portfolio 동기화 완료: %d개 종목", len(holdings))
     return len(holdings)
 
@@ -744,15 +795,15 @@ async def _monitor_market_task(
             owned_stocks = [h.name for h in holdings]
 
             # Portfolio 테이블 동기화 — 잔고 조회 성공 시에만 실행.
-            # 잘린 잔고에서 전량 교체하면 보유 종목이 사라지므로,
+            # 잘린 잔고로 동기화하면 아직 못 읽은 보유 종목이 삭제되므로,
             # _sync_portfolio_from_balance가 내부에서 잘림을 감지해 건너뜁니다.
             # 동기화 실패는 감시 루프에 영향을 주지 않아야 하므로 예외를 격리합니다.
             try:
                 with Session(engine) as sync_session:
                     sync_result = _sync_portfolio_from_balance(balance_text, sync_session, holdings=holdings)
                 # 잘림·마커 부재로 동기화를 건너뛴 경우(None)에는 테이블이 그대로이므로
-                # 브로드캐스트하지 않는다. 동기화가 수행된 경우 전량 교체 특성상 내용이
-                # 직전과 동일해도 신호가 나간다 — 즉 정상 주기마다 1건이다.
+                # 브로드캐스트하지 않는다. 동기화가 수행된 경우 updated_at을 매번 갱신하는
+                # 특성상 내용이 직전과 동일해도 신호가 나간다 — 즉 정상 주기마다 1건이다.
                 # payload에는 보유 종목 개수만 싣고 종목명·수량 등 실제 보유 내역은 담지
                 # 않는다. WebSocket에는 인증이 없어(#266) 계좌 보유 현황이 인증 없는
                 # 채널로 유출될 수 있으므로, 신호만 보내고 클라이언트가

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -396,8 +396,10 @@ def _sync_portfolio_from_balance(
     재파싱을 건너뜁니다. None이면 balance_text에서 직접 파싱합니다.
     잘림·마커 가드는 holdings 인자 유무에 관계없이 항상 balance_text를 검사합니다.
 
-    반환값(이슈 #229): 동기화를 실제로 수행했으면 삽입한 종목 수(int, 0 이상)를,
-    잘림·마커 부재로 건너뛰었으면 None을 반환합니다. bool 대신 개수를 반환하는 이유는
+    반환값(이슈 #229): 동기화를 실제로 수행했으면 동기화한 보유 종목 수(int, 0 이상)를,
+    잘림·마커 부재로 건너뛰었으면 None을 반환합니다. 이 값은 잔고 응답의 항목 수이지
+    테이블 행 수가 아닙니다 — upsert 후에는 삽입이 0건일 수 있고, 한 응답에 같은
+    코드가 두 번 오면 반환값이 행 수보다 큽니다. bool 대신 개수를 반환하는 이유는
     호출처(monitor_market_task)가 WebSocket으로 PORTFOLIO_UPDATE를 브로드캐스트할 때
     holdings_count를 함께 실어야 하는데, bool만으로는 호출처가 그 값을 얻기 위해
     holdings 리스트를 별도로 들고 있거나 다시 세야 하기 때문입니다. int 반환값 자체가
@@ -448,10 +450,7 @@ def _sync_portfolio_from_balance(
         if rows:
             row = rows[0]
             # 잔고 응답에서 온 필드만 갱신한다. current_price는 여기에 없으므로
-            # **건드리지 않는다** — 이것이 전량 교체 대신 upsert를 쓰는 이유다.
-            # 전량 교체였다면 이 이슈(#196)가 붙일 시세 조회 결과가 10분 주기마다
-            # null로 되돌아가고, PR #204가 도입한 price_known 플래그가 "시세를
-            # 채웠는데도 모름"으로 잘못 나가는 회귀가 된다.
+            # 건드리지 않는다 — 근거는 이 함수 docstring의 "upsert여야 하는 이유".
             row.stock_name = h.name
             row.quantity = h.quantity
             row.avg_price = h.avg_price

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -1685,6 +1685,133 @@ def test_sync_portfolio_removes_stale_holdings(portfolio_session):
     assert rows[0].stock_code == "005930"
 
 
+def test_sync_portfolio_upserts_instead_of_replacing_rows(portfolio_session):
+    """같은 종목을 두 번 동기화해도 행이 중복되지 않고 기존 행이 갱신됩니다 (#196).
+
+    이 테스트가 잡는 mutation: (1) upsert를 전량 DELETE + INSERT로 되돌리면 id가
+    바뀌어 id 단언이 실패한다. (2) 기존 행을 찾기만 하고 잔고 값을 반영하지 않는
+    no-op upsert는 quantity·avg_price 단언이 잡는다. (3) 기존 행을 찾지 않고 늘
+    새 행을 add하는 회귀는 len(rows) == 1이 잡는다.
+
+    id를 42로 명시해 심는 이유: SQLModel의 id는 SQLite의 rowid이고 AUTOINCREMENT가
+    없어, 테이블을 비운 뒤 다시 넣으면 rowid가 1부터 재사용된다. 기본 id(1)로
+    심으면 전량 교체 뮤턴트도 우연히 id == 1을 돌려줘 단언이 통과해버린다.
+    빈 테이블에서 절대 나올 수 없는 값을 심어야 이 단언이 판별력을 갖는다.
+    (1차 리뷰 🟡4가 지적한 "Portfolio.id를 참조하는 테이블이 생기면 참조가 매
+    주기 끊긴다"를 그대로 고정하는 단언이기도 하다.)
+    """
+    from sqlmodel import select
+    from ..models import Portfolio
+    from ..scheduler import _sync_portfolio_from_balance
+
+    portfolio_session.add(Portfolio(
+        id=42, stock_code="005930", stock_name="삼성전자", quantity=10, avg_price=70000
+    ))
+    portfolio_session.commit()
+
+    # 같은 종목, 수량·평단가만 바뀐 다음 주기 잔고
+    _sync_portfolio_from_balance(_make_balance_text(("삼성전자", "005930", 15, 72000)), portfolio_session)
+
+    rows = portfolio_session.exec(select(Portfolio)).all()
+    assert len(rows) == 1
+    assert rows[0].id == 42  # 행이 교체되지 않고 갱신됐다
+    assert rows[0].quantity == 15
+    assert rows[0].avg_price == 72000.0
+
+
+def test_sync_portfolio_preserves_fields_absent_from_balance(portfolio_session):
+    """잔고 응답에 없는 필드(current_price)가 재동기화 후에도 보존됩니다 (#196).
+
+    **이 파일에서 upsert 전환의 핵심 단언이다.** #196이 시세 조회를 붙이면
+    current_price에 값이 들어가는데, 동기화가 전량 교체면 10분 주기마다 그 값이
+    null로 되돌아가고 PR #204의 price_known 플래그가 "시세를 채웠는데도 모름"으로
+    잘못 나간다. 원인 추적이 어려운 형태의 회귀라 지금 미리 고정한다.
+
+    이 테스트가 잡는 mutation: 전량 DELETE + INSERT로 되돌리기, 또는 upsert
+    루프에서 row.current_price = None을 함께 쓰기 → 둘 다 current_price가 null이
+    되어 마지막 단언이 실패한다.
+
+    current_price를 실제로 채우는 프로덕션 경로는 아직 없다 — get_balance
+    (inquire-balance, TTTC8434R) output1에 현재가 필드가 있는지가 실계좌 실측
+    전까지 미확인이기 때문이다(#196). 그래서 여기서는 그 경로가 생긴 뒤의 상태를
+    DB에 직접 써서 재현한다.
+    """
+    from sqlmodel import select
+    from ..models import Portfolio
+    from ..scheduler import _sync_portfolio_from_balance
+
+    text = _make_balance_text(("삼성전자", "005930", 10, 70000))
+    _sync_portfolio_from_balance(text, portfolio_session)
+
+    # #196이 시세를 채운 뒤의 상태를 재현한다
+    row = portfolio_session.exec(select(Portfolio)).one()
+    row.current_price = 75000.0
+    portfolio_session.add(row)
+    portfolio_session.commit()
+
+    # 다음 주기의 동기화: 잔고에는 current_price가 없다
+    _sync_portfolio_from_balance(text, portfolio_session)
+
+    rows = portfolio_session.exec(select(Portfolio)).all()
+    assert len(rows) == 1
+    assert rows[0].current_price == 75000.0
+
+
+def test_sync_portfolio_preserves_price_only_for_still_held_stocks(portfolio_session):
+    """보존과 삭제가 한 동기화 안에서 함께 성립합니다 (#196).
+
+    upsert 전환이 "아무것도 지우지 않게" 되어버리는 반대 방향의 회귀를 잡는다:
+    stale 삭제 루프를 제거하면 SK하이닉스 행이 남아 len(rows) == 1이 실패한다.
+    동시에 삼성전자의 current_price 단언이, 삭제를 살리려고 전량 교체로 되돌리는
+    회귀를 잡는다.
+    """
+    from sqlmodel import select
+    from ..models import Portfolio
+    from ..scheduler import _sync_portfolio_from_balance
+
+    portfolio_session.add(Portfolio(
+        stock_code="005930", stock_name="삼성전자", quantity=10, avg_price=70000, current_price=75000.0
+    ))
+    portfolio_session.add(Portfolio(
+        stock_code="000660", stock_name="SK하이닉스", quantity=5, avg_price=200000, current_price=210000.0
+    ))
+    portfolio_session.commit()
+
+    # 삼성전자만 남은 잔고
+    _sync_portfolio_from_balance(_make_balance_text(("삼성전자", "005930", 10, 70000)), portfolio_session)
+
+    rows = portfolio_session.exec(select(Portfolio)).all()
+    assert len(rows) == 1                      # SK하이닉스는 삭제됐다
+    assert rows[0].stock_code == "005930"
+    assert rows[0].current_price == 75000.0    # 남은 종목의 시세는 보존됐다
+
+
+def test_sync_portfolio_collapses_duplicate_stock_code_rows(portfolio_session):
+    """같은 stock_code 행이 둘 이상이면 한 행으로 수렴합니다 (#196).
+
+    Portfolio.stock_code에는 유일성 제약이 없어(models.py는 index=True만 선언)
+    중복 행이 존재할 수 있는 상태를 스키마가 막지 못한다. 중복을 정리하지 않으면
+    upsert가 어느 행을 갱신했는지에 따라 /api/v1/portfolio 응답이 달라져
+    비결정적이 된다.
+
+    이 테스트가 잡는 mutation: 삭제 루프에서 rows[1:] 정리를 빼고 stale 종목만
+    지우도록 되돌리는 회귀 → 중복 행이 남아 len(rows) == 1이 실패한다.
+    """
+    from sqlmodel import select
+    from ..models import Portfolio
+    from ..scheduler import _sync_portfolio_from_balance
+
+    portfolio_session.add(Portfolio(stock_code="005930", stock_name="삼성전자", quantity=10, avg_price=70000))
+    portfolio_session.add(Portfolio(stock_code="005930", stock_name="삼성전자", quantity=99, avg_price=1))
+    portfolio_session.commit()
+
+    _sync_portfolio_from_balance(_make_balance_text(("삼성전자", "005930", 10, 70000)), portfolio_session)
+
+    rows = portfolio_session.exec(select(Portfolio)).all()
+    assert len(rows) == 1
+    assert rows[0].quantity == 10
+
+
 def test_sync_portfolio_skips_when_balance_truncated(portfolio_session):
     """잔고 연속조회가 잘리면 기존 Portfolio 데이터를 파괴하지 않습니다.
 

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -1812,6 +1812,41 @@ def test_sync_portfolio_collapses_duplicate_stock_code_rows(portfolio_session):
     assert rows[0].quantity == 10
 
 
+def test_sync_portfolio_collapses_duplicate_codes_within_one_response(portfolio_session):
+    """한 잔고 응답에 같은 코드가 두 번 와도 행이 하나만 남습니다 (#196).
+
+    위 테스트는 **DB에 이미 있던** 중복 행을 다루지만, 이 테스트는 동기화가
+    **스스로 만들어 내는** 중복을 다룬다. 빈 테이블에서 시작하므로 첫 항목은
+    else 분기(신규 삽입)를 타고, 그때 새 행을 existing에 등록하지 않으면 두 번째
+    항목이 또 하나의 새 행을 만든다. 그 행들은 existing에 없어 삭제 루프도
+    지나치므로 테이블에 2행이 남는다.
+
+    KIS output1은 pdno가 키라 정상 응답에는 중복이 없지만, 스키마가 막아주지
+    않는 이상 이 함수가 스스로 불변식("코드당 1행")을 깨뜨려서는 안 된다.
+
+    이 테스트가 잡는 mutation: 신규 삽입 분기의 existing[h.code] = [row] 등록을
+    제거 → len(rows)가 2가 되어 실패한다. 등록은 하되 재방문 시 갱신을 하지 않는
+    회귀는 quantity·avg_price 단언이 잡는다(마지막 항목의 값으로 수렴해야 한다).
+    """
+    from sqlmodel import select
+    from ..models import Portfolio
+    from ..scheduler import _sync_portfolio_from_balance
+
+    text = _make_balance_text(
+        ("삼성전자", "005930", 10, 70000),
+        ("삼성전자", "005930", 5, 71000),
+    )
+    returned = _sync_portfolio_from_balance(text, portfolio_session)
+
+    rows = portfolio_session.exec(select(Portfolio)).all()
+    assert len(rows) == 1
+    assert rows[0].quantity == 5          # 마지막 항목으로 갱신됐다
+    assert rows[0].avg_price == 71000.0
+    # 반환값은 잔고 응답의 항목 수라 행 수와 갈릴 수 있다(docstring 참고).
+    # #229의 PORTFOLIO_UPDATE holdings_count 호환을 위해 len(holdings)를 유지한다.
+    assert returned == 2
+
+
 def test_sync_portfolio_skips_when_balance_truncated(portfolio_session):
     """잔고 연속조회가 잘리면 기존 Portfolio 데이터를 파괴하지 않습니다.
 


### PR DESCRIPTION
## 왜 지금 upsert인가

`_sync_portfolio_from_balance`(PR #204)는 **전량 DELETE + INSERT**입니다. 전량 교체는 **잔고 응답에 없는 필드를 매 주기 기본값으로 되돌립니다.**

지금은 `current_price`가 항상 null이라 관측되는 차이가 없습니다. 문제는 이 이슈(#196)의 본체가 그 필드를 채우는 순간입니다:

1. #196이 시세 조회를 붙여 `current_price`에 값이 들어감
2. 10분 뒤 스케줄러가 `get_balance`로 동기화 → 전량 교체가 그 값을 null로 되돌림
3. `/api/v1/portfolio`가 `return_rate: null`, **`price_known: False`** 로 응답
4. PR #204가 "0%와 모름을 구분하려고" 도입한 플래그가 **"시세를 채웠는데도 모름"** 으로 잘못 나감

시세 조회 코드는 정상이고 DB에도 잠깐은 값이 있었기 때문에, 증상만 보면 시세 조회가 실패한 것처럼 보입니다. 원인 추적이 어려운 형태의 회귀입니다. **이 PR은 #196 본체를 구현하기 전에 그 지뢰를 제거합니다.**

PR #204 1차 리뷰 🟡4 / 2차 리뷰 🟡2(@Kiyeon-Nam)에서 지적된 선행 조건이고, 이슈 #196 본문 맨 아래 체크박스이기도 합니다.

## 변경 내용

### `backend/scheduler.py` — `_sync_portfolio_from_balance`

`stock_code` 기준 upsert로 전환했습니다.

- **잔고에 있는 종목**: 기존 행이 있으면 갱신, 없으면 삽입. 갱신 대상은 잔고 응답에서 온 필드(`stock_name`·`quantity`·`avg_price`)와 `updated_at`뿐입니다. **`current_price`는 읽지도 쓰지도 않아 그대로 보존됩니다.**
- **잔고에 없는 종목**: 계속 삭제합니다 — 전량 교체 시절과 같은 동작입니다.
- **코드 중복 행 정리**: `Portfolio.stock_code`에 유일성 제약이 없어(아래 참고) 같은 코드의 행이 둘 이상 존재하는 상태를 스키마가 막지 못합니다. 코드당 첫 행만 갱신 대상으로 남기고 나머지를 삭제해, 동기화가 돌 때마다 테이블이 "코드당 1행"으로 수렴합니다. 이 정리가 없으면 upsert가 중복 중 어느 행을 갱신했는지에 따라 API 응답이 달라져 비결정적이 됩니다. 한 응답 안에 같은 코드가 두 번 오는 경우도(KIS `output1`은 `pdno`가 키라 정상 응답에는 없지만) 새 행을 `existing`에 등록해 함께 막습니다.

### 불변으로 유지한 것

| 항목 | 상태 |
| --- | --- |
| 커밋 경계 | 종전과 동일 — 한 동기화 = 한 트랜잭션, 갱신·삽입·삭제가 함께 커밋되거나 함께 롤백 |
| 반환값 | `len(holdings)` 그대로 → #229의 `PORTFOLIO_UPDATE` `holdings_count`가 바뀌지 않음 |
| 잘림 가드 | `is_balance_truncated` → 동기화 건너뜀, 기존 데이터 보존 |
| 마커 부재 가드 | `[보유 종목 리스트]` 없으면 건너뜀 + error 로그 |
| 잔고 조회 실패 시 미동기화 | 호출처(`_monitor_market_task`)의 성공 분기 구조 그대로 |
| `updated_at` | 값 변화와 무관하게 매 주기 갱신("잔고를 마지막으로 확인한 시각") |
| 관측 가능한 동작 | `current_price`가 항상 null인 현 시점에서는 **결과 동일** |

이슈 #196의 세 번째 체크박스(PR #204의 세 가드 유지 확인)는 기존 테스트 6건이 그대로 통과하는 것으로 확인했습니다.

### `backend/models.py` — 주석만

`stock_code`에 `unique=True`가 없는 이유와 `current_price`가 늘 null인 이유를 필드 옆에 기록했습니다. 스키마·동작 변경은 없습니다.

## 남은 게이트

### 1. `Portfolio.stock_code`의 `unique=True` — 이 PR에 넣지 않았습니다

이슈 #196의 두 번째 체크박스입니다. **넣지 않은 이유는 부팅 실패 위험 때문입니다:**

- 이미 배포된 SQLite 파일에는 비유일 인덱스 `ix_portfolio_stock_code`가 이미 있고, `create_all()`은 **기존 인덱스를 바꾸지 않습니다.** 모델에 `unique=True`만 붙이면 새로 만든 DB와 기존 DB의 스키마가 조용히 갈립니다.
- 제대로 하려면 `DROP INDEX` → 중복 행 정리 → `CREATE UNIQUE INDEX` 순서가 필요합니다. `database.py`의 `_PENDING_COLUMN_MIGRATIONS`는 **컬럼 추가 전용**이라 이 형태를 담지 못하고, `_run_table_recreate_migrations`는 `agentreport` 전용입니다. 세 번째 마이그레이션 메커니즘을 부팅 경로에 새로 만드는 일입니다.
- 중복 행을 지우지 않은 채 유니크 인덱스를 만들면 `init_db()`가 실패해 **영구 부팅 불능**이 됩니다.

**upsert의 정확성은 이 제약에 의존하지 않습니다.** 위의 중복 행 정리가 논리적 불변식("코드당 1행")을 코드에서 보장하고, 회귀 테스트로 고정했습니다. 제약은 그 위에 얹는 방어선이므로, 부팅 경로를 건드리는 별도 PR에서 다루는 편이 안전합니다. 원하시면 이슈로 분리하겠습니다.

### 2. `current_price` 소스 — 미확인, 실계좌 실측 필요

**이슈 본체는 이 PR의 범위가 아닙니다.** `get_balance`(`inquire-balance`, `TTTC8434R`) `output1`에 현재가 필드(`prpr` 추정)가 있는지는 **실계좌 호출로 실측해야만 알 수 있고**, 이 환경에서는 불가능했습니다. 저장소 안의 유일한 근거인 `mcp-trading/balance-rlz-pl-report.js:38`의 `row.prpr`은 **다른 TR**(`TTTC8494R`, inquire-balance-rlz-pl)의 응답이라 증명이 되지 못합니다. 옵션 B(종목별 `get_stock_quote`)의 비용 검토도 손대지 않았습니다.

그래서 `current_price`는 **null도 값도 쓰지 않고 그냥 두었습니다.** 코드 주석·docstring·모델 주석 세 곳에 "미확인 — 실계좌 실측 필요"로 남겼습니다.

**이 전환이 후속 작업의 전제를 어떻게 해소했는가:** #196 본체를 구현하는 사람은 이제 `current_price`를 채우는 코드만 쓰면 됩니다. 그 값이 다음 동기화 주기에 살아남는지 걱정할 필요가 없고, `price_known` 플래그가 진실을 말하는지 따로 확인할 필요도 없습니다. 전량 교체였다면 시세 조회를 붙인 뒤에야 "10분마다 값이 사라진다"를 발견하고, 그 원인이 시세 조회가 아니라 동기화 쪽에 있다는 것을 역추적해야 했을 것입니다. 그 역추적이 통째로 사라졌습니다. 잔고 응답에 없는 필드를 Portfolio에 더하는 **모든** 후속 작업이 같은 이득을 받습니다.

## 검증 방법

로컬 `uv run`이 정책상 차단돼 있어, 별도 venv(CPython 3.13.14, `backend/pyproject.toml` 의존성 + `pyright==1.1.411`)를 만들어 직접 실행했습니다.

**`pytest backend/` — 1054 → 1058 passed, 3 skipped** (실패 0건, +4건). 변경 전 baseline도 같은 환경에서 1054 passed로 확인했습니다.

**`pyright --project backend`** (`scheduler.py`·`models.py`·`test_scheduler.py`) — **0 errors, 0 warnings.**
초안에서 `Portfolio(stock_code=h.code)` 부분 생성자가 `reportCallIssue`로 잡혀(SQLModel의 생성자는 기본값 없는 필드를 전부 요구합니다), 신규 행을 필드 전체로 생성하도록 고쳤습니다.

### 뮤테이션 — 6종 전부 red 확인

| 뮤턴트 | 결과 |
| --- | --- |
| 전량 DELETE + INSERT로 되돌림 | **3 failed** ✅ |
| 기존 행을 찾기만 하고 갱신 안 함(no-op upsert) | **1 failed** ✅ |
| 항상 새 행 insert(기존 행 조회 무시) | **5 failed** ✅ |
| stale 삭제 제거 | **3 failed** ✅ |
| 코드 중복 행 정리 제거 | **1 failed** ✅ |
| upsert 루프에서 `current_price=None` 덮어씀 | **2 failed** ✅ |

### 추가한 테스트 4건 (`backend/tests/test_scheduler.py`)

- `test_sync_portfolio_upserts_instead_of_replacing_rows` — 같은 종목을 두 번 동기화해도 행이 중복되지 않고 기존 행이 갱신된다.
  **`id`를 42로 명시해 심었습니다.** SQLModel의 `id`는 SQLite의 rowid이고 AUTOINCREMENT가 없어 테이블을 비운 뒤 다시 넣으면 rowid가 1부터 재사용됩니다. 기본 `id`(1)로 심으면 전량 교체 뮤턴트도 우연히 `id == 1`을 돌려줘 단언이 통과해버립니다 — 실제로 초안에서 이 뮤턴트가 survive 했고, 그래서 빈 테이블에서 절대 나올 수 없는 값으로 바꿨습니다. 1차 리뷰 🟡4의 "`Portfolio.id`를 참조하는 테이블이 생기면 참조가 매 주기 끊긴다"도 함께 고정합니다.
- `test_sync_portfolio_preserves_fields_absent_from_balance` — **이 전환의 핵심 단언.** `current_price`가 재동기화 후에도 보존된다. 시세를 채우는 프로덕션 경로가 아직 없으므로, 그 경로가 생긴 뒤의 상태를 DB에 직접 써서 재현했습니다.
- `test_sync_portfolio_preserves_price_only_for_still_held_stocks` — 보존과 삭제가 한 동기화 안에서 함께 성립한다(upsert가 "아무것도 안 지우게" 되는 반대 방향 회귀 차단).
- `test_sync_portfolio_collapses_duplicate_stock_code_rows` — 같은 `stock_code` 행이 둘 이상이면 한 행으로 수렴한다.

## 확인하지 못한 것

- `inquire-balance`(`TTTC8434R`) `output1`의 실제 필드 목록 — 실계좌 호출이 필요합니다(이슈 본체, 위 "남은 게이트 2").
- 실제 배포 SQLite 파일에 대한 마이그레이션 — 이 PR은 스키마를 바꾸지 않으므로 해당 사항이 없습니다.

Refs #196
