### PR TITLE
fix: poison 뒤 update 선행 실행을 되돌린다 (#259 1단계, #270)

### DIFF
--- a/backend/redis_state.py
+++ b/backend/redis_state.py
@@ -28,17 +28,13 @@ COOLDOWN_TTL_SEC = 60 * 10
 TELEGRAM_ALERT_MODES = {"urgent", "all", "off"}
 DEFAULT_TELEGRAM_ALERT_MODE = "urgent"
 
-# 폴러 상태(offset·handled_ahead) TTL: 7일.
+# 폴러 상태(offset) TTL: 7일.
 # Telegram 서버는 미확정 update를 24시간만 보관하므로, 그보다 오래된 offset은 보호할 대상이
 # 이미 없다. TTL은 값의 유효기간이 아니라 폴러가 영구히 내려간 뒤 남는 키를 정리하는 장치다.
 # 쓰기는 update를 처리할 때만 일어나므로 7일 내내 update가 없으면 만료된다 — 폴러가 살아
 # 있다는 것만으로는 갱신되지 않는다. 이 값을 줄이려면 RedisTelegramPollerStore 독스트링의
 # "유휴 기간 < TTL" 조건을 먼저 따져야 한다 (PR #251 리뷰).
 TELEGRAM_POLLER_STATE_TTL_SEC = 60 * 60 * 24 * 7
-# 저장된 handled_ahead의 허용 상한. 도달 가능한 최댓값(산출 근거는
-# RedisTelegramPollerStore._deserialize)에서 넉넉히 떨어뜨렸다 — 오염된 값만 걸러내고
-# 정상 상태는 절대 버리지 않도록 잡았다. 상한에 걸리면 상태를 버리므로 중복 실행이 생긴다.
-MAX_HANDLED_AHEAD = 100_000
 # offset의 허용 상한. Telegram update_id는 32비트라 정상값이 넘을 수 없다.
 # 왜 위쪽도 닫는지는 RedisTelegramPollerStore._deserialize 참조.
 MAX_OFFSET = 2**31
@@ -257,16 +253,16 @@ class RedisSchedulerState:
 class TelegramPollerState:
     """폴러가 재시작을 넘겨 살려야 하는 최소 상태 (#248).
 
-    두 값은 항상 함께 읽고 함께 쓴다. offset만 살아남고 handled_ahead가 사라지면
-    poison 뒤에서 이미 실행한 update가 재배달되어 중복 실행되고, 반대로 handled_ahead만
-    살아남으면 offset이 되감겨 같은 결과가 된다. 한 덩어리로 다뤄야 의미가 있다.
+    #248은 offset과 함께 handled_ahead(poison 뒤에서 선행 실행한 update_id)를 담았다. 그
+    필드는 #259 1단계에서 없앴다 — 배치가 poison에서 끊기게 되면서 선행 실행 자체가 사라져
+    기억할 것이 남지 않는다. 값이 하나뿐이어도 dataclass를 유지하는 이유는 저장소 계약
+    (TelegramPollerStore)이 "한 번에 읽고 한 번에 쓰는 상태 덩어리"이기 때문이다.
 
     재시도 예산(_UpdateFailure)은 일부러 담지 않는다. 유실되면 poison의 폐기 시점이
     미뤄질 뿐 중복 실행으로 이어지지 않으므로, 매 update 쓰기에 얹을 값이 아니다.
     """
 
     offset: int | None = None
-    handled_ahead: frozenset[int] = frozenset()
 
 
 class TelegramPollerStore(Protocol):
@@ -278,7 +274,7 @@ class TelegramPollerStore(Protocol):
     (#248이 닫으려던 중복 실행 창이 그대로 열린다). 그래서 이름·인자 모양만큼은
     test_redis_state.test_store_matches_protocol_shape가 CI에서 고정한다.
 
-    두 값을 한 덩어리(TelegramPollerState)로 주고받는 이유는 그 dataclass의 독스트링에 있다.
+    상태를 한 덩어리(TelegramPollerState)로 주고받는 이유는 그 dataclass의 독스트링에 있다.
     """
 
     async def load(self) -> TelegramPollerState: ...
@@ -304,11 +300,11 @@ class InMemoryTelegramPollerStore:
 
 
 class RedisTelegramPollerStore:
-    """폴러의 offset·handled_ahead를 redis에 영속화한다 (#248).
+    """폴러의 offset을 redis에 영속화한다 (#248).
 
-    두 값을 한 키에 JSON 한 덩어리로 쓴다. 키를 나누면 offset만 전진하고 handled_ahead
-    정리는 유실된 절반 상태가 생기는데, 그게 정확히 이 이슈가 막으려는 중복 실행의 원인이다.
-    폴러는 단일 인스턴스이므로 원자적 SET 하나면 둘의 일관성이 보장된다.
+    #259 1단계 전에는 handled_ahead도 같은 키에 함께 썼다. 지금 남은 값은 offset 하나지만
+    JSON 오브젝트 형태는 유지한다 — 스칼라로 바꾸면 다음에 담을 값이 생길 때 저장 형식이
+    또 한 번 바뀌고, 그 사이 배포는 서로의 payload를 읽지 못한다.
 
     호출자(TelegramCommandPoller)가 예외를 삼키는 fail-open이다.
     RedisPendingOrderStore의 fail-closed와 갈리는 근거는 "redis가 죽었을 때 무엇이 중복될 수
@@ -390,53 +386,18 @@ class RedisTelegramPollerStore:
             # 정상값이 넘길 수 없다 (PR #251 리뷰).
             if offset > MAX_OFFSET:
                 raise ValueError(f"offset too large ({offset} > {MAX_OFFSET})")
-        # `or []`로 기본값을 주면 false·0·"" 같은 falsy 비-list 값이 조용히 []로 바뀌어
-        # 바로 아래 검사를 건너뛴다. 결과는 fail-safe지만 손상을 감지하지 못해 키가 남고
-        # 다음 재시작도 같은 값을 그대로 통과시킨다 (PR #251 리뷰).
-        handled_ahead = data.get("handled_ahead")
-        if handled_ahead is None:
-            handled_ahead = []
-        if not isinstance(handled_ahead, list):
-            raise TypeError(f"handled_ahead must be a list, got {handled_ahead!r}")
-        # 정상 운영에서 이 집합은 _forget_passed_updates가 묶는다. 상한은 오염된 값이
-        # 들어왔을 때만 의미가 있다. 검사가 json.loads 뒤라 파싱 시점의 메모리 폭증 자체는
-        # 막지 못한다 — 실제로 막는 것은 그 값을 save()가 매 update마다 재직렬화(sorted +
-        # json.dumps)하는 지속 비용이다 (PR #251 리뷰). 한계에 걸리면 상태를 버리고 중복이
-        # 생기므로 도달 가능한 최댓값에서 넉넉히 떨어뜨렸다: 전송 실패 창 335초 동안 최소
-        # 간격 5초로 폴링하면 67배치이고, 배치당 최대치는 _get_updates가 넘기는 limit이다.
-        # limit을 지정하지 않으면 Telegram 기본값 100이라 67 × 100 = 6,700이 상한이다.
-        # 실제로는 telegram_commands.GET_UPDATES_LIMIT(=10)을 명시하므로 67 × 10 = 670이고
-        # (#253), 6,700은 limit을 지우는 회귀까지 덮는 상계다. MAX_HANDLED_AHEAD는 그 상계의
-        # 15배 이상이므로, limit이 바뀌어도 이 상한을 함께 고칠 일은 없다.
-        if len(handled_ahead) > MAX_HANDLED_AHEAD:
-            raise ValueError(
-                f"handled_ahead too large ({len(handled_ahead)} > {MAX_HANDLED_AHEAD})"
-            )
-        for update_id in handled_ahead:
-            if isinstance(update_id, bool) or not isinstance(update_id, int):
-                raise TypeError(f"handled_ahead must hold ints, got {update_id!r}")
-        return TelegramPollerState(offset=offset, handled_ahead=frozenset(handled_ahead))
+        # 모르는 키는 그냥 무시한다. 이 배포가 처음 읽는 값은 #259 1단계 이전이 쓴
+        # {"offset": ..., "handled_ahead": [...]}이고, handled_ahead를 이제 안 읽는 것이
+        # 곧 의도한 동작이다 — 되돌린 최적화의 상태이므로 복원할 대상이 아니다.
+        return TelegramPollerState(offset=offset)
 
     async def save(self, state: TelegramPollerState) -> None:
-        # 상한은 load()에만 걸려 있어, 메모리에서 넘어가면 여기서는 그대로 쓰고 다음 재시작의
-        # load()가 조용히 거부한다 — 영속화가 무의미해진 상태를 알릴 신호가 없어진다.
-        # 실패 방향 자체는 수용 가능하므로(상태를 버려도 offset=None 재시작이 받는 집합이
-        # handled_ahead가 덮던 집합과 같다) 거부 대신 경고만 남긴다 (PR #251 리뷰).
-        if len(state.handled_ahead) > MAX_HANDLED_AHEAD // 2:
-            logger.warning(
-                "telegram poller handled_ahead가 상한의 절반을 넘었다 (%s / %s). "
-                "상한을 넘기면 다음 재시작의 load()가 상태를 버려 중복 실행이 생긴다.",
-                len(state.handled_ahead),
-                MAX_HANDLED_AHEAD,
-            )
-        # 상태가 그대로여도(blocked 재배달 배치처럼) 같은 payload를 다시 쓴다. dirty check를
-        # 두지 않은 이유는 TTL 갱신이 아니라 비용 대비다 — blocked 구간은 재시도 예산으로
-        # 유계(≤335초)이고 TTL은 7일(604,800초)이라 만료까지 3자릿수 배수의 여유가 있고,
-        # 쓰기가 진짜 0인 유휴 구간은 dirty check가 있든 없든 같다. 단일 채팅 규모에서 중복
-        # SET의 비용이 무시 가능해 상태를 하나 더 들일 값어치가 없다고 봤다 (PR #251 리뷰).
-        payload = json.dumps(
-            {"offset": state.offset, "handled_ahead": sorted(state.handled_ahead)}
-        )
+        # 상태가 그대로여도 같은 payload를 다시 쓴다. dirty check를 두지 않은 이유는 TTL
+        # 갱신이 아니라 비용 대비다 — 재시도 대기 구간은 예산으로 유계(≤335초)이고 TTL은
+        # 7일(604,800초)이라 만료까지 3자릿수 배수의 여유가 있고, 쓰기가 진짜 0인 유휴
+        # 구간은 dirty check가 있든 없든 같다. 단일 채팅 규모에서 중복 SET의 비용이 무시
+        # 가능해 상태를 하나 더 들일 값어치가 없다고 봤다 (PR #251 리뷰).
+        payload = json.dumps({"offset": state.offset})
         await self.redis.set(
             self._keys.telegram_poller_state(), payload, ex=self.ttl_sec
         )

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -140,7 +140,10 @@ UPDATE_RETRY_WINDOW_SECONDS = 60.0
 #
 # 이 값은 무한정 키우면 안 된다. handle_update가 던지는 지배적 경로가 전송 실패라서,
 # 영구적 전송 실패(특정 메시지의 Markdown 파싱 400)가 하나 들어오면 offset이 이 시간만큼
-# 얼어붙어 #241이 그대로 재발한다. 상한이 있다는 사실 자체를 테스트가 고정한다
+# 얼어붙는다. #259 1단계 이전에는 그 동결이 "#241의 재발"이었지만 지금은 채택한 설계다 —
+# 배치가 그 update에서 끊기는 것이 이 봇이 중복 실행 대신 고른 쪽이다. 그래서 상한이 필요한
+# 이유는 오히려 더 강해졌다: 얼어붙는 동안 뒤의 명령도 실행되지 않아 봇이 이 시간만큼 통째로
+# 무응답이다. 상한이 있다는 사실 자체를 테스트가 고정한다
 # (test_poller_eventually_skips_persistent_send_failures).
 SEND_FAILURE_RETRY_WINDOW_SECONDS = 300.0
 # 재시도 간격. 실패가 이어지면 폴링을 늦춰 텔레그램 rate limit을 자극하지 않는다.
@@ -2214,13 +2217,15 @@ class TelegramCommandPoller:
         # update_id -> 재시도 예산. 유실돼도 poison 폐기가 미뤄질 뿐 중복 실행으로 이어지지
         # 않으므로 영속화하지 않는다. 매 update 쓰기에 얹을 값이 아니다 (#248).
         #
-        # 대가는 분명히 해 둔다: _restore_state가 이 값을 건드리지 않으므로 재시작마다
-        # poison에 예산이 새로 지급된다. 배포가 잦으면 폐기가 무기한 미뤄지고, 그동안 배치는
-        # 매번 같은 poison에서 끊긴다 — #259 1단계로 뒤의 update가 선행 실행되지 않게 되면서
-        # 이 지연이 곧 "내 다음 명령이 늦게 실행됨"이 됐다. 영속화하는 offset이 "자신을
-        # poison에 붙들어 매는 상태"인 반면 이건 "poison을 포기하게 해주는 유일한 상태"라
-        # 방향이 반대다. 다만 이 값을 안 남기는 것이 새로 들이는 위험은 아니다 — 이전에도
-        # 재시작 후 Telegram이 같은 지점부터 재배달하며 예산이 리셋됐다 (PR #251 리뷰).
+        # 대가가 #259 1단계로 커졌다: _restore_state가 이 값을 건드리지 않으므로 재시작마다
+        # poison에 예산이 새로 지급되는데, 이제 배치가 그 poison에서 끊기므로 예산보다 잦은
+        # 재시작이 이어지면 폐기가 무기한 미뤄지고 **그 채팅의 모든 명령이 정지한다**.
+        # #241 하에서는 뒤의 update가 선행 실행돼 "poison 폐기가 미뤄짐"에 그쳤다.
+        # 리셋 계기는 배포가 아니라 Dockerfile의 uvicorn --reload + bind mount다 — backend
+        # 파일 저장 하나면 된다. 영속화할지 알람으로 감지만 할지는 #350에서 정한다.
+        #
+        # 방향이 offset과 반대라는 점은 그대로다: offset은 "자신을 poison에 붙들어 매는
+        # 상태"이고 이건 "poison을 포기하게 해주는 유일한 상태"다 (PR #251 리뷰).
         self._failures: dict[int, _UpdateFailure] = {}
 
     async def run(self) -> None:
@@ -2458,7 +2463,18 @@ class TelegramCommandPoller:
             logger.error("Telegram poller 상태 저장 실패, 인메모리로 계속: %s", exc)
 
     def _forget_passed_updates(self, offset: int) -> None:
-        """offset이 지나간 update_id 기록을 정리해 추적 상태가 무한히 커지지 않게 한다 (#241)."""
+        """offset이 지나간 update_id 기록을 정리해 추적 상태가 무한히 커지지 않게 한다 (#241).
+
+        #259 1단계 이후 이 정리는 도달 가능한 모든 상태에서 no-op이다. _failures에 항목을
+        새로 넣는 것은 배치를 끊는 RETRY 하나뿐이고, 그 항목은 offset이 지나가지 못한 가장
+        작은 id라 다음 배치의 맨 앞으로 정렬된다 — 거기서 pop되거나 다시 배치를 끊으므로,
+        유일한 호출부(그 pop 바로 다음 줄)가 보는 dict는 항상 비어 있다.
+
+        그래도 남기는 이유는 skip 통지 병합(_notify_updates_skipped 호출부 주석)과 같다.
+        "항목이 최대 1개"는 배치 루프의 모양에 딸린 성질이라 루프가 다시 바뀌면 무한 증가가
+        되살아나는데, 그것을 막는 코드는 여기뿐이다. 정리 자체는
+        test_forget_passed_updates_drops_only_what_the_offset_passed가 helper 단위로 고정한다.
+        """
         self._failures = {
             update_id: failure
             for update_id, failure in self._failures.items()

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -2124,10 +2124,15 @@ class TelegramCommandHandler:
 def _update_sort_key(update: dict[str, Any]) -> tuple[int, int]:
     """update_id 오름차순 정렬 키. update_id가 없는 update는 맨 앞으로 보낸다 (#241).
 
+    #259 1단계로 "poison 뒤 update 선행 실행"은 되돌렸지만 이 정렬은 남는다. 배치를 poison에서
+    끊는 것은 미해결 update를 그보다 뒤의 update보다 먼저 만난다는 전제 위에서만 offset을
+    지켜주기 때문이다 — 역순 배치라면 뒤쪽 update가 먼저 성공해 offset이 poison을 지나가고,
+    그러면 그 poison은 재배달 대상에서 조용히 사라진다.
+
     update_id가 없는 update는 재시도 예산도 offset도 추적할 수 없어 실패해도 그 자리에서
-    끝난다(= blocked를 만들지 않는다). 그래서 앞에 두어도 뒤에 오는 update의 재시도 판정에
+    끝난다(= 배치를 끊지 않는다). 그래서 앞에 두어도 뒤에 오는 update의 재시도 판정에
     영향을 주지 않는다. 다만 offset이 그걸 지나갈 수 없어 재배달될 때마다 다시 실행되고,
-    blocked가 아니라 sleep도 없으므로 getUpdates busy loop가 된다. 실제 Telegram은 항상
+    배치가 끊기지 않아 sleep도 없으므로 getUpdates busy loop가 된다. 실제 Telegram은 항상
     update_id를 주므로 이론적 경로다 (PR #242 리뷰).
     """
     update_id = update.get("update_id")
@@ -2194,19 +2199,14 @@ class TelegramCommandPoller:
                 pending_order_store=_create_pending_order_store(),
             )
         self.handler = handler
-        # offset과 _handled_ahead는 redis에 함께 영속화된다 (#248). 둘 다 인메모리였을 때는
-        # blocked 구간에 프로세스가 죽으면 여기 기록된 update들이 "실행됐지만 서버에 미확정"
-        # 상태로 남아 재시작 후 전부 재실행됐다. 창의 길이가 재시도 예산과 같아
-        # (일반 실패 65초, 전송 실패 335초) 무시할 수 없었다.
+        # offset은 redis에 영속화된다 (#248). 인메모리였을 때는 재시작이 offset을 처음으로
+        # 되감아, 배치 중간까지 실행한 update가 통째로 재배달·재실행됐다.
         #
-        # "429와 재시작이 배포라는 원인을 공유한다"는 근거는 폐기했다 — 배포는 자기가 죽이는
-        # 프로세스의 poison을 만들 수 없고(_handled_ahead는 blocked가 이미 True일 때만 차므로
-        # poison이 사망보다 먼저, 같은 프로세스 안에서 일어나야 한다), 애초에 이 레포엔 CD도
-        # restart: 정책도 없다. 실제 재시작 계기는 Dockerfile의 uvicorn --reload + .:/app
-        # bind mount이며, 그 재시작은 SIGTERM → lifespan → stop_telegram_commands()의 취소
-        # 경로를 탄다. 근거는 확률이 아니라 비용 대비다: _handled_ahead는 Telegram이 원리적으로
-        # 보호해줄 수 없는 유일한 상태인데(서버는 미확정 update만 알 뿐 무엇을 이미 실행했는지
-        # 모른다) 영속화 비용은 이미 쓰는 키에 필드 하나다 (PR #251 리뷰).
+        # #248이 offset과 함께 저장하던 _handled_ahead는 #259 1단계에서 사라졌다. 그 집합은
+        # "poison 뒤 update를 먼저 실행한다"는 #241의 최적화가 만들어낸 중복 실행 위험을 막는
+        # 장치였는데, 최적화 자체를 되돌려 poison에서 배치를 끊게 하면서 기억해야 할 선행
+        # 실행이 없어졌다. 남는 창은 handle_update 한 번의 실행 시간뿐이라 offset만 저장한다
+        # (#270 → #259).
         self.state_store: TelegramPollerStore = (
             state_store if state_store is not None else _create_poller_state_store()
         )
@@ -2215,22 +2215,13 @@ class TelegramCommandPoller:
         # 않으므로 영속화하지 않는다. 매 update 쓰기에 얹을 값이 아니다 (#248).
         #
         # 대가는 분명히 해 둔다: _restore_state가 이 값을 건드리지 않으므로 재시작마다
-        # poison에 예산이 새로 지급된다. 배포가 잦으면 폐기가 무기한 미뤄지고 그동안
-        # _handled_ahead도 함께 묶인다. 영속화하는 offset·_handled_ahead가 "자신을 poison에
-        # 붙들어 매는 상태"인 반면 이건 "poison을 포기하게 해주는 유일한 상태"라 방향이
-        # 반대다. 다만 이 PR이 새로 들이는 위험은 아니다 — 이전에도 재시작 후 Telegram이
-        # 같은 지점부터 재배달하며 예산이 리셋됐다 (PR #251 리뷰).
+        # poison에 예산이 새로 지급된다. 배포가 잦으면 폐기가 무기한 미뤄지고, 그동안 배치는
+        # 매번 같은 poison에서 끊긴다 — #259 1단계로 뒤의 update가 선행 실행되지 않게 되면서
+        # 이 지연이 곧 "내 다음 명령이 늦게 실행됨"이 됐다. 영속화하는 offset이 "자신을
+        # poison에 붙들어 매는 상태"인 반면 이건 "poison을 포기하게 해주는 유일한 상태"라
+        # 방향이 반대다. 다만 이 값을 안 남기는 것이 새로 들이는 위험은 아니다 — 이전에도
+        # 재시작 후 Telegram이 같은 지점부터 재배달하며 예산이 리셋됐다 (PR #251 리뷰).
         self._failures: dict[int, _UpdateFailure] = {}
-        # 재시도 대기 중인 update보다 뒤에 있어서 먼저 처리해버린 update_id.
-        # offset은 실패 지점에서 멈추므로 이 update들은 다음 폴링에 다시 배달되는데,
-        # 그대로 재실행하면 주문 같은 부수효과가 중복된다 (#241).
-        #
-        # 영속화로 창은 "실행 완료 후 redis 쓰기까지"로 좁혀졌지만 0은 아니다. 순서를 뒤집어
-        # 실행 전에 기록하면 중복 대신 유실(기록만 남고 실행 안 됨)이 되는데, 여기서는
-        # at-least-once가 낫다 — 금전 경로는 GETDEL claim·set_if_absent가 이미 막고 있어
-        # 중복의 실질 비용은 LLM 재호출과 중복 메시지인 반면, 유실은 사용자의 명령이 아무
-        # 흔적 없이 사라지는 것이다 (#248).
-        self._handled_ahead: set[int] = set()
 
     async def run(self) -> None:
         if not self.notifier.enabled:
@@ -2249,37 +2240,34 @@ class TelegramCommandPoller:
                 await self._sleep(UPDATE_RETRY_BACKOFF_SECONDS[0])
                 continue
 
-            # 재시도 대기 중인 update가 앞에 있으면 offset을 더 전진시킬 수 없다.
-            # 그래도 배치의 나머지 update는 계속 처리해서, poison 1건이 뒤의 명령을
-            # 통째로 막지 않게 한다 (#241).
-            # blocked는 미해결 update를 먼저 만난다는 전제 위에서만 offset을 지켜준다.
-            # getUpdates가 오름차순을 보장한다는 외부 전제에 정확성을 걸지 않도록
-            # 여기서 직접 정렬해 전제를 없앤다 (#241).
+            # 재시도 대기 중인 update를 만나면 배치를 그 자리에서 끊는다. #241은 반대로
+            # 뒤의 update를 계속 실행해 head-of-line blocking을 없앴는데, 그 선행 실행분은
+            # offset이 확정하지 못한 채 재배달되므로 "무엇을 이미 실행했는지"를 기억하는
+            # 상태(_handled_ahead)가 딸려왔다. 그 상태의 유실은 곧 주문 부수효과의 중복
+            # 실행이고, 그것을 막을 장치는 상태 자신뿐이었다. 단일 채팅·단일 프로세스인 이
+            # 봇에서 선행 실행이 사는 값은 "내 다음 명령이 최대 335초(전송 실패 예산) 늦게
+            # 실행되는 것"을 피하는 정도라, 중복 실행 위험과 맞바꾸지 않는다 (#270 → #259).
+            #
+            # 끊는 것은 미해결 update를 그보다 뒤의 update보다 먼저 만난다는 전제 위에서만
+            # offset을 지켜준다. getUpdates가 오름차순을 보장한다는 외부 전제에 정확성을
+            # 걸지 않도록 여기서 직접 정렬해 전제를 없앤다 (#241).
             updates = sorted(updates, key=_update_sort_key)
-            blocked = False
+            retry_pending = False
             skipped: list[dict[str, Any]] = []
             for update in updates:
                 update_id = update.get("update_id")
-                if isinstance(update_id, int) and update_id in self._handled_ahead:
-                    # 이미 처리한 update의 재배달이다. 다시 실행하면 부수효과가 중복되므로
-                    # 건너뛰되, offset은 전진시켜야 여기서 다시 막히지 않는다 (#241).
-                    outcome = _UpdateOutcome.DONE
-                else:
-                    outcome = await self._handle_one_update(update, update_id)
+                outcome = await self._handle_one_update(update, update_id)
                 if outcome is _UpdateOutcome.RETRY:
-                    blocked = True
-                    continue
+                    retry_pending = True
+                    break
                 if outcome is _UpdateOutcome.SKIPPED:
                     skipped.append(update)
                 if not isinstance(update_id, int):
                     continue
 
                 self._failures.pop(update_id, None)
-                if blocked:
-                    self._handled_ahead.add(update_id)
-                else:
-                    self.offset = update_id + 1
-                    self._forget_passed_updates(self.offset)
+                self.offset = update_id + 1
+                self._forget_passed_updates(self.offset)
                 # 배치 끝이 아니라 update마다 쓴다. 배치 단위로 미루면 중간에 죽었을 때
                 # 이미 실행한 update의 기록이 통째로 사라져 영속화의 의미가 없다 (#248).
                 #
@@ -2302,8 +2290,15 @@ class TelegramCommandPoller:
             if skipped:
                 # 배치 통지는 한 건으로 합친다. poison N건에 N번 발송하면 채팅당 초당 ~1건
                 # 제한에 걸려 429를 만들고, 429는 다시 전송 실패 = 새 poison이 된다 (PR #242 리뷰).
+                #
+                # #259 1단계 이후 이 목록의 원소는 실제로는 최대 1개다 — 예산은 시도해야 쌓이고
+                # 시도는 첫 RETRY에서 끊기므로, 한 배치에서 예산을 소진할 수 있는 update는
+                # 맨 앞의 것 하나뿐이다. 합치는 코드를 남겨두는 이유는 그 상한이 배치 루프의
+                # 모양에 딸린 성질이라서다: 루프가 다시 바뀌면 N건이 되살아나는데, 그때
+                # 통지가 429를 만드는 경로는 여기서만 막힌다. 상한 자체는
+                # test_skip_notice_merges_updates_into_one_message가 helper 단위로 고정한다.
                 await self._notify_updates_skipped(skipped)
-            if blocked:
+            if retry_pending:
                 # 실패한 update를 곧바로 다시 받아 예산을 순식간에 소진하지 않도록 쉬어 간다.
                 # 실패가 이어지면 간격을 늘려 복구 창을 벌고 rate limit도 덜 자극한다 (#241).
                 await self._sleep(self._retry_delay())
@@ -2420,7 +2415,7 @@ class TelegramCommandPoller:
             logger.error("Telegram skip notice not delivered for %s updates", len(mine))
 
     async def _restore_state(self) -> None:
-        """재시작 전 offset·_handled_ahead를 복원한다 (#248).
+        """재시작 전 offset을 복원한다 (#248).
 
         실패하면 빈 상태로 시작한다. Telegram이 미확정 update를 전부 재배달하므로 명령이
         유실되지는 않지만, 실행됐던 것이 다시 실행된다 — 영속화 이전과 같은 상태다.
@@ -2439,16 +2434,11 @@ class TelegramCommandPoller:
             logger.error("Telegram poller 상태 복원 실패, 빈 상태로 시작: %s", exc)
             return
         self.offset = state.offset
-        self._handled_ahead = set(state.handled_ahead)
-        if state.offset is not None or state.handled_ahead:
-            logger.info(
-                "Telegram poller 상태 복원: offset=%s, 처리 완료 대기 %s건",
-                state.offset,
-                len(state.handled_ahead),
-            )
+        if state.offset is not None:
+            logger.info("Telegram poller 상태 복원: offset=%s", state.offset)
 
     async def _persist_state(self) -> None:
-        """offset과 _handled_ahead를 한 번에 저장한다 (#248).
+        """offset을 저장한다 (#248).
 
         쓰기 실패는 삼킨다 — fail-open 근거는 RedisTelegramPollerStore 독스트링에 있다.
         폴링은 인메모리 상태로 계속되고, 다음 update의 쓰기가 성공하면 그 시점 상태가
@@ -2460,12 +2450,7 @@ class TelegramCommandPoller:
         """
         try:
             await asyncio.wait_for(
-                self.state_store.save(
-                    TelegramPollerState(
-                        offset=self.offset,
-                        handled_ahead=frozenset(self._handled_ahead),
-                    )
-                ),
+                self.state_store.save(TelegramPollerState(offset=self.offset)),
                 timeout=STATE_STORE_TIMEOUT_SECONDS,
             )
         except Exception as exc:
@@ -2478,9 +2463,6 @@ class TelegramCommandPoller:
             update_id: failure
             for update_id, failure in self._failures.items()
             if update_id >= offset
-        }
-        self._handled_ahead = {
-            update_id for update_id in self._handled_ahead if update_id >= offset
         }
 
     async def _sleep(self, seconds: float) -> None:

--- a/backend/tests/test_compose_ports.py
+++ b/backend/tests/test_compose_ports.py
@@ -1,7 +1,7 @@
 """docker-compose가 무인증 서비스를 전 인터페이스에 게시하지 않는지 고정한다(#285).
 
 `finus-nat`은 `/v1/chat/completions`를 인증 없이 받고, `redis`에는 `requirepass`가
-없는데 대기 주문(`RedisPendingOrderStore`)·폴러 offset·`_handled_ahead`(#248)·스케줄러
+없는데 대기 주문(`RedisPendingOrderStore`)·폴러 offset(#248)·스케줄러
 락처럼 금전 경로의 상태가 들어 있다. 둘 다 컴포즈 내부에서는 네트워크 별칭으로만
 불리므로 호스트 게시는 로컬 디버깅 편의일 뿐이고, 그 편의는 루프백으로 충분하다.
 

--- a/backend/tests/test_redis_integration.py
+++ b/backend/tests/test_redis_integration.py
@@ -110,13 +110,12 @@ async def test_real_redis_poller_state_survives_a_new_store_instance():
 
     try:
         writer = RedisTelegramPollerStore(redis, keys=keys)
-        await writer.save(TelegramPollerState(offset=44, handled_ahead=frozenset({42, 43})))
+        await writer.save(TelegramPollerState(offset=44))
 
         reader = RedisTelegramPollerStore(redis, keys=keys)
         loaded = await reader.load()
 
         assert loaded.offset == 44
-        assert loaded.handled_ahead == frozenset({42, 43})
         assert await redis.ttl(keys.telegram_poller_state()) > 0
     finally:
         stale = await redis.keys(f"{prefix}:*")

--- a/backend/tests/test_redis_state.py
+++ b/backend/tests/test_redis_state.py
@@ -4,7 +4,6 @@ import json
 import pytest
 
 from backend.redis_state import (
-    MAX_HANDLED_AHEAD,
     SIGNAL_HASH_TTL_SEC,
     TELEGRAM_POLLER_STATE_TTL_SEC,
     InMemoryPendingOrderStore,
@@ -179,18 +178,16 @@ async def test_telegram_alert_mode_ignores_invalid_values():
 
 
 @pytest.mark.asyncio
-async def test_poller_state_round_trips_offset_and_handled_ahead():
+async def test_poller_state_round_trips_offset():
     redis = FakeRedis()
     store = RedisTelegramPollerStore(redis)
 
     assert await store.load() == TelegramPollerState()
 
-    await store.save(TelegramPollerState(offset=44, handled_ahead=frozenset({42, 43})))
+    await store.save(TelegramPollerState(offset=44))
     loaded = await store.load()
 
     assert loaded.offset == 44
-    assert loaded.handled_ahead == frozenset({42, 43})
-    # 두 값이 한 키에 함께 저장되어야 절반만 반영된 상태가 생기지 않는다.
     assert list(redis.store) == ["finus:telegram:poller_state"]
     assert redis.calls[-1][2] == TELEGRAM_POLLER_STATE_TTL_SEC
 
@@ -220,16 +217,6 @@ async def test_poller_state_load_drops_corrupted_value():
         # 위쪽도 닫혀 있어야 한다. 거대 양수가 새면 Telegram이 미확정 update를 전부 삭제하고
         # 봇이 영구 무응답이 된다 (PR #251 리뷰).
         '{"offset": 99999999999}',
-        '{"offset": 42, "handled_ahead": "42"}',
-        '{"offset": 42, "handled_ahead": ["42"]}',
-        # 원소의 bool 가드. 구현은 있었는데 케이스가 없어 뮤테이션이 살아 있었다
-        # (PR #251 리뷰). `1 in frozenset({True})`가 True라 update_id 1이 건너뛰어진다.
-        '{"offset": 42, "handled_ahead": [true]}',
-        # falsy 비-list 값. `or []`로 기본값을 주면 조용히 []가 되어 검사를 건너뛴다
-        # (PR #251 리뷰).
-        '{"handled_ahead": false}',
-        '{"handled_ahead": 0}',
-        '{"handled_ahead": ""}',
     ],
 )
 async def test_poller_state_load_rejects_wrong_types(payload):
@@ -247,52 +234,54 @@ async def test_poller_state_save_overwrites_whole_state():
     redis = FakeRedis()
     store = RedisTelegramPollerStore(redis)
 
-    await store.save(TelegramPollerState(offset=None, handled_ahead=frozenset({42, 43})))
-    await store.save(TelegramPollerState(offset=44, handled_ahead=frozenset()))
+    await store.save(TelegramPollerState(offset=None))
+    await store.save(TelegramPollerState(offset=44))
 
-    assert await store.load() == TelegramPollerState(offset=44, handled_ahead=frozenset())
+    assert await store.load() == TelegramPollerState(offset=44)
 
 
 @pytest.mark.asyncio
-async def test_poller_state_load_accepts_zero_offset_and_empty_handled_ahead():
-    """0과 빈 리스트는 정상값이다 — falsy라고 손상으로 몰면 안 된다 (PR #251 리뷰)."""
+async def test_poller_state_load_accepts_zero_offset():
+    """0은 정상값이다 — falsy라고 손상으로 몰면 안 된다 (PR #251 리뷰)."""
     redis = FakeRedis()
-    redis.store["finus:telegram:poller_state"] = '{"offset": 0, "handled_ahead": []}'
+    redis.store["finus:telegram:poller_state"] = '{"offset": 0}'
     store = RedisTelegramPollerStore(redis)
 
-    assert await store.load() == TelegramPollerState(offset=0, handled_ahead=frozenset())
+    assert await store.load() == TelegramPollerState(offset=0)
     # 정상값이므로 키가 남아 있어야 한다.
     assert "finus:telegram:poller_state" in redis.store
 
 
 @pytest.mark.asyncio
-async def test_poller_state_load_rejects_oversized_handled_ahead():
-    """오염된 거대 집합은 버린다. frozenset 생성과 매 update sorted()가 CPU를 먹는다 (PR #251 리뷰)."""
+async def test_poller_state_load_ignores_legacy_handled_ahead_field():
+    """#259 1단계 이전 배포가 남긴 payload를 손상으로 몰지 않는다.
+
+    되돌린 최적화의 상태라 복원할 대상이 아니지만, 거부하면 키가 삭제되면서 offset까지 함께
+    날아가 재시작이 미확정 update를 처음부터 다시 배달받는다 — 필드 하나 무시로 끝날 일이
+    전면 재실행이 된다.
+    """
     redis = FakeRedis()
-    oversized = list(range(MAX_HANDLED_AHEAD + 1))
-    redis.store["finus:telegram:poller_state"] = json.dumps({"offset": 1, "handled_ahead": oversized})
+    redis.store["finus:telegram:poller_state"] = json.dumps(
+        {"offset": 44, "handled_ahead": [42, 43]}
+    )
     store = RedisTelegramPollerStore(redis)
 
-    assert await store.load() == TelegramPollerState()
-    assert redis.store == {}
+    assert await store.load() == TelegramPollerState(offset=44)
+    assert "finus:telegram:poller_state" in redis.store
 
 
 @pytest.mark.asyncio
-async def test_poller_state_load_keeps_realistic_handled_ahead_size():
-    """도달 가능한 최댓값의 상계(6,700)는 상한에 걸리지 않아야 한다 (PR #251 리뷰).
-
-    상한에 걸리면 상태를 버려 중복 실행이 생긴다 — 정상 상태를 버리는 상한은 이 PR이
-    고치려는 버그를 되살린다. 전송 실패 창 335초 / 최소 간격 5초 = 67배치이고, 배치당
-    최대치는 getUpdates의 limit이다(미지정 = 기본값 100 → 6,700). 실제 도달 가능한 값은
-    GET_UPDATES_LIMIT(=10)이 걸려 67 × 10 = 670이므로(#253), 6,700은 limit을 지우는 회귀까지
-    덮는 상계다 — 이 단언은 그 아래 모든 값에 대해서도 성립한다.
-    """
+async def test_poller_state_save_drops_the_legacy_handled_ahead_field():
+    """다음 쓰기가 옛 필드를 지운다 — payload에 읽지 않는 값이 TTL 내내 남지 않는다."""
     redis = FakeRedis()
-    reachable = list(range(6_700))
-    redis.store["finus:telegram:poller_state"] = json.dumps({"offset": 1, "handled_ahead": reachable})
+    redis.store["finus:telegram:poller_state"] = json.dumps(
+        {"offset": 44, "handled_ahead": [42, 43]}
+    )
     store = RedisTelegramPollerStore(redis)
 
-    assert len((await store.load()).handled_ahead) == 6_700
+    await store.save(TelegramPollerState(offset=45))
+
+    assert json.loads(redis.store["finus:telegram:poller_state"]) == {"offset": 45}
 
 
 @pytest.mark.asyncio
@@ -314,33 +303,6 @@ async def test_poller_state_load_logs_when_corrupted_key_delete_fails(caplog):
         assert await store.load() == TelegramPollerState()
 
     assert "손상 키 삭제 실패" in caplog.text
-
-
-@pytest.mark.asyncio
-async def test_poller_state_save_warns_when_handled_ahead_nears_limit(caplog):
-    """상한은 load에만 걸려 있어, 넘어가는 순간을 save가 알리지 않으면 신호가 없다 (PR #251 리뷰)."""
-    store = RedisTelegramPollerStore(FakeRedis())
-    near_limit = frozenset(range(MAX_HANDLED_AHEAD // 2 + 1))
-
-    with caplog.at_level("WARNING"):
-        await store.save(TelegramPollerState(offset=1, handled_ahead=near_limit))
-
-    assert "상한의 절반을 넘었다" in caplog.text
-
-
-@pytest.mark.asyncio
-async def test_poller_state_save_is_quiet_below_warning_threshold(caplog):
-    """도달 가능한 크기의 상계(6,700)에서 경고가 울리면 로그가 무의미해진다 (PR #251 리뷰).
-
-    단언을 caplog.text == ""로 두면 무관한 라이브러리 경고 하나에 깨지고, 원인이 이 PR과
-    무관해 보여 추적이 어렵다. 뮤테이션 감지력은 이 문구 검사와 동일하다 (PR #251 리뷰).
-    """
-    store = RedisTelegramPollerStore(FakeRedis())
-
-    with caplog.at_level("WARNING"):
-        await store.save(TelegramPollerState(offset=1, handled_ahead=frozenset(range(6_700))))
-
-    assert "상한의 절반을 넘었다" not in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -2623,12 +2623,20 @@ async def test_poller_eventually_skips_persistent_send_failures(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_poller_handles_later_update_when_earlier_update_is_poison(monkeypatch):
-    """배치 안의 poison 1건이 뒤의 정상 update를 막지 않는다 (#241)."""
+async def test_poller_stops_the_batch_at_a_poison_update(monkeypatch):
+    """poison을 만나면 배치를 끊는다 — 뒤의 update는 poison이 폐기된 뒤에야 실행된다.
+
+    #241은 반대였다(뒤의 update를 선행 실행). 그 선행 실행분은 offset이 확정하지 못한 채
+    재배달되므로 "이미 실행했다"는 상태(_handled_ahead)가 필요했고, 그 상태의 유실이 곧
+    주문 부수효과의 중복 실행이었다. #259 1단계가 그 교환을 되돌린다 — 여기서 고정하는
+    것은 "42가 41의 예산이 소진되기 전에는 한 번도 실행되지 않는다"이다 (#270 → #259).
+    """
     notifier = FakeNotifier()
     notifier.enabled = True
     notifier.bot_token = "token"
     handled = []
+    # 41이 아직 창 안일 때 42가 실행됐는지 보려면, 배치가 끊긴 시점마다 확인해야 한다.
+    handled_before_skip = []
 
     class PartialHandler:
         async def handle_update(self, update):
@@ -2637,7 +2645,14 @@ async def test_poller_handles_later_update_when_earlier_update_is_poison(monkeyp
             handled.append(update["update_id"])
 
     poller = _make_poller(notifier, handler=PartialHandler())
-    clock = FakePollerClock()
+
+    class WatermarkClock(FakePollerClock):
+        async def _sleep(self, delay):
+            # 41이 폐기되기 전 매 배치 끝에서 42는 아직 손도 대지 않은 상태여야 한다.
+            handled_before_skip.append(list(handled))
+            await super()._sleep(delay)
+
+    clock = WatermarkClock()
     clock.install(monkeypatch, poller)
     batch = _poison_batch()
 
@@ -2653,10 +2668,12 @@ async def test_poller_handles_later_update_when_earlier_update_is_poison(monkeyp
     with pytest.raises(asyncio.CancelledError):
         await poller.run()
 
-    # 정상 update는 첫 배치에서 바로 처리되고, 재배달되어도 중복 실행되지 않는다.
+    # 41이 폐기되기 전 세 배치에서 42는 실행되지 않았다. 선행 실행이 살아 있으면
+    # 첫 배치부터 [42]가 찍힌다.
+    assert handled_before_skip == [[], [], []]
+    # 41 폐기 뒤에야 42가, 정확히 한 번 실행된다.
     assert handled == [42]
     assert poller.offset == 43
-    assert poller._handled_ahead == set()
     assert poller._failures == {}
     # 상수를 그대로 비교하면 동어반복이라 값 변경을 못 잡는다. 리터럴로 고정한다 (PR #242 리뷰).
     assert clock.sleeps == [5.0, 15.0, 45.0]
@@ -2667,7 +2684,7 @@ async def test_poller_handles_later_update_when_earlier_update_is_poison(monkeyp
 
 @pytest.mark.asyncio
 async def test_poller_offset_stays_behind_poison_until_retries_exhausted(monkeypatch):
-    """poison 뒤의 update를 처리해도 offset은 poison이 해소되기 전엔 넘어가지 않는다 (#241)."""
+    """offset은 poison이 해소되기 전엔 그것을 넘어가지 않는다 (#241)."""
     notifier = FakeNotifier()
     notifier.enabled = True
     notifier.bot_token = "token"
@@ -2701,10 +2718,9 @@ async def test_poller_offset_stays_behind_poison_until_retries_exhausted(monkeyp
     with pytest.raises(asyncio.CancelledError):
         await poller.run()
 
-    # 뒤의 update는 처리됐지만(중복 없이 1회), 41은 아직 창 안이라 버려지지 않았다.
-    assert handled == [42]
+    # 41이 아직 창 안이라 배치가 거기서 끊긴다 — 42는 실행되지 않는다.
+    assert handled == []
     assert poller.offset is None
-    assert poller._handled_ahead == {42}
     assert poller._failures[41].attempts == 2
     assert clock.now < telegram_commands.UPDATE_RETRY_WINDOW_SECONDS
     assert notifier.messages == []
@@ -2712,7 +2728,11 @@ async def test_poller_offset_stays_behind_poison_until_retries_exhausted(monkeyp
 
 @pytest.mark.asyncio
 async def test_poller_offset_stays_behind_poison_in_out_of_order_batch(monkeypatch):
-    """배치가 update_id 역순으로 와도 offset은 poison을 넘지 않는다 (#241)."""
+    """배치가 update_id 역순으로 와도 offset은 poison을 넘지 않는다 (#241).
+
+    정렬이 빠지면 42가 먼저 성공해 offset이 43이 되고, 41은 재배달 대상에서 사라진다 —
+    배치를 poison에서 끊는 것만으로는 이 유실을 막지 못한다.
+    """
     notifier = FakeNotifier()
     notifier.enabled = True
     notifier.bot_token = "token"
@@ -2745,19 +2765,27 @@ async def test_poller_offset_stays_behind_poison_in_out_of_order_batch(monkeypat
     assert poller.offset is None
     assert set(poller._failures) == {41}
     assert poller._failures[41].attempts == 1
-    assert poller._handled_ahead == {42}
-    assert handled == [None, 42]
+    # update_id 없는 update는 정렬 키가 맨 앞으로 보내고 실패해도 배치를 끊지 않으므로
+    # 41보다 먼저 실행된다. 42는 41에 막혀 이 배치에서 실행되지 않는다.
+    assert handled == [None]
 
 
 @pytest.mark.asyncio
-async def test_poller_batches_skip_notice_for_multiple_poison_updates(monkeypatch):
-    """한 배치에 poison이 여럿이어도 통지는 한 건으로 합친다 (#241, PR #242 리뷰)."""
+async def test_poller_skips_poison_updates_one_at_a_time(monkeypatch):
+    """poison이 여럿이면 앞에서부터 하나씩 폐기된다 — 뒤의 것은 그전에 시도조차 되지 않는다.
+
+    #241에서는 한 배치가 여럿을 함께 폐기할 수 있었다. 배치를 끊는 지금은 예산이 쌓이려면
+    시도가 있어야 하고 시도는 첫 RETRY에서 멈추므로, 한 배치가 폐기할 수 있는 것은 맨 앞
+    하나뿐이다. 통지 병합 자체는 test_skip_notice_merges_updates_into_one_message가 고정한다.
+    """
     notifier = FakeNotifier()
     notifier.enabled = True
     notifier.bot_token = "token"
+    attempted = []
 
     class FailingHandler:
         async def handle_update(self, update):
+            attempted.append(update["update_id"])
             raise RuntimeError("poison update")
 
     poller = _make_poller(notifier, handler=FailingHandler())
@@ -2777,6 +2805,35 @@ async def test_poller_batches_skip_notice_for_multiple_poison_updates(monkeypatc
         await poller.run()
 
     assert poller.offset == 43
+    # 41의 예산(4회)이 소진되기 전에는 42를 건드리지 않는다.
+    assert attempted == [41, 41, 41, 41, 42, 42, 42, 42]
+    assert notifier.messages == [
+        f"{telegram_commands.UPDATE_SKIPPED_NOTICE}\n실패한 요청: /alerts off",
+        f"{telegram_commands.UPDATE_SKIPPED_NOTICE}\n실패한 요청: /help",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_skip_notice_merges_updates_into_one_message():
+    """통지는 update가 몇 건이든 한 건으로 합친다 (#241, PR #242 리뷰).
+
+    poison N건에 N번 발송하면 채팅당 초당 ~1건 제한에 걸려 429를 만들고, 429는 다시 전송
+    실패 = 새 poison이 된다. #259 1단계 이후 배치가 실어 보내는 건수는 최대 1이라 run()을
+    통해서는 이 성질을 더 이상 재현할 수 없다 — 배치 루프가 다시 바뀌어 N건이 되살아날 때
+    이 병합이 남아 있도록 helper 단위로 고정한다.
+    """
+    notifier = FakeNotifier()
+    notifier.enabled = True
+    notifier.bot_token = "token"
+
+    class NoopHandler:
+        async def handle_update(self, update):
+            return None
+
+    poller = _make_poller(notifier, handler=NoopHandler())
+
+    await poller._notify_updates_skipped(_poison_batch())
+
     assert notifier.messages == [
         f"{telegram_commands.UPDATE_SKIPPED_NOTICE}\n실패한 요청: /alerts off, /help"
     ]
@@ -2946,11 +3003,12 @@ def test_poller_defaults_to_redis_state_store(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_poller_restart_does_not_reexecute_updates_handled_ahead_of_poison(monkeypatch):
-    """poison 뒤에서 먼저 실행한 update는 재시작 후에도 다시 실행되지 않는다 (#248).
+async def test_poller_restart_cannot_reexecute_updates_behind_a_poison(monkeypatch):
+    """poison 뒤의 update는 재시작을 사이에 두고도 중복 실행될 수 없다 (#248 → #259 1단계).
 
-    이 이슈의 본체다. 영속화 이전에는 blocked 구간(일반 실패 65초, 전송 실패 335초)에
-    프로세스가 죽으면 offset과 _handled_ahead가 함께 사라져 42, 43이 재실행됐다.
+    #248은 이 성질을 _handled_ahead의 영속화로 샀다. 그 집합이 유실되면(redis 장애·손상 키)
+    보호가 통째로 사라지는 구조였다. 배치를 poison에서 끊으면 선행 실행 자체가 없어져
+    기억할 것도, 유실될 것도 남지 않는다 — 이 테스트는 상태가 아니라 그 부재를 고정한다.
     """
     notifier = FakeNotifier()
     notifier.enabled = True
@@ -2987,19 +3045,18 @@ async def test_poller_restart_does_not_reexecute_updates_handled_ahead_of_poison
     with pytest.raises(asyncio.CancelledError):
         await first.run()
 
-    # 41은 아직 창 안이라 offset이 멈춰 있고, 42·43은 이미 실행됐다.
-    assert handled == [42, 43]
+    # 41이 창 안이라 배치가 거기서 끊긴다 — 42·43은 아직 실행되지 않았다.
+    assert handled == []
     assert first.offset is None
-    assert first._handled_ahead == {42, 43}
 
     # 프로세스 교체. 41은 여전히 미확정이라 텔레그램이 42·43까지 다시 배달한다.
     second = run_process()
     with pytest.raises(asyncio.CancelledError):
         await second.run()
 
-    assert handled == [42, 43]  # 재실행 없음
+    # 재시작 전에 실행한 것이 없으므로 중복될 것도 없다.
+    assert handled == []
     assert second.offset is None
-    assert second._handled_ahead == {42, 43}
 
 
 @pytest.mark.asyncio
@@ -3008,7 +3065,7 @@ async def test_poller_restores_offset_across_restart(monkeypatch):
     notifier = FakeNotifier()
     notifier.enabled = True
     notifier.bot_token = "token"
-    store = InMemoryTelegramPollerStore(TelegramPollerState(offset=42, handled_ahead=frozenset()))
+    store = InMemoryTelegramPollerStore(TelegramPollerState(offset=42))
     requested_offsets = []
 
     class NoopHandler:
@@ -4698,9 +4755,12 @@ async def test_confirmed_order_is_reexecuted_when_restart_lands_in_the_settled_s
 
     창의 정체: place_order 성공(telegram_commands.py의 _handle_confirm)과 _persist_state()
     (run()의 배치 루프) 사이에 _send_text_settled가 최대 20초 들어앉는다. 그 사이 SIGTERM이
-    오면 offset이 전진하지 못한 채 죽고, Telegram이 같은 update를 재배달하며, _handled_ahead도
-    비어 있어 재실행된다. claim(GETDEL)은 이미 주문을 소비했으므로 재실행은 "확정할 대기
+    오면 offset이 전진하지 못한 채 죽고, Telegram이 같은 update를 재배달하며, 재실행을 막을
+    상태가 아무것도 없다. claim(GETDEL)은 이미 주문을 소비했으므로 재실행은 "확정할 대기
     주문이 없습니다"로 끝난다 — 체결된 주문을 미체결로 오표시한다.
+
+    이 창은 #241 revert(#259 1단계)와 무관하다. 원인이 _handled_ahead의 유무가 아니라
+    handle_update 한 번의 실행 시간이기 때문이다.
 
     이 테스트는 지금 열려 있는 창을 **기록**하는 것이지 승인하는 것이 아니다. 닫는 작업은
     #293으로 뺐고, 그 이슈가 닫히면 아래 마지막 두 단언이 뒤집혀야 한다.

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -2557,7 +2557,13 @@ async def test_poller_extends_window_when_send_failure_appears_later(monkeypatch
 
 @pytest.mark.asyncio
 async def test_poller_retry_delay_follows_the_newest_failure(monkeypatch):
-    """간격은 배치에 하나뿐이라 가장 급한 update에 맞춘다 (PR #242 리뷰)."""
+    """간격은 배치에 하나뿐이라 가장 급한 update에 맞춘다 (PR #242 리뷰).
+
+    _failures가 2건 이상인 상태는 #259 1단계 이후 run()이 만들 수 없어(배치가 첫 RETRY에서
+    끊기므로 한 배치가 새로 넣는 항목은 최대 1개다) 아래에서 41을 직접 주입한다. _retry_delay의
+    min() 중재도 그래서 지금은 도달 불가지만, 상한이 배치 루프의 모양에 딸린 성질이라
+    남긴다 — skip 통지 병합·_forget_passed_updates와 같은 판단이다.
+    """
     notifier = FakeNotifier()
     notifier.enabled = True
     notifier.bot_token = "token"
@@ -2584,6 +2590,30 @@ async def test_poller_retry_delay_follows_the_newest_failure(monkeypatch):
 
     # 42가 41의 45초 간격을 물려받으면 자기 창(60초) 안에서 시도 횟수를 손해 본다.
     assert clock.sleeps == [5.0]
+
+
+def test_forget_passed_updates_drops_only_what_the_offset_passed():
+    """offset이 지나간 실패 기록만 버린다 (#241).
+
+    run()의 호출부가 보는 _failures는 #259 1단계 이후 항상 비어 있어 루프로는 이 성질을
+    재현할 수 없다. 루프가 다시 바뀌어 기록이 여러 건 쌓일 때 이 정리가 남아 있도록
+    helper 단위로 고정한다 — 헬퍼 독스트링의 근거와 짝이다.
+    """
+    notifier = FakeNotifier()
+
+    class NoopHandler:
+        async def handle_update(self, update):
+            return None
+
+    poller = _make_poller(notifier, handler=NoopHandler())
+    for update_id in (40, 41, 42):
+        poller._failures[update_id] = telegram_commands._UpdateFailure(
+            first_at=0.0, attempts=1, send_failure=False
+        )
+
+    poller._forget_passed_updates(42)
+
+    assert set(poller._failures) == {42}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 요약

#259의 **1단계**입니다. 이슈 본문이 "revert로 정하면 그 작업은 별도 PR로 뺀다"고 못박아 둔 그 PR이고, 2026-09-02 결정 기록의 ①(#241 revert — **한다**)를 그대로 구현합니다. 2단계(outbox)는 이 PR이 착지한 뒤 단순해진 배치 루프 위에 얹습니다 — 결정 기록의 "순서 변경" 항목대로입니다.

**바꾸는 것 하나:** 재시도 대기 중인 update를 만나면 배치를 그 자리에서 끊습니다(`break`). 그 결과 `_handled_ahead`와 그 redis 영속화가 통째로 사라집니다.

> 거래 요약: **"중복 주문 실행 위험"을 "내 명령이 최대 335초 늦게 실행됨"으로 바꿉니다.**

> ⚠️ 그 "최대 335초"는 **재시작이 없을 때만** 성립하는 상한입니다. `_failures`는 영속화되지 않아 재시작이 예산을 리셋하는데, 이제 배치가 poison에서 끊기므로 예산보다 잦은 재시작이 이어지면 폐기가 무기한 미뤄지고 **그동안 모든 명령이 정지**합니다. 리셋 계기는 배포가 아니라 `Dockerfile`의 `uvicorn --reload` + bind mount라 backend 파일 저장 하나면 됩니다. 영속화할지 알람으로 감지만 할지는 **#350**에서 정합니다.

## 왜

#241(PR #242)은 poison 1건이 뒤의 명령을 막지 않게 하려고 배치를 계속 돌게 했습니다. 그 선행 실행분은 offset이 확정하지 못한 채 재배달되므로 **"무엇을 이미 실행했는지"를 기억하는 상태**가 필요해졌고(`_handled_ahead`), 그 집합의 유실이 곧 주문 부수효과의 중복 실행이라 #248(PR #251)이 redis 영속화까지 얹었습니다. `telegram_commands.py:2196-2218`의 20줄짜리 주석이 그 상태를 왜 영속화해야 하는지 논증하고 있었는데, **주문 경로에서 주석이 그 길이로 붙어 있다는 것 자체가 이 상태가 진 위험의 무게**입니다.

이 봇은 `TELEGRAM_CHAT_ID` 단일 채팅·단일 프로세스라, 선행 실행이 사는 값은 "내 다음 명령이 늦게 실행되는 것"을 피하는 정도입니다. 그 값과 중복 실행 위험을 맞바꾸지 않습니다.

## 무엇을 지우고 무엇을 남겼나

**지운 것**
- `_handled_ahead` — 폴러 필드, 재배달 스킵 분기, `_forget_passed_updates`의 절반
- 그 영속화 — `TelegramPollerState.handled_ahead`, `_deserialize`의 검증 4종, `save()`의 상한 경고, payload 필드, `MAX_HANDLED_AHEAD`
- `blocked` → `retry_pending`으로 개명. 이제 offset 보호가 아니라 **배치 뒤 sleep 여부만** 결정합니다.

**남긴 것 — #270이 "딸려온 비용"으로 적어둔 것 중 둘은 revert 후에도 필요합니다**
- `sorted(updates)` / `_update_sort_key`: 배치를 끊는 것도 **"미해결 update를 그보다 뒤의 update보다 먼저 만난다"는 전제 위에서만** offset을 지켜줍니다. 역순 배치에서 정렬이 없으면 뒤쪽 update가 먼저 성공해 offset이 poison을 지나가고, 그 poison은 재배달 대상에서 조용히 사라집니다. `test_poller_offset_stays_behind_poison_in_out_of_order_batch`가 이걸 잡습니다(정렬을 지우면 이 테스트만 빨개집니다).
- `_UpdateOutcome`: 세 결과의 처리가 여전히 다릅니다 — DONE은 offset 전진, SKIPPED는 전진 + 통지, RETRY는 배치 중단.

**남기되 근거를 다시 적은 것 — 루프 모양이 바뀌면서 도달 불가가 된 셋**

배치가 첫 RETRY에서 끊기므로 한 배치가 `_failures`에 새로 넣는 항목은 최대 1개이고, 그 항목은 다음 배치의 맨 앞으로 정렬돼 먼저 pop됩니다. 그래서 아래 셋은 지금 도달 불가입니다. 코드는 남기되(상한이 **배치 루프의 모양에 딸린 성질**이라 루프가 다시 바뀌면 되살아납니다) 그 사실과 근거를 주석에 적고, 성질 자체는 helper 단위 테스트로 옮겼습니다.

| 도달 불가가 된 것 | 처리 |
| --- | --- |
| 배치 skip 통지 병합 (429 방어) | 호출부 주석 + `test_skip_notice_merges_updates_into_one_message` |
| `_forget_passed_updates`의 정리 | 독스트링 + `test_forget_passed_updates_drops_only_what_the_offset_passed` |
| `_retry_delay`의 `min()` 중재 | `test_poller_retry_delay_follows_the_newest_failure` 독스트링에 "직접 주입하는 이유" 명시 |

`_forget_passed_updates`가 실제로 no-op인지는 실측했습니다 — 정리 직전에 `all(k >= offset)` 프로브를 넣고 `test_telegram_commands` 전체(182건)를 돌렸을 때 한 번도 걸리지 않았습니다.

## 마이그레이션

옛 payload `{"offset": …, "handled_ahead": […]}`는 **필드를 무시하고** 읽습니다. 되돌린 최적화의 상태라 복원할 대상이 아닙니다. 거부(=손상 키 취급)하면 키가 삭제되면서 offset까지 함께 날아가 재시작이 미확정 update를 처음부터 다시 받으므로, 그 방향은 택하지 않았습니다. 다음 `save()`가 옛 필드를 지웁니다.

전환 구간에 **딱 한 번** 남는 창: 배포 시점에 `_handled_ahead`에 값이 들어 있었다면(= 그 순간 poison이 있었다면) 그 update들은 재배달되어 한 번 더 실행됩니다. 배포와 poison이 겹쳐야 하고, 금전 경로는 GETDEL claim·`set_if_absent`가 막고 있어 실질 비용은 LLM 재호출과 중복 메시지입니다.

## #293과의 관계 — 이 PR은 #293을 닫지 않습니다

이슈 본문의 "revert하면 … 3단계에서 #293을 어떻게 닫을지가 달라진다"는 서술이 "revert가 #293 창을 없앤다"로 읽힐 수 있는데, 결정 기록의 ⚠️ 정정대로 두 창은 별개입니다.

| 창 | 원인 | 없애는 것 |
| --- | --- | --- |
| 선행 실행 창 (`_handled_ahead` 유실 시 중복 실행) | #241 | **이 PR** |
| 재시작 오표시 창 (#293) | `_send_text_settled`가 폴러 루프 안에 있음 | 2단계 outbox |

`test_confirmed_order_is_reexecuted_when_restart_lands_in_the_settled_send`는 **단언을 그대로 뒀고 독스트링만** 고쳤습니다(그 창의 원인이 `_handled_ahead`가 아니라는 점을 명시).

## 테스트

레포 관례대로 **수정을 되돌리면 실패하는지 실측**했습니다.

| 되돌린 것 | 실패한 테스트 |
| --- | --- |
| `break` → `continue` | `test_poller_stops_the_batch_at_a_poison_update`, `..._offset_stays_behind_poison_until_retries_exhausted`, `..._in_out_of_order_batch`, `..._skips_poison_updates_one_at_a_time`, `..._restart_cannot_reexecute_updates_behind_a_poison` (5건) |
| `sorted(updates)` 제거 | `..._in_out_of_order_batch` (1건) |
| 옛 `handled_ahead` 필드를 거부 / 다시 기록 | `test_poller_state_load_ignores_legacy_handled_ahead_field`, `..._save_drops_the_legacy_handled_ahead_field`, `..._round_trips_offset`, `..._save_overwrites_whole_state` (4건) |
| `_forget_passed_updates`의 `if update_id >= offset` 제거 | `test_forget_passed_updates_drops_only_what_the_offset_passed` (1건) |

바뀐 테스트의 성격:
- `test_poller_handles_later_update_when_earlier_update_is_poison` → **`test_poller_stops_the_batch_at_a_poison_update`**. 동작이 뒤집혔으므로 이름과 단언을 함께 뒤집었습니다. 배치가 끊긴 시점마다 "42가 아직 실행되지 않았다"를 확인하는 워터마크를 넣었습니다 — 최종 상태만 보면 선행 실행이 살아 있어도 통과할 수 있습니다.
- `test_poller_restart_does_not_reexecute_updates_handled_ahead_of_poison` → **`..._cannot_reexecute_updates_behind_a_poison`**. #248은 이 성질을 상태의 영속화로 샀고 그 상태가 유실되면 보호가 사라지는 구조였습니다. 이제 **상태가 아니라 그 부재**를 고정합니다.

```
uv run --frozen pytest tests/   # 1059 passed, 3 skipped
```

`tests/test_setup_env.py` 2건은 main에서도 동일하게 실패하는 기존 건입니다(경로 관련, 이 변경과 무관).

## 남은 단계

- [ ] **#350** — 재시작이 재시도 예산을 리셋해 poison 뒤 모든 명령이 무기한 정지할 수 있다 (이 PR이 심각도를 키운 건, `상태: 논의 중`)
- [ ] 2단계 — outbox 설계·구현 (`TradeHistory.notified_at`, 결정 기록 ②)
- [ ] 3단계 — #293 재시작 창 닫기 (2단계 이후 A/B 택일)
- [ ] 4단계 — #275 진행 메시지 중복
- [ ] 5단계 — 전송 최종 실패 알람·메트릭 (**이 PR과 병렬로 뗄 수 있는 조각**)

Refs #259, #270, #241, #248, #350
