### PR TITLE
fix: 병합 경합으로 낡은 테스트 대역을 되살려 main을 초록으로 돌린다

### DIFF
--- a/finus_nat/tests/test_pii_guard.py
+++ b/finus_nat/tests/test_pii_guard.py
@@ -533,7 +533,12 @@ class TestSaveDiaryRejectsUnrestorable:
             async def __aexit__(self, exc_type, exc, tb):
                 return False
 
-            async def post(self, url, json):
+            async def post(self, url, json, headers=None):
+                # headers를 받는다 — 프로덕션이 backend 호출에 `X-API-Key`를 싣기
+                # 때문이다 (#266 2단계). 받지 않으면 TypeError가 나는데, 그 예외는
+                # save_trading_diary의 넓은 except가 삼켜 오류 JSON으로 바뀌므로
+                # "저장이 안 됐다"는 얼굴로만 드러난다. 헤더 값 자체의 계약은
+                # test_finus_api.py의 *_sends_the_api_key_header가 고정한다.
                 captured["json"] = json
                 return FakeResponse()
 


### PR DESCRIPTION
## 📝 개요

각각 초록으로 머지된 두 PR이 서로를 보지 못해 빨개진 main을 되돌린다. 프로덕션 동작은 바꾸지 않고, 낡아진 테스트 대역 하나만 현재 호출 규약에 맞춘다.

## 🔍 발견된 문제

1. 머지 직후 main의 CI가 빨갛다. finus_nat pytest 한 잡만 실패하고 나머지 11개 잡은 통과한다. 두 PR 각각은 자기 브랜치에서 초록이었으므로 어느 쪽 PR 체크로도 잡히지 않았다.
2. 실패 메시지가 원인을 가린다. 매매일지 저장 도구는 백엔드 호출 중 난 예외를 넓게 잡아 오류 JSON으로 바꾸므로, 테스트에는 "대역이 낡았다"가 아니라 "POST가 아예 일어나지 않았다"로 나타난다. 원인에 닿으려면 삼켜진 예외까지 되짚어야 한다.

## 🔧 문제 해결 방법

1. 한쪽 PR이 매매일지 저장 요청에 인증 헤더를 추가하며 그때 있던 httpx 대역을 모두 고쳤는데, 그 사이 머지된 다른 PR이 대역 하나를 새로 들여왔다. 남겨진 그 대역이 헤더 인자를 받도록 형제 대역 세 개와 같은 모양으로 맞춘다. 헤더 값 자체의 계약은 별도 테스트가 이미 고정하고 있어 여기서는 인자를 받기만 한다.
2. 다음 사람이 같은 길을 되짚지 않도록, 왜 이 인자가 필요하고 빠지면 왜 엉뚱한 얼굴로 드러나는지를 대역 자리에 주석으로 남긴다.

## ✅ 검증

- 뮤테이션 실측: 이 PR이 추가한 인자를 다시 빼면 `test_save_diary_still_stores_content_this_request_can_restore`가 실패한다(1 failed, 30 passed). 되돌리면 31 passed로 돌아온다. 이 한 줄이 실제로 실패를 갈랐다.
- 실패 잡 특정: 빨간 런의 잡 12개 중 실패는 finus_nat pytest 하나뿐이고, 이 PR의 변경 범위와 일치한다.

## 🔗 관련 이슈

- 경합한 두 변경: #339(일지 저장 가드), #266(backend API 키 인증)
