### PR TITLE
feat: NAT 도구 결과가 마스킹 없이 OpenAI로 나가는 경로를 막는다 (#231)

### DIFF
--- a/docs/nfr-05-nat-tool-masking.md
+++ b/docs/nfr-05-nat-tool-masking.md
@@ -1,0 +1,130 @@
+# NFR-05 — NAT 도구 결과 마스킹 (#231)
+
+관련 요구사항: F-17(비식별화). `docs/nfr-05-pii-masking.md`가 기술하는 backend 계층(#230)의
+**보완 문서**다. 두 문서는 같은 요구사항의 서로 다른 적용 경로를 다룬다.
+
+> 이 문서를 따로 둔 이유: `docs/nfr-05-pii-masking.md`는 진행 중인 다른 PR(#332)이 고치고
+> 있어 같은 파일을 건드리면 충돌이 난다. #332가 머지된 뒤 이 문서의 요약을 그쪽 "미적용
+> 경로" 절에 합치는 것이 후속 정리다.
+
+## 위협 모델 — backend 마스킹으로 막히지 않는 이유
+
+backend의 마스킹은 **backend가 조립한 프롬프트**를 가린다. 그런데 NAT 경로에서 backend가
+보내는 것은 사용자 발화 하나뿐이고, 계좌 데이터는 그 다음 단계에서 NAT 프로세스 안에서
+생긴다.
+
+```
+사용자: "내 잔고 어때?"
+  1. backend --(user_msg only)--> NAT            # 마스킹해도 걸릴 PII가 없다
+  2. NAT 라우터 --> trading_agent (ReAct)
+  3. trading_agent --> KIS/mcp-trading 도구 호출
+  4. 잔고 리포트(보유종목·수량·평단가·평가금액·예수금)가 Observation으로 컨텍스트에 삽입
+  5. 그 컨텍스트가 openai_cloud_llm(api.openai.com)으로 전송   <-- 유출 지점
+```
+
+backend는 3~5단계를 보지 못한다. 실제로 나가는 문자열은
+`mcp-trading/tests/fixtures/balance_report.json`의 `expected_text`와 동일한 형태다.
+
+## 택한 선택지 — A(도구 결과 마스킹)
+
+이슈 #231의 세 안 중 **A**를 택했다.
+
+| 안 | 판단 |
+| --- | --- |
+| A. MCP 도구 결과 마스킹 | **채택.** 유출 지점(4단계)에 가장 가깝고, 방어 지점이 함수 3~4곳으로 좁다. 도구가 늘어도 한 곳에서 처리된다. |
+| B. LLM 호출 직전 훅 | 미채택. NAT 1.6이 그 지점에 공개 훅을 주지 않아 `scripts/patch_vendor.py` 계열의 벤더 패치가 된다. `ci.yml`이 이미 벤더 패치 drift를 감시할 만큼 그 방식은 부채다(#152에서 같은 이유로 패치를 걷어냈다). |
+| C. 계좌 취급 에이전트를 로컬 모델로 | 미채택(이번 범위에서). 외부 전송 자체가 사라지는 근본 해결이지만, 모델 품질·운영 비용 판단과 에이전트별 LLM 분리 검증이 필요해 한 PR에 담기지 않는다. A와 배타적이지 않다 — C를 나중에 택해도 A는 그대로 유효하다(Mem0·SQLite 저장 경로는 로컬 모델로 바꿔도 남는다). |
+
+## 경계 — 어디서 가리고 어디서 되돌리는가
+
+```
+                          ┌─ 마스킹(들어오는 쪽) ─┐
+KIS / mcp-trading / diary ─┤                      ├─> ReAct 컨텍스트 ─> OpenAI
+                          └ _mask_account_tool_result
+
+OpenAI ─> 최상위 워크플로 응답 ─ without_pii_placeholders ─> backend ─> 사용자
+                    │
+                    └ LLM이 만든 도구 인자 ─ restore_outbound ─> MCP / backend DB
+```
+
+- **마스킹 지점** — `finus_nat/src/nat_finus_nat/finus_api.py`의
+  `_mask_account_tool_result()` 호출부. 항상 `_record_to_ledger()` **뒤**에 온다:
+  원장(#152/#209)은 원문으로 판정해야 오류·빈 결과 리터럴 탐지가 마스킹에 흔들리지
+  않는다. 원장에 남는 것은 불리언 3개뿐이라 원문 판정이 유출로 이어지지 않는다.
+- **복원 지점 1(사용자)** — `agents.finus_reasoning_trace_agent`. 두 라우터 config의
+  최상위 `workflow`이므로, 자리표시자가 이 경계를 넘어 사용자에게 나가는 경로는 없다.
+  각주 부착(`with_reasoning_trace`, #294)이 본문 문자열 비교를 하므로 **복원은 각주
+  부착 뒤**에 실행한다.
+- **복원 지점 2(기계)** — `restore_outbound()`. LLM이 만든 MCP 인자와 매매일지 본문은
+  실제 시스템에 나가는 값이라 원값이어야 한다. 여기서는 매핑에 없는 자리표시자를
+  한국어 중립 문구로 바꾸지 않는다(주문 파라미터 자리에 "(이전 금액 1)"이 들어가는 것은
+  토큰보다 나을 게 없고 실패 원인만 가린다).
+- **중간 구간은 전부 마스킹 상태** — ReAct 컨텍스트, supervisor 히스토리, Mem0 저장,
+  SQLite 대화 기록, api.openai.com.
+
+세션 매핑은 요청 하나짜리 `ContextVar`(`pii.PII_SESSION`)에 담긴다. 최상위 워크플로가
+한 번만 심고 안쪽은 읽기만 한다 — `DATA_TOOL_LEDGER`/`REASONING_TRACE`와 같은 이유로
+`ContextVar.set()`은 안쪽에서 바깥으로 전파되지 않기 때문이다.
+
+## 무엇을 가리고 무엇을 남기는가
+
+가리면 분석이 불가능해지는 값까지 덮으면 기능이 죽는다. 그래서 **계좌 범위**만 가린다.
+
+| 대상 | 마스킹 | 근거 |
+| --- | --- | --- |
+| `finus_mcp_trading_get_balance` / `_balance_rlz_pl` / `_today_orders` | O | mcp-trading은 서버 전체가 CANO 기반 계좌 TR 래퍼다 |
+| `finus_save_diary` / `finus_list_diaries` | O | 사용자가 적은 자기 거래 기록 |
+| `finus_account_balance`(KIS pass-through) | api_type별 | 한 도구가 계좌 TR과 시세 TR을 모두 태운다 |
+| `finus_market_news` / `finus_disclosure_signal` / `finus_earnings_report` | X | 공개 정보. 가리면 분석만 망가지고 막히는 유출은 없다 |
+| 종목명·수익률(%)·손익률 | X | F-17이 정의한 3종(계좌번호·원화 금액·보유 수량)이 아니다 |
+
+KIS pass-through의 판정(`pii.kis_api_type_is_account_scoped`)은 **공개 시세 allowlist**
+방식이다 — 목록에 없는 api_type은 전부 계좌 TR로 간주해 마스킹한다. deny-list로 두면
+KIS가 새 계좌 TR을 추가하는 순간 조용히 평문으로 나간다. 반대 방향의 오판(시세를 가림)은
+답변 품질만 떨어뜨린다. 비대칭이므로 모르는 쪽은 마스킹으로 눕힌다. 이 방향은
+`_READONLY_API_ALLOWLIST_PREFIXES`(#66)와 같다.
+
+## fail-closed
+
+마스킹 엔진(`backend/pii_mask.py`)을 로드하지 못하거나 마스킹이 실패하면, 도구는 조회
+결과 대신 `{"error": "pii_masking_unavailable", ...}`를 반환한다. 유출보다 조회 실패가
+낫다는 것이 F-17의 전제다. 이 오류는 원장에 기록하지 않는다 — 도구는 실제로 성공했고,
+성공을 실패로 뒤집으면 도구 강제 게이트(#152)가 같은 조회를 한 번 더 실행한다.
+
+세션 상자가 없는 경로(최상위 워크플로를 거치지 않은 호출)에서도 마스킹은 적용된다.
+복원할 방법이 없어 답변 품질은 떨어지지만, 상자가 없다고 원값을 흘리지는 않는다.
+
+## 마스킹 엔진 재사용
+
+`backend/pii_mask.py`를 **한 줄도 고치지 않고 파일 경로로 로드해 재사용**한다
+(`pii._load_pii_mask()`). 정규식을 복사하면 두 계층의 판정이 조용히 갈라진다 —
+실제로 #330·#333·#334가 그 정규식을 연달아 고쳤다.
+
+finus_nat은 backend와 별도 패키지·별도 컨테이너라 `import backend.pii_mask`가 성립하지
+않는다. `finus_nat/Dockerfile`이 그 파일 **하나만** 이미지에 복사하고
+(`/workspace/backend/pii_mask.py`), `pii._pii_mask_candidates()`가
+`FINUS_VENDOR_ROOT`(=`/workspace`) 기준으로 찾는다. 배치가 다르면
+`FINUS_PII_MASK_PATH`로 파일 경로를 직접 지정한다.
+
+## 알려진 한계
+
+- **도구 호출마다 scope가 다르다.** `mask_pii`는 호출당 새 nonce를 뽑으므로, 같은 금액이
+  두 도구 결과에 나와도 서로 다른 자리표시자가 된다. LLM은 두 값이 같다는 것을 알 수 없다.
+- **이전 턴의 자리표시자는 복원되지 않는다.** SQLite 대화 기록에는 마스킹된 답변이
+  저장되고 다음 턴 세션에는 그 scope가 없다. `unmask_pii`의 fail-open 경로가
+  "(이전 금액 1)"로 바꾼다 — 조용한 오답 대신 관측 가능한 저하다. 저장을 원문으로
+  되돌리면 다음 턴 히스토리가 평문으로 OpenAI에 재전송되므로 그쪽이 더 나쁘다.
+- **절대 금액 기반 판단은 여전히 불가능하다.** `docs/nfr-05-pii-masking.md`가 기록한
+  (a) 방식의 한계를 그대로 물려받는다. 부분 마스킹(#330)·조 단위 표기(#333)의 결론도
+  같은 엔진을 쓰므로 그대로 적용된다.
+
+## 이번 범위에서 뺀 것
+
+- **Mem0 저장 경로.** `add_user_memory`는 LLM이 만든 텍스트를 받으므로, 도구 결과에서
+  온 계좌 데이터는 이제 마스킹된 형태로 저장된다 — 즉 평문 축적은 줄어든다. 다만
+  vendor `auto_memory_agent`가 무엇을 어떤 형태로 넣는지는 NAT 런타임을 띄워야 확인할
+  수 있어 이번 PR에서 검증하지 못했다. Mem0 저장 내용 실측과 범위 확정은 후속이다.
+- **`finus_order_verifier` 경로.** backend가 NAT의 검증 엔드포인트를 직접 부르며
+  주문 수량·가격을 프롬프트에 싣는다. 라우터 워크플로 바깥이라 이 PR의 경계가 닿지
+  않는다. 별도 이슈로 다뤄야 한다.
+- **옵션 C(로컬 모델 라우팅).** 위 표 참고.

--- a/finus_nat/Dockerfile
+++ b/finus_nat/Dockerfile
@@ -18,6 +18,13 @@ ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0+docker
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION}
 
 COPY finus_nat /workspace/finus_nat
+# F-17 마스킹 엔진(#230). NAT 프로세스 안에서 만들어지는 계좌 데이터를 외부 LLM에
+# 보내기 전에 가리는 데 쓴다(#231). backend 전체가 아니라 이 파일 하나만 넣는다 —
+# 순수 stdlib 모듈이라 backend 의존성이 따라오지 않고, 정규식을 복사하지 않으므로
+# backend 경로와 NAT 경로의 마스킹 판정이 갈라지지 않는다.
+# nat_finus_nat/pii.py 의 _pii_mask_candidates()가 FINUS_VENDOR_ROOT(=/workspace)
+# 기준으로 이 경로를 찾는다.
+COPY backend/pii_mask.py /workspace/backend/pii_mask.py
 COPY mcp-news /workspace/mcp-news
 COPY mcp-trading /workspace/mcp-trading
 COPY mcp-dart /workspace/mcp-dart

--- a/finus_nat/src/nat_finus_nat/agents.py
+++ b/finus_nat/src/nat_finus_nat/agents.py
@@ -34,6 +34,7 @@ from nat_finus_nat.finus_api import (
     DataToolLedger,
     ReasoningTrace,
 )
+from nat_finus_nat.pii import PII_SESSION, PiiSession
 
 logger = logging.getLogger(__name__)
 
@@ -655,6 +656,34 @@ def with_reasoning_trace(response: ChatResponse, trace: ReasoningTrace) -> ChatR
     )
 
 
+def without_pii_placeholders(response: ChatResponse, session: PiiSession) -> ChatResponse:
+    """응답 본문의 PII 자리표시자를 원값으로 되돌린다 (#231).
+
+    **:func:`with_reasoning_trace` 뒤에 부른다.** 각주 부착 판정은 본문과
+    ``trace.branch_answer``를 문자열 비교하는데, 기록된 쪽은 마스킹된 텍스트다.
+    먼저 복원하면 두 값이 달라져 정상 경로의 각주가 통째로 사라진다(#294 경고 로그가
+    "vendor가 본문을 변형함"으로 오인식된다).
+
+    ``model_copy``로 갈아끼우므로 ``extra="allow"``로 실린 ``routed_agent``/
+    ``tools_used``(#260)는 그대로 남는다. 바뀐 것이 없으면 원본 객체를 그대로 돌려준다.
+    """
+    restored_choices = []
+    changed = False
+    for choice in response.choices:
+        content = choice.message.content
+        if isinstance(content, str):
+            restored = session.unmask(content)
+            if restored != content:
+                changed = True
+                choice = choice.model_copy(
+                    update={"message": choice.message.model_copy(update={"content": restored})}
+                )
+        restored_choices.append(choice)
+    if not changed:
+        return response
+    return response.model_copy(update={"choices": restored_choices})
+
+
 class FinusReasoningTraceAgentConfig(FunctionBaseConfig, name="finus_reasoning_trace_agent"):
     inner_agent_name: FunctionRef = Field(..., description="Agent/workflow to invoke with a reasoning-trace box installed.")
     description: str = Field(default="Fin-Us agent that attaches the reasoning trace footnote (#260)")
@@ -690,11 +719,21 @@ async def finus_reasoning_trace_agent(config: FinusReasoningTraceAgentConfig, bu
         # ContextVar.set()은 LangGraph의 copy_context() 경계를 넘어 바깥으로 전파되지
         # 않기 때문이다(DataToolLedger와 동일). 반대 방향(바깥→안쪽)은 전파되므로
         # vendor auto_memory_agent가 중간에 끼어 있어도 안쪽이 같은 박스를 본다.
+        #
+        # #231: PII 마스킹 세션 상자도 같은 자리에서 심는다. 안쪽 도구가 계좌 데이터를
+        # 마스킹하며 이 상자에 매핑을 쌓고, 여기가 그 매핑으로 복원하는 **유일한**
+        # 지점이다 — 이 함수가 두 라우터 config의 최상위 workflow이므로, 자리표시자가
+        # 이 경계를 넘어 사용자에게 나가는 경로는 없다. 반대로 이 안쪽(ReAct 컨텍스트,
+        # supervisor 히스토리, Mem0, SQLite 대화 기록, api.openai.com)은 전부 마스킹된
+        # 상태로만 계좌 데이터를 본다.
         trace = ReasoningTrace()
+        pii_session = PiiSession()
         trace_token = REASONING_TRACE.set(trace)
+        pii_token = PII_SESSION.set(pii_session)
         try:
             result = await inner_agent.ainvoke(chat_request_or_message)
         finally:
+            PII_SESSION.reset(pii_token)
             REASONING_TRACE.reset(trace_token)
 
         # 문자열 입력(`nat run --input`)은 평문으로 돌려준다 — 각주를 실을 곳이 없다.
@@ -705,12 +744,15 @@ async def finus_reasoning_trace_agent(config: FinusReasoningTraceAgentConfig, bu
         # 여기서는 검사 순서를 뒤집어 그 의도를 실제로 실행한다. HTTP 경로(backend·
         # scheduler)는 messages를 보내므로 영향받지 않는다.
         if chat_request_or_message.is_string:
-            return chat_response_plain_text(result)
+            return pii_session.unmask(chat_response_plain_text(result))
         if isinstance(result, ChatResponse):
-            return with_reasoning_trace(result, trace)
+            return without_pii_placeholders(with_reasoning_trace(result, trace), pii_session)
         # vendor auto_memory_agent는 str을 돌려준다 — 여기서 ChatResponse로 만들며
         # 각주를 붙이므로, 안쪽에서 무엇이 버려졌는지와 무관하게 필드가 실린다.
-        return with_reasoning_trace(ChatResponse.from_string(str(result), usage=Usage()), trace)
+        return without_pii_placeholders(
+            with_reasoning_trace(ChatResponse.from_string(str(result), usage=Usage()), trace),
+            pii_session,
+        )
 
     yield FunctionInfo.from_fn(_response_fn, description=config.description)
 

--- a/finus_nat/src/nat_finus_nat/finus_api.py
+++ b/finus_nat/src/nat_finus_nat/finus_api.py
@@ -22,6 +22,14 @@ from nat.builder.builder import Builder
 from nat.builder.function_info import FunctionInfo
 from nat.cli.register_workflow import register_function
 from nat.data_models.function import FunctionBaseConfig
+from nat_finus_nat.pii import (
+    ACCOUNT_SCOPED_TOOLS,
+    PiiMaskUnavailableError,
+    kis_api_type_is_account_scoped,
+    mask_account_text,
+    masking_unavailable_error_json,
+    restore_outbound,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -328,6 +336,49 @@ def _record_to_ledger(tool_name: str, result: str) -> None:
     )
 
 
+# ---- PII 마스킹 경계 (#231) ----
+
+
+def _mask_account_tool_result(
+    tool_name: str,
+    result: str,
+    *,
+    account_scoped: bool | None = None,
+) -> str:
+    """계좌 범위 도구 결과를 LLM 컨텍스트에 넣기 전에 마스킹한다 (#231).
+
+    마스킹 대상 판정은 기본적으로 :data:`~nat_finus_nat.pii.ACCOUNT_SCOPED_TOOLS`
+    한 곳에서만 온다 — 호출부가 각자 판단하면 도구가 늘어날 때 한 곳만 빠뜨려도
+    조용히 평문이 나간다. *account_scoped*를 명시하는 것은 도구 이름만으로 정할 수
+    없는 KIS pass-through 하나뿐이다(api_type마다 계좌/시세가 갈린다).
+
+    **반드시 :func:`_record_to_ledger` 뒤에 부른다.** 원장은 원문으로 판정해야
+    #152/#209의 오류·빈 결과 리터럴 판정이 마스킹에 영향받지 않는다. 원장에 남는 것은
+    불리언 3개뿐이라 원문으로 판정해도 PII가 밖으로 새지 않는다.
+
+    마스킹 엔진을 쓸 수 없으면 **원본 대신 오류 JSON을 반환한다**(fail-closed).
+    유출보다 조회 실패가 낫다는 것이 F-17의 전제다. 이 오류는 원장에 기록하지 않는다 —
+    도구는 실제로 성공했고, 성공을 실패로 뒤집으면 도구 강제 게이트(#152)가 재시도를
+    유발해 같은 조회를 한 번 더 실행하게 된다.
+
+    자리표시자는 최상위 워크플로(`agents.finus_reasoning_trace_agent`)에서만 복원된다.
+    그 사이 구간(ReAct 컨텍스트, supervisor 히스토리, Mem0 저장, SQLite 대화 기록)은
+    전부 마스킹된 상태로 흐른다.
+    """
+    scoped = tool_name in ACCOUNT_SCOPED_TOOLS if account_scoped is None else account_scoped
+    if not scoped:
+        return result
+    try:
+        return mask_account_text(result)
+    except PiiMaskUnavailableError as exc:
+        logger.error(
+            "PII 마스킹 불가 — %s의 결과를 반환하지 않고 차단합니다(fail-closed): %s",
+            tool_name,
+            exc,
+        )
+        return masking_unavailable_error_json(tool_name, str(exc))
+
+
 # Remote MCP / doc 한도
 _MCP_DOC_MAX_CHARS = 14_000 #텍스트 최대 길이
 _MCP_LIST_TOOLS_GRACE_SEC = 10.0 #툴 호출 시 timeout 방지
@@ -498,12 +549,17 @@ async def _mcp_call_tool(
         cwd=str(server_dir),
     )
 
+    # LLM이 만든 인자에 자리표시자가 섞여 있으면 원값으로 되돌린다 (#231).
+    # 도구 인자는 사람이 읽는 문장이 아니라 실제 시스템에 나가는 값이다 — 자리표시자가
+    # 그대로 나가면 주문 파라미터나 매매일지 본문이 내부 토큰으로 저장된다.
+    call_arguments = restore_outbound(arguments)
+
     # 실제 stdio 세션 안에서 단일 tool 호출을 수행하는 inner.
     async def _inner() -> str:
         async with stdio_client(params) as (read, write):
             async with ClientSession(read, write) as session:
                 await session.initialize()
-                return _mcp_call_tool_first_text(await session.call_tool(tool_name, arguments))
+                return _mcp_call_tool_first_text(await session.call_tool(tool_name, call_arguments))
 
     return await _run_mcp_timed(_inner, tool_name=tool_name, timeout_sec=timeout_sec)
 
@@ -524,10 +580,13 @@ async def _mcp_call_tool_remote(
             hint="Set mcp_url on finus_account_balance (Kis Trading MCP) config.",
         )
 
+    # 자리표시자 복원 근거는 _mcp_call_tool 쪽 주석 참고 (#231).
+    call_arguments = restore_outbound(arguments)
+
     # 실제 원격 세션을 열고 단일 tool 호출을 수행하는 inner.
     async def _inner() -> str:
         async with _remote_mcp_session(transport=transport, url=url, operation_timeout=timeout_sec) as session:
-            return _mcp_call_tool_first_text(await session.call_tool(tool_name, arguments))
+            return _mcp_call_tool_first_text(await session.call_tool(tool_name, call_arguments))
 
     return await _run_mcp_timed(_inner, tool_name=tool_name, timeout_sec=timeout_sec)
 
@@ -997,10 +1056,14 @@ async def _call_kis_mcp_and_record(
     arguments: McpCallArguments,
     config: FinusAccountBalanceConfig,
 ) -> str:
-    """원격 MCP 호출 후 원장에 기록한다 — finus_account_balance·readonly 공유.
+    """원격 MCP 호출 후 원장에 기록하고, 계좌 TR이면 마스킹해 반환한다.
 
     두 래퍼가 개별로 _mcp_call_tool_remote + _record_to_ledger(_KIS_BALANCE_LEDGER_NAME)를
     중복 구현하는 것을 이 헬퍼 한 곳으로 모은다.
+
+    이 도구 하나가 계좌 TR(잔고·체결·주문가능금액)과 시세 TR(현재가·호가·순위)을 모두
+    태우므로, 마스킹 여부는 도구 이름이 아니라 ``api_type``으로 가른다 (#231).
+    판정은 fail-closed다 — 근거는 :func:`nat_finus_nat.pii.kis_api_type_is_account_scoped`.
     """
     result = await _mcp_call_tool_remote(
         transport=config.mcp_transport,
@@ -1010,7 +1073,11 @@ async def _call_kis_mcp_and_record(
         timeout_sec=config.timeout_sec,
     )
     _record_to_ledger(_KIS_BALANCE_LEDGER_NAME, result)
-    return result
+    return _mask_account_tool_result(
+        _KIS_BALANCE_LEDGER_NAME,
+        result,
+        account_scoped=kis_api_type_is_account_scoped(str(arguments.get("api_type", ""))),
+    )
 
 
 async def _build_kis_mcp_description(doc: str, config: FinusAccountBalanceConfig) -> str:
@@ -1200,7 +1267,7 @@ async def finus_mcp_trading_today_orders(config: FinusMcpTradingTodayOrdersConfi
             arguments=arguments,
         )
         _record_to_ledger("finus_mcp_trading_today_orders", result)
-        return result
+        return _mask_account_tool_result("finus_mcp_trading_today_orders", result)
 
     get_today_daily_orders.__doc__ = doc
     yield FunctionInfo.from_fn(
@@ -1226,7 +1293,7 @@ async def finus_mcp_trading_get_balance(config: FinusMcpTradingGetBalanceConfig,
             arguments={},
         )
         _record_to_ledger("finus_mcp_trading_get_balance", result)
-        return result
+        return _mask_account_tool_result("finus_mcp_trading_get_balance", result)
 
     get_balance.__doc__ = doc
     yield FunctionInfo.from_fn(
@@ -1256,7 +1323,7 @@ async def finus_mcp_trading_balance_rlz_pl(config: FinusMcpTradingBalanceRlzPlCo
             arguments=arguments,
         )
         _record_to_ledger("finus_mcp_trading_balance_rlz_pl", result)
-        return result
+        return _mask_account_tool_result("finus_mcp_trading_balance_rlz_pl", result)
 
     get_balance_rlz_pl.__doc__ = doc
     yield FunctionInfo.from_fn(
@@ -1281,8 +1348,11 @@ async def finus_save_diary(config: FinusSaveDiaryConfig, _builder: Builder):
         Returns:
             저장된 일지 메타데이터 JSON 문자열. 실패 시 ``error`` 필드를 가진 JSON.
         """
-        title = (inp.title or "").strip()
-        content = (inp.content or "").strip()
+        # 본문은 LLM이 마스킹된 관측(Observation)을 보고 쓴 것이라 자리표시자가 섞일 수
+        # 있다. DB에 그대로 저장하면 사용자가 나중에 읽는 일지가 내부 토큰이 된다 —
+        # 저장은 마스킹 경계 바깥이므로 여기서 원값으로 되돌린다 (#231).
+        title = restore_outbound((inp.title or "").strip())
+        content = restore_outbound((inp.content or "").strip())
         if not title:
             result = _err_json("diary_title_required", hint="Provide a non-empty title.")
             _record_to_ledger("finus_save_diary", result)
@@ -1318,7 +1388,7 @@ async def finus_save_diary(config: FinusSaveDiaryConfig, _builder: Builder):
             return result
         result = json.dumps(body.get("data"), ensure_ascii=False)
         _record_to_ledger("finus_save_diary", result)
-        return result
+        return _mask_account_tool_result("finus_save_diary", result)
 
     yield FunctionInfo.from_fn(
         save_trading_diary,
@@ -1364,7 +1434,7 @@ async def finus_list_diaries(config: FinusListDiariesConfig, _builder: Builder):
             return result
         result = json.dumps(body.get("data"), ensure_ascii=False)
         _record_to_ledger("finus_list_diaries", result)
-        return result
+        return _mask_account_tool_result("finus_list_diaries", result)
 
     yield FunctionInfo.from_fn(
         list_trading_diaries,

--- a/finus_nat/src/nat_finus_nat/pii.py
+++ b/finus_nat/src/nat_finus_nat/pii.py
@@ -1,0 +1,390 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NAT 프로세스 내부에서 만들어지는 계좌 PII의 마스킹 경계 (#231, F-17 / NFR-05).
+
+## 왜 backend 마스킹(#230)으로 막히지 않는가
+
+`backend/services.py`의 `llm_chat()`은 backend가 **보내는 프롬프트**를 마스킹한다.
+그런데 NAT 경로에서 backend가 보내는 것은 사용자 발화(`user_msg`) 하나뿐이고,
+계좌 데이터는 그 다음 단계에서 NAT 프로세스 **안에서** 생긴다:
+
+    backend --("내 잔고 어때?")--> NAT 라우터 --> trading_agent
+        --> KIS/mcp-trading 도구 호출 --> 잔고 리포트
+        --> ReAct 컨텍스트에 삽입 --> openai_cloud_llm (api.openai.com)
+
+backend는 3~4단계를 보지 못한다. 그래서 마스킹 지점이 이쪽에도 하나 더 필요하다.
+
+## 경계 (이 모듈이 정의하는 것)
+
+들어오는 쪽 — **마스킹**:
+    계좌 범위 도구의 결과 텍스트가 에이전트(=LLM 컨텍스트)로 돌아가기 직전.
+    호출 지점은 `finus_api.py`의 `_mask_account_tool_result()` 세 곳뿐이다.
+
+나가는 쪽 — **복원**:
+    1. 최상위 워크플로 응답 (`agents.finus_reasoning_trace_agent`) — 사용자에게 나가는 본문.
+    2. LLM이 만든 도구 인자 (`finus_api._restore_outbound_arguments()`) — MCP·backend로
+       실제 값이 나가야 하는 자리. 여기서 복원하지 않으면 자리표시자가 그대로 주문
+       파라미터나 매매일지 본문으로 저장된다.
+
+두 방향 모두 :data:`PII_SESSION`에 담긴 **요청 하나짜리** 매핑을 쓴다. 박스는
+최상위 워크플로가 한 번만 심는다 — `DATA_TOOL_LEDGER`/`REASONING_TRACE`와 같은 이유로
+`ContextVar.set()`은 안쪽에서 바깥으로 전파되지 않기 때문이다.
+
+## 마스킹 엔진을 왜 import해서 쓰는가
+
+`backend/pii_mask.py`가 F-17의 마스킹 엔진이다(#230). finus_nat이 같은 정규식을
+복사하면 두 계층의 판정이 조용히 갈라진다 — 실제로 #330·#333·#334가 그 정규식을
+연달아 고쳤고, 복사본이 있었다면 그 수정이 NAT 경로에만 반영되지 않았을 것이다.
+그래서 이 모듈은 **파일 경로로 로드해 재사용만** 한다. `backend/pii_mask.py`는
+한 줄도 고치지 않는다(진행 중인 #332와 겹치지 않게 하려는 목적도 있다).
+
+finus_nat은 backend와 별도 패키지·별도 컨테이너라 `import backend.pii_mask`가 성립하지
+않는다. 그래서 :func:`_load_pii_mask`가 파일 위치를 직접 찾는다. Docker 이미지에는
+`finus_nat/Dockerfile`이 `backend/pii_mask.py` 한 파일만 복사해 넣는다.
+
+## 알려진 한계 (이번 범위에서 남기는 것)
+
+- **도구 호출마다 scope가 다르다.** `mask_pii`는 호출당 새 nonce를 뽑으므로, 같은
+  금액이 두 도구 결과에 나와도 서로 다른 자리표시자가 된다. LLM은 두 값이 같다는 것을
+  알 수 없다. 값 단위 동일성이 필요해지면 별도 이슈로 다룬다.
+- **이전 턴의 자리표시자는 복원되지 않는다.** SQLite 대화 기록에는 마스킹된 답변이
+  저장되고, 다음 턴의 세션 매핑에는 그 scope가 없다. `unmask_pii`의 fail-open 경로가
+  "(이전 금액 1)" 같은 중립 문구로 바꾼다 — 조용한 오답 대신 관측 가능한 저하다.
+  (반대로 저장을 원문으로 되돌리면 다음 턴 히스토리가 평문으로 OpenAI에 재전송된다.)
+"""
+
+import importlib.util
+import json
+import logging
+import os
+import sys
+from collections.abc import Iterator
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+class PiiMaskUnavailableError(RuntimeError):
+    """마스킹 엔진(`backend/pii_mask.py`)을 로드하거나 적용하지 못했다.
+
+    호출부는 이 예외를 **원본 데이터를 반환하지 않는 방향**으로 처리해야 한다
+    (fail-closed). 유출보다 기능 실패가 낫다는 것이 F-17의 전제다.
+    """
+
+
+class _PiiMaskModule(Protocol):
+    """`backend/pii_mask.py`가 제공해야 하는 최소 공개 API (#230)."""
+
+    def mask_pii(self, text: str | None) -> tuple[str | None, dict[str, str]]: ...
+
+    def unmask_pii(self, text: str | None, mapping: dict[str, str]) -> str | None: ...
+
+
+# 로드된 모듈 캐시. None은 "아직 시도하지 않음"이다 — 실패는 캐시하지 않는다.
+# 배포 도중 파일이 늦게 마운트되는 경우(볼륨 마운트 순서)에 재시도가 가능해야 한다.
+_MASKER: Any = None
+
+#: `backend/pii_mask.py`를 직접 가리키는 경로 재정의. 컨테이너 배치가 아래 탐색과
+#: 다를 때만 쓴다.
+_PATH_ENV = "FINUS_PII_MASK_PATH"
+
+#: 파일 위치를 로드된 모듈 이름과 분리한다 — `backend` 패키지로 등록하면 backend
+#: 프로세스와 이름이 겹쳐 진단이 어려워진다.
+_MODULE_NAME = "nat_finus_nat._vendored_backend_pii_mask"
+
+
+def _finus_nat_root() -> Path:
+    """finus_nat 패키지 루트 (`src/nat_finus_nat/pii.py` -> `finus_nat/`)."""
+    return Path(__file__).resolve().parents[2]
+
+
+def _pii_mask_candidates() -> Iterator[Path]:
+    """`backend/pii_mask.py` 후보 경로를 우선순위대로 낸다.
+
+    ``finus_api.fin_us_vendor_root()``와 같은 규칙을 의도적으로 **복제**한다.
+    그 함수는 `nat.*`를 import하는 모듈에 있어서, 이 모듈이 그것을 import하면
+    NAT 런타임 없이는 마스킹 계층을 단위 테스트할 수 없게 된다. 규칙이 갈라지면
+    후보 목록이 한 칸 늘어날 뿐 마스킹이 조용히 꺼지지는 않는다 —
+    어느 후보에서도 못 찾으면 fail-closed로 떨어진다.
+    """
+    override = os.environ.get(_PATH_ENV, "").strip()
+    if override:
+        yield Path(override).expanduser().resolve()
+        return
+
+    vendor_root = os.environ.get("FINUS_VENDOR_ROOT", "").strip()
+    if vendor_root:
+        # Docker: FINUS_VENDOR_ROOT=/workspace, Dockerfile이 여기에 파일을 복사한다.
+        yield Path(vendor_root).expanduser().resolve() / "backend" / "pii_mask.py"
+
+    integrate_root = _finus_nat_root().parent
+    yield integrate_root / "backend" / "pii_mask.py"          # 저장소 체크아웃(로컬 실행)
+    yield integrate_root / "fin-us" / "backend" / "pii_mask.py"  # finus_nat이 형제 디렉터리인 배치
+
+
+def _load_pii_mask() -> Any:
+    """`backend/pii_mask.py`를 파일 경로로 로드해 캐시한다.
+
+    Raises:
+        PiiMaskUnavailableError: 후보 경로 어디에도 파일이 없거나 로드에 실패했을 때.
+    """
+    global _MASKER
+    if _MASKER is not None:
+        return _MASKER
+
+    tried: list[str] = []
+    for candidate in _pii_mask_candidates():
+        tried.append(str(candidate))
+        if not candidate.is_file():
+            continue
+        spec = importlib.util.spec_from_file_location(_MODULE_NAME, candidate)
+        if spec is None or spec.loader is None:
+            continue
+        module = importlib.util.module_from_spec(spec)
+        # sys.modules 등록은 실행 **전에** 해야 한다 — dataclass/typing 등 일부 구문이
+        # 자기 모듈을 sys.modules에서 되찾는다.
+        sys.modules[_MODULE_NAME] = module
+        try:
+            spec.loader.exec_module(module)
+        except Exception as exc:  # noqa: BLE001
+            sys.modules.pop(_MODULE_NAME, None)
+            raise PiiMaskUnavailableError(
+                f"backend/pii_mask.py 로드 실패: {candidate} ({exc})"
+            ) from exc
+        if not (hasattr(module, "mask_pii") and hasattr(module, "unmask_pii")):
+            sys.modules.pop(_MODULE_NAME, None)
+            raise PiiMaskUnavailableError(
+                f"{candidate}에 mask_pii/unmask_pii가 없습니다 — F-17 마스킹 엔진이 아닙니다."
+            )
+        _MASKER = module
+        logger.info("PII 마스킹 엔진을 로드했습니다: %s", candidate)
+        return _MASKER
+
+    raise PiiMaskUnavailableError(
+        "backend/pii_mask.py를 찾지 못했습니다. 탐색 경로: "
+        + ", ".join(tried)
+        + f". 배치가 다르면 {_PATH_ENV}로 파일 경로를 직접 지정하세요."
+    )
+
+
+@dataclass
+class PiiSession:
+    """요청 하나 동안의 자리표시자 -> 원값 매핑.
+
+    ``mask_pii``는 호출마다 새 매핑을 돌려주므로, 한 요청에서 도구를 여러 번 부르면
+    매핑도 여러 개가 된다. 복원은 요청 끝에서 한 번에 일어나야 하므로 여기서 누적한다.
+    scope nonce가 호출마다 달라 키가 겹치지 않는다(`backend/pii_mask.py`의 `_Counter`
+    docstring 참고).
+    """
+
+    mapping: dict[str, str] = field(default_factory=dict)
+
+    def mask(self, text: str) -> str:
+        """*text*를 마스킹하고 매핑을 이 세션에 누적한다.
+
+        Raises:
+            PiiMaskUnavailableError: 마스킹 엔진을 쓸 수 없을 때.
+        """
+        masker = _load_pii_mask()
+        try:
+            masked, mapping = masker.mask_pii(text)
+        except Exception as exc:  # noqa: BLE001
+            raise PiiMaskUnavailableError(f"마스킹 적용 실패: {exc}") from exc
+        self.mapping.update(mapping)
+        return masked if masked is not None else text
+
+    def unmask(self, text: str) -> str:
+        """사용자에게 나가는 본문의 자리표시자를 원값으로 되돌린다.
+
+        ``unmask_pii``는 예외를 던지지 않는다(fail-open). 매핑에 없는 자리표시자는
+        중립 문구로 바뀐다 — 내부 토큰이 화면에 그대로 노출되는 것을 막기 위해서다.
+        엔진을 못 불러오면 마스킹도 되지 않았다는 뜻이므로 원문을 그대로 돌려준다.
+        """
+        if not text:
+            return text
+        try:
+            masker = _load_pii_mask()
+            restored = masker.unmask_pii(text, self.mapping)
+        except PiiMaskUnavailableError:
+            logger.error("PII 역치환 불가 — 마스킹 엔진을 로드하지 못했습니다.")
+            return text
+        return restored if restored is not None else text
+
+    def restore_literal(self, text: str) -> str:
+        """기계가 읽을 값(도구 인자)에서 **아는 자리표시자만** 원값으로 되돌린다.
+
+        :meth:`unmask`와 달리 모르는 자리표시자를 "(이전 금액 1)" 같은 한국어
+        중립 문구로 바꾸지 않는다. 사용자 화면이라면 그 대체가 맞지만, 주문 수량이나
+        가격 파라미터 자리에서는 한국어 문구가 토큰보다 나을 게 없고 실패 원인만
+        가린다. 여기서는 손대지 않고 남겨 호출 실패로 드러나게 한다.
+        """
+        if not text or not self.mapping:
+            return text
+        restored = text
+        for placeholder, original in self.mapping.items():
+            if placeholder in restored:
+                restored = restored.replace(placeholder, original)
+        return restored
+
+
+#: 요청 하나짜리 마스킹 세션 상자. 최상위 워크플로가 심고, 안쪽은 읽기만 한다.
+PII_SESSION: ContextVar[PiiSession | None] = ContextVar("finus_pii_session", default=None)
+
+
+# ---- 마스킹 대상 판정 ----
+
+#: 결과 전체가 사용자 계좌 데이터인 도구들 — 도구 이름만으로 마스킹이 결정된다.
+#: mcp-trading은 서버 전체가 KIS 계좌 TR 래퍼라 도구 단위로 판정할 수 있다
+#: (balance.js / balance-rlz-pl-report.js / order.js 모두 CANO 기반).
+#: 매매일지 2종은 사용자가 적은 자기 거래 기록이라 금액·수량이 그대로 들어 있다.
+#:
+#: 여기 **없는** 도구는 마스킹되지 않는다. 뉴스(`finus_market_news`)와 공시·실적
+#: (`finus_disclosure_signal`, `finus_earnings_report`)은 공개 정보이고 F-17의 보호
+#: 대상이 아니다 — 가리면 분석만 망가지고 막히는 유출은 없다.
+#: KIS pass-through(`finus_account_balance`)는 도구 단위로 정할 수 없어 여기 두지 않고
+#: :func:`kis_api_type_is_account_scoped`가 api_type 단위로 가른다.
+ACCOUNT_SCOPED_TOOLS: frozenset[str] = frozenset({
+    "finus_mcp_trading_get_balance",
+    "finus_mcp_trading_balance_rlz_pl",
+    "finus_mcp_trading_today_orders",
+    "finus_list_diaries",
+    "finus_save_diary",
+})
+
+# KIS Trading MCP pass-through(`finus_account_balance`)는 한 도구가 계좌 TR과 시세 TR을
+# 모두 태운다. 그래서 api_type 단위로 갈라야 한다.
+#
+# 방향은 **allowlist(fail-closed)** 다 — `_READONLY_API_ALLOWLIST_PREFIXES`와 같은 방식.
+# 모르는 api_type은 마스킹한다. 반대로 deny-list로 두면 KIS가 새 계좌 TR을 추가하는
+# 순간 조용히 평문으로 나간다.
+#
+# 여기에 올릴 수 있는 것은 **공개 시장 데이터**뿐이다 — 시세·호가·체결·지수·수급·순위·
+# 종목검색. 이것들은 F-17의 보호 대상(계좌번호·보유수량·계좌 금액)이 아니고, 가리면
+# "삼성전자 지금 얼마야?" 같은 가장 흔한 질문에서 에이전트가 답을 만들 수 없다.
+#
+# 운영자 추가 방법: 새 **시세** TR이 아래 접두사에 걸리지 않으면 접두사를 넓히거나
+# _PUBLIC_MARKET_API_EXACT에 정확한 이름을 추가하세요. 계좌 TR은 절대 추가하지 마세요.
+_PUBLIC_MARKET_API_PREFIXES: tuple[str, ...] = (
+    "inquire_price",        # 현재가
+    "inquire_daily_price",  # 일자별 시세
+    "inquire_asking_price",  # 호가/예상체결
+    "inquire_ccnl",         # 체결가 시세(계좌 체결내역 inquire_daily_ccld와 다르다)
+    "inquire_time_",        # 시간대별 체결·차트
+    "inquire_daily_itemchartprice",
+    "inquire_index",        # 지수
+    "inquire_investor",     # 투자자별 수급(시장 통계)
+    "inquire_member",       # 회원사 수급
+    "inquire_elw_",         # ELW 시세
+    "search_",              # 종목 검색
+    "ranking_",             # 각종 순위
+    "volume_rank",          # 거래량 순위
+    "market_cap",           # 시가총액
+    "fluctuation",          # 등락률 순위
+    "quotations",           # 시세 계열 경로 표기
+)
+_PUBLIC_MARKET_API_EXACT: frozenset[str] = frozenset({
+    "find_api_detail",  # TR 스키마 조회 — 계좌 값이 실리지 않는다.
+})
+
+
+def kis_api_type_is_account_scoped(api_type: str) -> bool:
+    """KIS pass-through의 *api_type*이 계좌 데이터를 낼 수 있으면 True (fail-closed).
+
+    공개 시장 데이터 allowlist에 없으면 전부 True다. 잘못 True로 판정하면 시세가
+    가려져 답변 품질이 떨어지고, 잘못 False로 판정하면 계좌 데이터가 평문으로
+    OpenAI에 나간다 — 비대칭이므로 모르는 쪽은 True로 눕힌다.
+    """
+    lower = (api_type or "").strip().lower()
+    if not lower:
+        return True
+    if lower in _PUBLIC_MARKET_API_EXACT:
+        return False
+    return not any(lower.startswith(prefix) for prefix in _PUBLIC_MARKET_API_PREFIXES)
+
+
+# ---- 호출부가 쓰는 얇은 진입점 ----
+
+
+def current_session() -> PiiSession | None:
+    return PII_SESSION.get()
+
+
+def mask_account_text(text: str) -> str:
+    """계좌 범위 도구 결과를 마스킹해 돌려준다.
+
+    세션 상자가 없으면(최상위 워크플로를 거치지 않은 호출 — `nat run` 단발 호출,
+    직접 함수 호출 등) 일회용 세션으로 마스킹하고 ERROR를 남긴다. 자리표시자를
+    되돌릴 방법이 없어 답변 품질은 떨어지지만, 상자가 없다고 원값을 흘리는 것보다
+    낫다. `_record_to_ledger`가 원장 상자 부재를 다루는 방식과 같은 판단이다.
+
+    Raises:
+        PiiMaskUnavailableError: 마스킹 엔진을 쓸 수 없을 때. 호출부는 원본 대신
+            오류를 반환해야 한다.
+    """
+    if not text:
+        return text
+    session = PII_SESSION.get()
+    if session is None:
+        logger.error(
+            "PII_SESSION이 없는 상태로 계좌 도구 결과를 마스킹합니다 — 자리표시자를 "
+            "복원할 수 없습니다. 최상위 워크플로(finus_reasoning_trace_agent) 밖에서 "
+            "도구가 실행된 경우입니다."
+        )
+        session = PiiSession()
+    return session.mask(text)
+
+
+def restore_outbound(value: Any) -> Any:
+    """LLM이 만든 값(도구 인자)에서 아는 자리표시자를 원값으로 되돌린다.
+
+    dict/list를 재귀적으로 훑어 문자열만 손댄다. 세션이 없거나 매핑이 비면 입력을
+    그대로 돌려준다 — 마스킹한 적이 없으면 되돌릴 것도 없다.
+    """
+    session = PII_SESSION.get()
+    if session is None or not session.mapping:
+        return value
+    return _restore_outbound_with(value, session)
+
+
+def _restore_outbound_with(value: Any, session: PiiSession) -> Any:
+    if isinstance(value, str):
+        return session.restore_literal(value)
+    if isinstance(value, dict):
+        return {key: _restore_outbound_with(item, session) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_restore_outbound_with(item, session) for item in value]
+    return value
+
+
+def masking_unavailable_error_json(tool_name: str, detail: str) -> str:
+    """fail-closed 응답 본문 — 원본 데이터 대신 에이전트에게 돌려줄 오류 JSON.
+
+    `finus_api._err_json`과 같은 모양(`{"error": ...}`)이라 `_ERROR_JSON_PREFIX_RE`
+    판정과 원장 기록이 그대로 동작한다. 그 함수를 쓰지 않는 이유는 순환 import
+    때문이다 — `finus_api`가 이 모듈을 import한다.
+    """
+    return json.dumps(
+        {
+            "error": "pii_masking_unavailable",
+            "tool": tool_name,
+            "detail": detail,
+            "hint": (
+                "계좌 데이터를 마스킹할 수 없어 조회 결과를 반환하지 않았습니다(#231). "
+                "재시도하지 말고 사용자에게 일시적인 오류임을 안내하세요."
+            ),
+        },
+        ensure_ascii=False,
+    )

--- a/finus_nat/tests/test_pii_tool_masking.py
+++ b/finus_nat/tests/test_pii_tool_masking.py
@@ -1,0 +1,568 @@
+"""#231: NAT 도구 결과 PII 마스킹 경계 고정 테스트.
+
+이 스위트가 지키는 계약은 셋이다.
+
+1. **마스킹 경계** — 계좌 범위 도구의 결과는 마스킹된 채로 에이전트(=LLM 컨텍스트)에
+   들어간다. 여기가 뚫리면 잔고가 평문으로 api.openai.com에 도달한다.
+2. **복원 경계** — 자리표시자는 최상위 워크플로 응답과 도구 인자에서만 원값으로
+   돌아온다. 여기가 뚫리면 사용자가 ``<AMOUNT_9f2a1c_1>``을 읽게 된다.
+3. **fail-closed** — 마스킹 엔진을 쓸 수 없으면 원본 대신 오류를 반환한다.
+
+실 KIS·OpenAI·backend 연결 없이 동작한다. MCP 왕복만 가짜로 갈아끼운다.
+"""
+
+import json
+import re
+from contextlib import asynccontextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from nat.data_models.api_server import ChatRequestOrMessage, ChatResponse, Usage
+
+from nat_finus_nat import pii
+from nat_finus_nat.agents import (
+    FinusReasoningTraceAgentConfig,
+    _trace_branch_answer,
+    _trace_ledger_tools,
+    _trace_route,
+    finus_reasoning_trace_agent,
+    without_pii_placeholders,
+)
+from nat_finus_nat.finus_api import (
+    DATA_TOOL_LEDGER,
+    DataToolLedger,
+    FinusAccountBalanceConfig,
+    FinusListDiariesConfig,
+    FinusMcpTradingBalanceRlzPlConfig,
+    FinusMcpTradingGetBalanceConfig,
+    FinusMcpTradingGetBalanceInput,
+    FinusMcpTradingStockNameInput,
+    FinusListDiariesInput,
+    FinusMarketNewsConfig,
+    FinusSaveDiaryConfig,
+    FinusSaveDiaryInput,
+    _ERROR_JSON_PREFIX_RE,
+    _call_kis_mcp_and_record,
+    _record_to_ledger,
+    finus_list_diaries,
+    finus_market_news,
+    finus_mcp_trading_balance_rlz_pl,
+    finus_mcp_trading_get_balance,
+    finus_save_diary,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_FINUS_API_SOURCE = Path(__file__).resolve().parents[1] / "src" / "nat_finus_nat" / "finus_api.py"
+
+#: mcp-trading/backend가 공유하는 잔고 리포트 픽스처(#137). 오늘 실제로 LLM 컨텍스트에
+#: 실리는 문자열이 이것이므로, 합성 문자열 대신 이 값으로 경계를 고정한다.
+_BALANCE_FIXTURE = json.loads(
+    (_REPO_ROOT / "mcp-trading" / "tests" / "fixtures" / "balance_report.json").read_text(
+        encoding="utf-8"
+    )
+)
+BALANCE_REPORT: str = _BALANCE_FIXTURE["normal"]["expected_text"]
+
+#: 잔고 리포트에서 반드시 가려져야 하는 값들 — 이슈 #231이 열거한 유출 대상
+#: (예수금·총평가금액·평가금액·평단가·보유수량).
+_MUST_NOT_LEAK = (
+    "1,210,000원",  # 총 평가금액 / 순자산금액
+    "1,000,000원",  # 예수금
+    "210,000원",    # 평가금액 / 금일 매수
+    "67,000원",     # 평단가
+    "201,000원",    # 평단가
+    "200,500원",    # 평가금액
+    "3주",          # 보유 수량
+    "1주",          # 보유 수량
+)
+
+#: 실현손익 리포트의 "[계좌 집계]" 블록에는 실제 계좌번호가 실린다
+#: (finus_api._has_empty_result 주석 참고).
+RLZ_PL_REPORT = (
+    "[실현손익]\n- 삼성전자 (005930) · 3주\n  실현손익 9,000원\n\n"
+    "[계좌 집계]\n- 계좌번호: 12345678-01\n- 예수금: 1,000,000원"
+)
+
+_PLACEHOLDER_RE = re.compile(r"<(ACCOUNT|AMOUNT|QTY)_[0-9a-f]{6}_\d+>")
+
+
+# ---------------------------------------------------------------------------
+# 헬퍼
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _pii_session():
+    """모든 테스트에 최상위 워크플로가 심는 것과 같은 세션 상자를 준다."""
+    session = pii.PiiSession()
+    token = pii.PII_SESSION.set(session)
+    yield session
+    pii.PII_SESSION.reset(token)
+
+
+@pytest.fixture(autouse=True)
+def _ledger():
+    """원장 부재 ERROR 로그가 테스트 출력을 덮지 않도록 상자를 심는다."""
+    ledger = DataToolLedger()
+    token = DATA_TOOL_LEDGER.set(ledger)
+    yield ledger
+    DATA_TOOL_LEDGER.reset(token)
+
+
+def _stub_mcp_call(monkeypatch, result: str) -> list[dict]:
+    """stdio MCP 왕복을 가짜로 갈아끼우고, 실제로 전달된 인자를 수집해 돌려준다."""
+    seen: list[dict] = []
+
+    async def _fake(*, vendor_root, subdir, tool_name, arguments, timeout_sec):  # noqa: ARG001
+        seen.append(dict(arguments))
+        return result
+
+    monkeypatch.setattr("nat_finus_nat.finus_api._mcp_call_tool", _fake)
+    return seen
+
+
+def _stub_remote_mcp_call(monkeypatch, result: str) -> list[dict]:
+    seen: list[dict] = []
+
+    async def _fake(*, transport, url, tool_name, arguments, timeout_sec):  # noqa: ARG001
+        seen.append(dict(arguments))
+        return result
+
+    monkeypatch.setattr("nat_finus_nat.finus_api._mcp_call_tool_remote", _fake)
+    return seen
+
+
+async def _single_fn(register_gen, config, builder=None):
+    """등록 제너레이터에서 실제 도구 함수 하나를 꺼낸다."""
+    async with register_gen(config, builder or MagicMock()) as info:
+        return info.single_fn
+
+
+def _assert_masked(text: str) -> None:
+    for raw in _MUST_NOT_LEAK:
+        assert raw not in text, f"마스킹되지 않은 값이 LLM 경계를 넘었습니다: {raw!r}"
+    assert _PLACEHOLDER_RE.search(text), "자리표시자가 하나도 없습니다 — 마스킹이 적용되지 않았습니다."
+
+
+# ---------------------------------------------------------------------------
+# 1. 마스킹 경계 — 계좌 데이터가 마스킹된 채로 LLM 컨텍스트에 들어간다
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_balance_report_crosses_the_llm_boundary_masked(monkeypatch):
+    """이슈 #231의 본체: get_balance 결과가 평문으로 ReAct 컨텍스트에 들어가면 red."""
+    _stub_mcp_call(monkeypatch, BALANCE_REPORT)
+    fn = await _single_fn(finus_mcp_trading_get_balance, FinusMcpTradingGetBalanceConfig())
+
+    observation = await fn(FinusMcpTradingGetBalanceInput())
+
+    _assert_masked(observation)
+    # 종목명·수익률은 남는다 — F-17 대상이 아니고, 가리면 분석이 불가능해진다.
+    assert "삼성전자" in observation
+    assert "+4.48%" in observation
+
+
+@pytest.mark.asyncio
+async def test_account_number_in_rlz_pl_report_is_masked(monkeypatch):
+    _stub_mcp_call(monkeypatch, RLZ_PL_REPORT)
+    fn = await _single_fn(finus_mcp_trading_balance_rlz_pl, FinusMcpTradingBalanceRlzPlConfig())
+
+    observation = await fn(FinusMcpTradingStockNameInput())
+
+    assert "12345678-01" not in observation
+    assert "<ACCOUNT_" in observation
+
+
+@pytest.mark.asyncio
+async def test_diary_list_is_masked(monkeypatch):
+    """매매일지는 사용자가 적은 자기 거래 기록이라 금액이 그대로 들어 있다."""
+
+    class _Resp:
+        @staticmethod
+        def raise_for_status() -> None: ...
+
+        @staticmethod
+        def json() -> dict:
+            return {"status": "success", "data": [{"content": "삼성전자 3주 210,000원에 매수"}]}
+
+    monkeypatch.setattr(
+        "nat_finus_nat.finus_api.httpx.AsyncClient",
+        lambda **_: _async_client_stub(get=_Resp()),
+    )
+    fn = await _single_fn(finus_list_diaries, FinusListDiariesConfig())
+
+    observation = await fn(FinusListDiariesInput())
+
+    assert "210,000원" not in observation
+    assert "3주" not in observation
+    assert "<AMOUNT_" in observation
+
+
+@pytest.mark.asyncio
+async def test_public_news_result_is_not_masked(monkeypatch):
+    """뉴스·공시는 공개 정보다. 가리면 분석만 망가지고 막히는 유출은 없다."""
+    news = "삼성전자 목표주가 95,000원으로 상향"
+    _stub_mcp_call(monkeypatch, news)
+    fn = await _single_fn(finus_market_news, FinusMarketNewsConfig())
+
+    observation = await fn("삼성전자")
+
+    assert observation == news
+
+
+# ---------------------------------------------------------------------------
+# 2. KIS pass-through — 한 도구 안에서 api_type으로 계좌/시세를 가른다
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "api_type,account_scoped",
+    [
+        ("inquire_balance", True),
+        ("inquire_account_balance", True),
+        ("inquire_present_balance", True),
+        ("inquire_psbl_order", True),
+        ("inquire_daily_ccld", True),
+        ("order_cash", True),
+        ("", True),
+        ("brand_new_kis_tr", True),  # 모르는 것은 마스킹한다(fail-closed)
+        ("inquire_price", False),
+        ("inquire_asking_price_exp_ccn", False),
+        ("inquire_daily_itemchartprice", False),
+        ("inquire_investor", False),
+        ("volume_rank", False),
+        ("search_stock_info", False),
+        ("find_api_detail", False),
+    ],
+)
+def test_kis_api_type_policy(api_type, account_scoped):
+    assert pii.kis_api_type_is_account_scoped(api_type) is account_scoped
+
+
+@pytest.mark.asyncio
+async def test_kis_balance_lookup_is_masked(monkeypatch):
+    _stub_remote_mcp_call(monkeypatch, BALANCE_REPORT)
+
+    result = await _call_kis_mcp_and_record(
+        "domestic_stock",
+        {"api_type": "inquire_balance", "params": {}},
+        FinusAccountBalanceConfig(),
+    )
+
+    _assert_masked(result)
+
+
+@pytest.mark.asyncio
+async def test_kis_price_lookup_keeps_public_market_data(monkeypatch):
+    """현재가는 PII가 아니다 — 가리면 가장 흔한 질문에 답할 수 없게 된다."""
+    quote = "삼성전자 현재가 75,300원 (+1.2%)"
+    _stub_remote_mcp_call(monkeypatch, quote)
+
+    result = await _call_kis_mcp_and_record(
+        "domestic_stock",
+        {"api_type": "inquire_price", "params": {}},
+        FinusAccountBalanceConfig(),
+    )
+
+    assert result == quote
+
+
+@pytest.mark.asyncio
+async def test_unknown_kis_api_type_is_masked(monkeypatch):
+    """허용 목록에 없는 api_type은 계좌 TR로 간주한다(fail-closed)."""
+    _stub_remote_mcp_call(monkeypatch, BALANCE_REPORT)
+
+    result = await _call_kis_mcp_and_record(
+        "domestic_stock",
+        {"api_type": "inquire_some_future_account_tr", "params": {}},
+        FinusAccountBalanceConfig(),
+    )
+
+    _assert_masked(result)
+
+
+# ---------------------------------------------------------------------------
+# 3. fail-closed — 마스킹이 불가능하면 원본을 내보내지 않는다
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_masking_failure_blocks_the_result_instead_of_leaking(monkeypatch):
+    """엔진을 못 찾으면 잔고 대신 오류가 나간다. 유출보다 조회 실패가 낫다."""
+    monkeypatch.setattr(pii, "_MASKER", None)
+    monkeypatch.setenv(pii._PATH_ENV, str(_REPO_ROOT / "does" / "not" / "exist.py"))
+    _stub_mcp_call(monkeypatch, BALANCE_REPORT)
+    fn = await _single_fn(finus_mcp_trading_get_balance, FinusMcpTradingGetBalanceConfig())
+
+    observation = await fn(FinusMcpTradingGetBalanceInput())
+
+    for raw in _MUST_NOT_LEAK:
+        assert raw not in observation
+    assert json.loads(observation)["error"] == "pii_masking_unavailable"
+
+
+def test_fail_closed_payload_is_shaped_like_other_tool_errors():
+    """원장(_record_to_ledger)과 에이전트가 오류로 인식할 수 있어야 한다."""
+    payload = pii.masking_unavailable_error_json("finus_mcp_trading_get_balance", "boom")
+    assert _ERROR_JSON_PREFIX_RE.match(payload)
+
+
+def test_missing_session_still_masks(caplog):
+    """세션 상자가 없어도 원값을 흘리지 않는다 — 복원 불가를 감수하고 마스킹한다."""
+    token = pii.PII_SESSION.set(None)
+    try:
+        with caplog.at_level("ERROR"):
+            masked = pii.mask_account_text("예수금 1,000,000원")
+    finally:
+        pii.PII_SESSION.reset(token)
+
+    assert "1,000,000원" not in masked
+    assert any("PII_SESSION" in record.message for record in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# 4. 복원 경계 — 자리표시자는 최상위 응답과 도구 인자에서만 돌아온다
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_workflow_restores_placeholders_in_the_user_facing_answer(monkeypatch, tmp_path):
+    """도구 -> 마스킹 -> LLM -> 최상위 응답 왕복. 사용자에게는 원값이 나간다."""
+    _stub_mcp_call(monkeypatch, BALANCE_REPORT)
+    balance_fn = await _single_fn(finus_mcp_trading_get_balance, FinusMcpTradingGetBalanceConfig())
+    seen_by_llm: list[str] = []
+
+    async def inner(_request):
+        # 브랜치가 도구를 부르고, 그 관측(Observation)을 인용해 답변을 만든다.
+        observation = await balance_fn(FinusMcpTradingGetBalanceInput())
+        seen_by_llm.append(observation)
+        _record_to_ledger("finus_mcp_trading_get_balance", observation)
+        answer = "예수금은 " + observation.split("- 예수금: ")[1].split("\n")[0] + " 입니다."
+        _trace_branch_answer(answer)
+        return ChatResponse.from_string(answer, usage=Usage())
+
+    inner_fn = MagicMock()
+    inner_fn.ainvoke = AsyncMock(side_effect=inner)
+    builder = MagicMock()
+    builder.get_function = AsyncMock(return_value=inner_fn)
+
+    async with finus_reasoning_trace_agent(
+        FinusReasoningTraceAgentConfig(inner_agent_name="inner"), builder
+    ) as info:
+        result = await info.single_fn(
+            ChatRequestOrMessage(messages=[{"role": "user", "content": "내 잔고 어때?"}])
+        )
+
+    # LLM이 본 것은 마스킹된 텍스트다.
+    _assert_masked(seen_by_llm[0])
+    # 사용자가 받는 것은 원값이다.
+    assert result.choices[0].message.content == "예수금은 1,000,000원 입니다."
+
+
+@pytest.mark.asyncio
+async def test_restore_runs_after_the_footnote_check(monkeypatch):
+    """복원이 각주 부착보다 먼저면 본문 비교가 어긋나 각주가 통째로 사라진다(#294)."""
+    _stub_mcp_call(monkeypatch, BALANCE_REPORT)
+    balance_fn = await _single_fn(finus_mcp_trading_get_balance, FinusMcpTradingGetBalanceConfig())
+
+    async def inner(_request):
+        ledger = DataToolLedger()
+        token = DATA_TOOL_LEDGER.set(ledger)
+        try:
+            observation = await balance_fn(FinusMcpTradingGetBalanceInput())
+            _record_to_ledger("finus_mcp_trading_get_balance", observation)
+        finally:
+            DATA_TOOL_LEDGER.reset(token)
+        _trace_route("trading_agent")
+        _trace_ledger_tools(ledger)
+        answer = "예수금은 " + observation.split("- 예수금: ")[1].split("\n")[0] + " 입니다."
+        _trace_branch_answer(answer)
+        return ChatResponse.from_string(answer, usage=Usage())
+
+    inner_fn = MagicMock()
+    inner_fn.ainvoke = AsyncMock(side_effect=inner)
+    builder = MagicMock()
+    builder.get_function = AsyncMock(return_value=inner_fn)
+
+    async with finus_reasoning_trace_agent(
+        FinusReasoningTraceAgentConfig(inner_agent_name="inner"), builder
+    ) as info:
+        result = await info.single_fn(
+            ChatRequestOrMessage(messages=[{"role": "user", "content": "내 잔고 어때?"}])
+        )
+
+    dumped = result.model_dump()
+    assert dumped["tools_used"] == [
+        {"name": "finus_mcp_trading_get_balance", "ok": True, "empty": False}
+    ]
+
+
+def test_restore_preserves_reasoning_trace_fields():
+    session = pii.PiiSession()
+    masked = session.mask("예수금 1,000,000원")
+    response = ChatResponse.from_string(masked, usage=Usage()).model_copy(
+        update={"routed_agent": "trading_agent", "tools_used": []}
+    )
+
+    restored = without_pii_placeholders(response, session)
+
+    dumped = restored.model_dump()
+    assert dumped["choices"][0]["message"]["content"] == "예수금 1,000,000원"
+    assert dumped["routed_agent"] == "trading_agent"
+
+
+def test_sessions_do_not_share_mappings_across_requests():
+    """앞 요청의 매핑으로 다음 요청의 자리표시자가 복원되면 조용한 오답이 된다."""
+    first = pii.PiiSession()
+    masked = first.mask("예수금 1,000,000원")
+
+    second = pii.PiiSession()
+    restored = second.unmask(masked)
+
+    assert "1,000,000원" not in restored
+    assert "(이전 금액 1)" in restored  # pii_mask의 fail-open 중립 문구
+
+
+# ---------------------------------------------------------------------------
+# 5. 나가는 쪽 — LLM이 만든 도구 인자는 원값으로 되돌린다
+# ---------------------------------------------------------------------------
+
+
+def _async_client_stub(*, get=None, post=None):
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    if get is not None:
+        client.get = AsyncMock(return_value=get)
+    if post is not None:
+        client.post = AsyncMock(return_value=post)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_mcp_arguments_are_restored_before_the_call(monkeypatch, _pii_session):
+    """자리표시자가 그대로 MCP로 나가면 주문·조회 파라미터가 내부 토큰이 된다.
+
+    복원 지점은 실제 세션이 열리는 ``_mcp_call_tool_remote`` 안이므로, MCP 세션만
+    가짜로 갈아끼워 ``call_tool``이 실제로 받은 인자를 본다.
+    """
+    masked = _pii_session.mask("1,000주")
+    seen: list[dict] = []
+
+    @asynccontextmanager
+    async def _fake_session(*, transport, url, operation_timeout):  # noqa: ARG001
+        async def _call_tool(tool_name, arguments):  # noqa: ARG001
+            seen.append(arguments)
+            return SimpleNamespace(content=[SimpleNamespace(text="ok")])
+
+        yield SimpleNamespace(call_tool=_call_tool)
+
+    monkeypatch.setattr("nat_finus_nat.finus_api._remote_mcp_session", _fake_session)
+
+    await _call_kis_mcp_and_record(
+        "domestic_stock",
+        {"api_type": "inquire_price", "params": {"qty": masked}},
+        FinusAccountBalanceConfig(),
+    )
+
+    assert seen[0]["params"]["qty"] == "1,000주"
+
+
+@pytest.mark.asyncio
+async def test_diary_content_is_restored_before_it_is_persisted(monkeypatch, _pii_session):
+    """마스킹된 본문이 그대로 저장되면 사용자가 나중에 읽는 일지가 토큰이 된다."""
+    masked_content = _pii_session.mask("삼성전자 3주를 210,000원에 매수")
+    captured: dict = {}
+
+    class _Resp:
+        @staticmethod
+        def raise_for_status() -> None: ...
+
+        @staticmethod
+        def json() -> dict:
+            return {"status": "success", "data": {"id": 1}}
+
+    client = _async_client_stub(post=_Resp())
+
+    async def _post(url, json=None):  # noqa: A002
+        captured["payload"] = json
+        return _Resp()
+
+    client.post = AsyncMock(side_effect=_post)
+    monkeypatch.setattr("nat_finus_nat.finus_api.httpx.AsyncClient", lambda **_: client)
+    fn = await _single_fn(finus_save_diary, FinusSaveDiaryConfig())
+
+    await fn(FinusSaveDiaryInput(title="매매일지", content=masked_content))
+
+    assert captured["payload"]["content"] == "삼성전자 3주를 210,000원에 매수"
+
+
+def test_outbound_restore_leaves_unknown_placeholders_alone():
+    """기계가 읽는 값에는 '(이전 금액 1)' 같은 한국어 대체를 넣지 않는다."""
+    session = pii.PiiSession()
+    session.mask("1,000,000원")
+    token = pii.PII_SESSION.set(session)
+    try:
+        restored = pii.restore_outbound({"qty": "<QTY_abcdef_9>"})
+    finally:
+        pii.PII_SESSION.reset(token)
+
+    assert restored == {"qty": "<QTY_abcdef_9>"}
+
+
+# ---------------------------------------------------------------------------
+# 6. 기존 계약 비회귀 — 원장(#152/#209)은 원문으로 판정한다
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ledger_still_sees_a_successful_read(monkeypatch, _ledger):
+    """마스킹이 원장 판정을 바꾸면 도구 강제 게이트가 헛돌며 조회를 두 번 한다."""
+    _stub_mcp_call(monkeypatch, BALANCE_REPORT)
+    fn = await _single_fn(finus_mcp_trading_get_balance, FinusMcpTradingGetBalanceConfig())
+
+    await fn(FinusMcpTradingGetBalanceInput())
+
+    assert _ledger.any_success() is True
+    assert _ledger.records[-1].empty is False
+
+
+@pytest.mark.asyncio
+async def test_ledger_still_detects_an_empty_result(monkeypatch, _ledger):
+    _stub_mcp_call(monkeypatch, "보유 종목이 없습니다.")
+    fn = await _single_fn(finus_mcp_trading_balance_rlz_pl, FinusMcpTradingBalanceRlzPlConfig())
+
+    await fn(FinusMcpTradingStockNameInput())
+
+    assert _ledger.only_empty_reads() is True
+
+
+# ---------------------------------------------------------------------------
+# 7. 드리프트 가드 — 마스킹 대상 목록과 실제 도구 이름이 어긋나지 않게
+# ---------------------------------------------------------------------------
+
+
+def test_account_scoped_tools_are_real_tool_names():
+    """오타 하나로 마스킹이 조용히 꺼지는 것을 막는다.
+
+    :func:`_mask_account_tool_result`는 이름이 목록에 없으면 그냥 통과시킨다 —
+    잘못 적은 이름은 예외가 아니라 평문 유출로 나타난다.
+    """
+    source = _FINUS_API_SOURCE.read_text(encoding="utf-8")
+    for tool_name in pii.ACCOUNT_SCOPED_TOOLS:
+        assert f'_record_to_ledger("{tool_name}"' in source, (
+            f"{tool_name}은 finus_api.py의 원장 기록 이름과 일치하지 않습니다."
+        )
+        assert f'_mask_account_tool_result("{tool_name}"' in source, (
+            f"{tool_name}이 ACCOUNT_SCOPED_TOOLS에 있지만 마스킹 호출부가 없습니다."
+        )
+
+
+def test_public_market_allowlist_has_no_account_tr():
+    """시세 허용 목록에 계좌 TR 접두사가 섞이면 그 순간 평문으로 나간다."""
+    forbidden = ("inquire_balance", "inquire_account", "inquire_psbl", "inquire_daily_ccld", "order")
+    for prefix in pii._PUBLIC_MARKET_API_PREFIXES:
+        assert not any(prefix.startswith(bad) for bad in forbidden), prefix


### PR DESCRIPTION
## 무엇을 고치나

NAT 경로에서 **계좌·잔고 데이터가 마스킹 없이 api.openai.com으로 나가던 것**을 막습니다.

`Refs #231`

## 위협 모델 — backend 마스킹(#230)으로 막히지 않는 이유

backend의 마스킹은 **backend가 조립한 프롬프트**를 가립니다. 그런데 NAT 경로에서 backend가
보내는 것은 사용자 발화 하나뿐이고, 계좌 데이터는 그 다음 단계에서 NAT 프로세스 **안에서**
생깁니다.

```
사용자: "내 잔고 어때?"
  1. backend --(user_msg only)--> NAT            # 마스킹해도 걸릴 PII가 없다
  2. NAT 라우터 --> trading_agent (ReAct)
  3. trading_agent --> KIS / mcp-trading 도구 호출
  4. 잔고 리포트(보유종목·수량·평단가·평가금액·예수금)가 Observation으로 컨텍스트에 삽입
  5. 그 컨텍스트가 openai_cloud_llm(api.openai.com)으로 전송   <-- 유출 지점
```

backend는 3~5단계를 보지 못합니다. 실제로 나가던 문자열은
`mcp-trading/tests/fixtures/balance_report.json`의 `expected_text`와 같은 형태입니다.

## 택한 선택지 — A(도구 결과 마스킹)

| 안 | 판단 |
| --- | --- |
| **A. MCP 도구 결과 마스킹** | **채택.** 유출 지점(4단계)에 가장 가깝고 방어 지점이 함수 4곳으로 좁습니다. 도구가 늘어도 한 곳에서 처리됩니다. |
| B. LLM 호출 직전 훅 | 미채택. NAT 1.6이 그 지점에 공개 훅을 주지 않아 `scripts/patch_vendor.py` 계열의 벤더 패치가 됩니다. `ci.yml`이 이미 벤더 패치 drift를 감시할 만큼 그 방식은 부채이고, #152에서 같은 이유로 패치를 걷어냈습니다. |
| C. 계좌 취급 에이전트를 로컬 모델로 | 미채택(이번 범위에서). 근본 해결이지만 모델 품질·운영 비용 판단과 에이전트별 LLM 분리 검증이 한 PR에 담기지 않습니다. **A와 배타적이지 않습니다** — C를 나중에 택해도 Mem0·SQLite 저장 경로는 남으므로 A는 그대로 유효합니다. |

## `pii_mask.py`와 #332가 겹치지 않게 한 방법

**`backend/pii_mask.py`는 한 줄도 고치지 않았습니다.** 파일 경로로 로드해 `mask_pii`/
`unmask_pii`를 **import 재사용만** 합니다(`finus_nat/src/nat_finus_nat/pii.py`의
`_load_pii_mask`). `backend/tests/test_pii_mask.py`와 `docs/nfr-05-pii-masking.md`도
건드리지 않았습니다 — 셋 다 열린 PR #332의 소관입니다.

정규식을 복사하지 않은 이유는 그 자체가 결함이기 때문입니다. #330·#333·#334가 그 정규식을
연달아 고쳤는데, 복사본이 있었다면 그 수정들이 NAT 경로에만 반영되지 않았을 것입니다.

finus_nat은 backend와 별도 패키지·별도 컨테이너라 `import backend.pii_mask`가 성립하지
않습니다. `finus_nat/Dockerfile`이 그 파일 **하나만** 이미지에 넣고
(순수 stdlib 모듈이라 backend 의존성이 따라오지 않습니다), `FINUS_VENDOR_ROOT`(=`/workspace`)
기준으로 찾습니다. 배치가 다르면 `FINUS_PII_MASK_PATH`로 직접 지정할 수 있습니다.

## 마스킹 / 언마스킹 경계

```
                          ┌─ 마스킹(들어오는 쪽) ─┐
KIS / mcp-trading / diary ─┤                      ├─> ReAct 컨텍스트 ─> OpenAI
                          └ _mask_account_tool_result

OpenAI ─> 최상위 워크플로 응답 ─ without_pii_placeholders ─> backend ─> 사용자
                    │
                    └ LLM이 만든 도구 인자 ─ restore_outbound ─> MCP / backend DB
```

- **마스킹** — `finus_api._mask_account_tool_result()`. 항상 `_record_to_ledger()` **뒤**입니다:
  원장(#152/#209)은 원문으로 판정해야 오류·빈 결과 리터럴 탐지가 마스킹에 흔들리지 않습니다.
  원장에 남는 것은 불리언 3개뿐이라 원문 판정이 유출로 이어지지 않습니다.
- **복원 1(사용자)** — `agents.finus_reasoning_trace_agent`. 두 라우터 config의 최상위
  `workflow`이므로 자리표시자가 이 경계를 넘어 사용자에게 나가는 경로는 없습니다.
  **각주 부착(`with_reasoning_trace`, #294) 뒤에** 실행합니다 — 각주 판정이 본문 문자열
  비교라, 먼저 복원하면 정상 경로의 각주가 통째로 사라집니다(회귀 테스트로 고정).
- **복원 2(기계)** — `restore_outbound()`. LLM이 만든 MCP 인자와 매매일지 본문은 실제
  시스템에 나가는 값이라 원값이어야 합니다. 여기서는 매핑에 없는 자리표시자를 한국어
  중립 문구로 바꾸지 **않습니다** — 주문 파라미터 자리에 "(이전 금액 1)"이 들어가는 것은
  토큰보다 나을 게 없고 실패 원인만 가립니다.
- **중간 구간은 전부 마스킹 상태** — ReAct 컨텍스트, supervisor 히스토리, Mem0 저장,
  SQLite 대화 기록, api.openai.com.

세션 매핑은 요청 하나짜리 `ContextVar`(`pii.PII_SESSION`)입니다. 최상위 워크플로가 한 번만
심고 안쪽은 읽기만 합니다 — `DATA_TOOL_LEDGER`/`REASONING_TRACE`와 같은 이유입니다.

## 분석 능력을 죽이지 않기 위해 — 무엇을 가리고 무엇을 남기나

가리면 분석이 불가능해지는 값까지 덮으면 기능이 죽습니다. **계좌 범위만** 가립니다.

| 대상 | 마스킹 | 근거 |
| --- | --- | --- |
| `finus_mcp_trading_get_balance` / `_balance_rlz_pl` / `_today_orders` | O | mcp-trading은 서버 전체가 CANO 기반 계좌 TR 래퍼 |
| `finus_save_diary` / `finus_list_diaries` | O | 사용자가 적은 자기 거래 기록 |
| `finus_account_balance`(KIS pass-through) | api_type별 | 한 도구가 계좌 TR과 시세 TR을 모두 태움 |
| `finus_market_news` / `finus_disclosure_signal` / `finus_earnings_report` | X | 공개 정보. 가리면 분석만 망가지고 막히는 유출은 없음 |
| 종목명 · 수익률(%) · 손익률 | X | F-17이 정의한 3종이 아님 |

KIS pass-through 판정(`kis_api_type_is_account_scoped`)은 **공개 시세 allowlist**
방식입니다 — 목록에 없는 api_type은 전부 계좌 TR로 간주해 마스킹합니다. deny-list로 두면
KIS가 새 계좌 TR을 추가하는 순간 조용히 평문으로 나갑니다. 반대 오판(시세를 가림)은 답변
품질만 떨어뜨립니다. 비대칭이라 모르는 쪽은 마스킹으로 눕혔고, 방향은 #66의 조회 전용
게이트(`_READONLY_API_ALLOWLIST_PREFIXES`)와 같습니다.

`inquire_price`(현재가) 등 시세 TR은 그대로 통과하므로 "삼성전자 지금 얼마야?"는 종전대로
동작합니다. #330·#333의 부분 마스킹·조 단위 결론은 같은 엔진을 재사용하므로 그대로
적용되며, 이 PR이 그 판정을 바꾸지 않습니다.

## fail-closed

마스킹 엔진을 로드하지 못하거나 마스킹이 실패하면 조회 결과 대신
`{"error": "pii_masking_unavailable", ...}`를 반환합니다. 유출보다 조회 실패가 낫다는 것이
F-17의 전제입니다. 이 오류는 원장에 기록하지 않습니다 — 도구는 실제로 성공했고, 성공을
실패로 뒤집으면 도구 강제 게이트(#152)가 같은 조회를 한 번 더 실행합니다.

## 범위에서 뺀 것

- **Mem0 저장 경로.** `add_user_memory`는 LLM이 만든 텍스트를 받으므로, 도구 결과에서 온
  계좌 데이터는 이제 **마스킹된 형태로** 저장됩니다(= 평문 축적은 줄어듭니다). 다만 vendor
  `auto_memory_agent`가 무엇을 어떤 형태로 넣는지는 NAT 런타임을 띄워야 확인할 수 있어
  이번 PR에서 **검증하지 못했습니다.** 실측과 범위 확정은 후속입니다.
- **`finus_order_verifier` 경로.** backend가 NAT 검증 엔드포인트를 직접 부르며 주문 수량·
  가격을 프롬프트에 싣습니다. 라우터 워크플로 바깥이라 이 PR의 경계가 닿지 않습니다.
  별도 이슈가 필요합니다.
- **`docs/nfr-05-pii-masking.md` 갱신.** #332가 그 파일을 고치고 있어 충돌을 피했습니다.
  대신 `docs/nfr-05-nat-tool-masking.md`를 새로 두었고, #332 머지 뒤 그쪽 "미적용 경로" 절에
  요약을 합치는 것이 후속 정리입니다.
- **옵션 C(로컬 모델 라우팅).** 위 표 참고.
- **`pii_mask.py` 확장.** 부족한 기능은 발견되지 않았습니다(잔고 리포트는 `원`/`주` 접미
  표기라 기존 정규식이 그대로 잡습니다). KIS 원시 JSON처럼 접미사 없는 숫자 필드를 가려야
  하는 상황이 오면 `pii_mask.py` 확장이 필요하며, 그때는 **#332 머지 후 후속**으로 다뤄야
  합니다.

## 알려진 한계

- 도구 호출마다 scope nonce가 달라, 같은 금액이 두 도구 결과에 나오면 서로 다른 자리표시자가
  됩니다. LLM은 두 값이 같다는 것을 알 수 없습니다.
- 이전 턴의 자리표시자는 복원되지 않습니다. SQLite 대화 기록에는 마스킹된 답변이 저장되고
  다음 턴 세션에는 그 scope가 없어, `unmask_pii`의 fail-open 경로가 "(이전 금액 1)"로
  바꿉니다. 저장을 원문으로 되돌리면 다음 턴 히스토리가 평문으로 OpenAI에 재전송되므로
  그쪽이 더 나쁩니다.

## 검증

`finus_nat/tests/test_pii_tool_masking.py` 36건 추가. 잔고 리포트는 합성 문자열 대신
`mcp-trading/tests/fixtures/balance_report.json`의 `expected_text`(#137 공유 픽스처)를
씁니다 — 오늘 실제로 LLM 컨텍스트에 실리는 문자열입니다.

고정한 계약:
- 계좌 도구 결과가 마스킹된 채로 LLM 경계를 넘는가 (예수금·평가금액·평단가·보유수량·계좌번호)
- 사용자 응답과 도구 인자에서 원값으로 돌아오는가 (워크플로 왕복 테스트 포함)
- 마스킹 불가 시 원본 대신 오류가 나가는가 (fail-closed)
- 공개 시세·뉴스는 마스킹되지 않는가
- 비회귀: 원장(#152/#209) 판정, 각주 부착(#294), 세션 간 매핑 비공유
- 드리프트 가드: `ACCOUNT_SCOPED_TOOLS`의 이름이 실제 도구 이름과 일치하는가

```
352 passed, 1 skipped   (finus_nat/tests 전체, 신규 36건 포함)
```

**실행 방법 주의**: 로컬 `uv run`이 정책상 차단돼 있어 기존 `finus_nat/.venv`의 인터프리터로
`PYTHONPATH`를 이 브랜치 소스에 맞춰 직접 pytest를 돌렸습니다.

**못 한 검증**:
- **NAT 런타임 통합 검증**(실제 라우터를 띄우고 KIS MCP·OpenAI를 왕복시키는 e2e)은
  하지 못했습니다. MCP 왕복과 LLM만 가짜로 갈아끼운 단위 수준입니다.
- **Docker 이미지 빌드**를 실행하지 못했습니다. `finus_nat/Dockerfile`의
  `COPY backend/pii_mask.py`는 빌드 컨텍스트가 저장소 루트(`docker-compose.yml`의
  `context: .`)라는 사실에 근거한 변경입니다.
- **Mem0에 실제로 무엇이 저장되는지** 확인하지 못했습니다(위 "범위에서 뺀 것" 참고).
