### PR TITLE
test: httpx 대역이 프로덕션 호출 시그니처를 복제하지 않게 한다

### DIFF
--- a/finus_nat/tests/conftest.py
+++ b/finus_nat/tests/conftest.py
@@ -10,6 +10,11 @@
 ``httpx.MockTransport``는 조립이 끝난 ``httpx.Request``를 받으므로 호출 시그니처와
 무관하다 — 클라이언트 생성 인자든 ``post``/``get`` 인자든 프로덕션이 바꿔도 대역은
 그대로다. 단언도 시그니처가 아니라 요청 객체(URL·메서드·본문·헤더)에서 읽는다.
+
+**시그니처가 아니라 계약으로 지켜야 하는 것**: 구 대역의 ``def __init__(self, timeout)``은
+필수 위치 인자라서 프로덕션이 ``timeout=``을 잃으면 우연히 빨개졌다. 인자를 그대로
+흘리는 이 대역에는 그 우연이 없으므로, 클라이언트 생성 인자를 :attr:`client_kwargs`로
+관측해 테스트가 명시적으로 단언한다 (PR #359 리뷰).
 """
 
 import json
@@ -25,6 +30,9 @@ class RecordedBackend:
 
     def __init__(self) -> None:
         self.requests: list[httpx.Request] = []
+        # 마지막으로 만들어진 클라이언트의 생성 인자. timeout처럼 요청 객체에는 남지
+        # 않지만 계약인 값을 여기서 본다.
+        self.client_kwargs: dict = {}
 
     @property
     def called(self) -> bool:
@@ -59,34 +67,39 @@ class RecordedBackend:
 
 @pytest.fixture
 def mock_backend(monkeypatch):
-    """프로덕션의 ``httpx.AsyncClient``가 ``MockTransport``를 타게 만든다.
+    """``httpx.AsyncClient``가 ``MockTransport``를 타게 만든다.
 
-    ``payload``(JSON 본문)나 ``status_code``·``text``로 응답을 정하고, 요청마다 다른
-    응답이 필요하면 ``handler``(``httpx.Request`` -> ``httpx.Response``)를 준다.
-    반환값은 :class:`RecordedBackend`.
+    ``payload``(JSON 본문)나 ``status_code``·``text``로 응답을 정한다. 반환값은
+    :class:`RecordedBackend`.
+
+    패치 대상은 ``finus_api.httpx``, 즉 **전역 httpx 모듈**이다. 그래서 이 테스트가
+    도는 동안 만들어지는 다른 클라이언트(예: ``finus_api``의 remote-MCP용
+    ``httpx.AsyncClient()``)도 같은 transport를 타고 ``requests``에 섞인다. 지금
+    호출자는 전부 backend 왕복 하나만 태우므로 URL로 걸러내지 않는다 — 한 테스트가 두
+    종류의 호출을 태우게 되면 그때 필터를 넣어야 한다.
     """
+    # 진짜 클라이언트는 패치 **전에** 한 번만 잡는다. _install 안에서 읽으면 두 번째
+    # 호출의 "진짜"가 첫 번째 래퍼가 되어, 안쪽이 첫 transport로 덮어쓴다 — 두 번째
+    # RecordedBackend는 요청을 하나도 못 받은 채 `not backend.called`가 공허하게
+    # 통과한다 (PR #359 리뷰).
+    real_client = finus_api.httpx.AsyncClient
 
-    def _install(payload=None, *, status_code: int = 200, text: str | None = None, handler=None):
+    def _install(payload=None, *, status_code: int = 200, text: str | None = None):
         recorded = RecordedBackend()
-
-        def _respond(request: httpx.Request) -> httpx.Response:
-            if handler is not None:
-                return handler(request)
-            if text is not None:
-                return httpx.Response(status_code, text=text)
-            return httpx.Response(status_code, json=payload if payload is not None else {})
 
         def _dispatch(request: httpx.Request) -> httpx.Response:
             recorded.requests.append(request)
             # 응답은 요청마다 새로 만든다 — httpx.Response는 한 번 읽으면 스트림이 닫힌다.
-            return _respond(request)
+            if text is not None:
+                return httpx.Response(status_code, text=text)
+            return httpx.Response(status_code, json=payload if payload is not None else {})
 
         transport = httpx.MockTransport(_dispatch)
-        real_client = finus_api.httpx.AsyncClient
 
         def _client(*args, **kwargs):
             # 프로덕션이 넘기는 인자는 그대로 진짜 AsyncClient에 흘린다 — 그래서 인자가
             # 하나 더 붙어도 이 대역은 손댈 필요가 없다. transport만 우리 것으로 바꾼다.
+            recorded.client_kwargs = dict(kwargs)
             kwargs["transport"] = transport
             return real_client(*args, **kwargs)
 

--- a/finus_nat/tests/conftest.py
+++ b/finus_nat/tests/conftest.py
@@ -1,0 +1,96 @@
+"""finus_nat 테스트 공용 대역 — backend HTTP 호출을 요청 객체 수준에서 받는다 (#357).
+
+손으로 흉내 낸 ``async def post(self, url, json, headers=None)`` 대역은 프로덕션의
+**호출 시그니처를 복제**한다. 인자가 하나 붙는 날 대역마다 ``TypeError``가 나는데,
+``finus_api``의 넓은 ``except Exception``이 그 예외를 삼켜 오류 JSON으로 바꾸므로
+"저장이 안 됐다"는 얼굴로만 드러난다. 실제로 PR #352가 ``headers`` 인자를 붙이며 그
+시점의 대역을 모두 고쳤지만, 병렬로 머지된 #351이 대역을 하나 더 들여와 main이
+빨개졌다(PR #356에서 복구).
+
+``httpx.MockTransport``는 조립이 끝난 ``httpx.Request``를 받으므로 호출 시그니처와
+무관하다 — 클라이언트 생성 인자든 ``post``/``get`` 인자든 프로덕션이 바꿔도 대역은
+그대로다. 단언도 시그니처가 아니라 요청 객체(URL·메서드·본문·헤더)에서 읽는다.
+"""
+
+import json
+
+import httpx
+import pytest
+
+from nat_finus_nat import finus_api
+
+
+class RecordedBackend:
+    """``MockTransport``가 받아 둔 요청들 — 테스트의 단언은 여기서 읽는다."""
+
+    def __init__(self) -> None:
+        self.requests: list[httpx.Request] = []
+
+    @property
+    def called(self) -> bool:
+        return bool(self.requests)
+
+    @property
+    def last(self) -> httpx.Request:
+        assert self.requests, "backend 호출이 한 번도 일어나지 않았다"
+        return self.requests[-1]
+
+    @property
+    def method(self) -> str:
+        return self.last.method
+
+    @property
+    def url(self) -> str:
+        return str(self.last.url)
+
+    @property
+    def json_body(self):
+        """마지막 요청의 JSON 본문. 프로덕션이 실제로 직렬화해 보낸 바이트에서 읽는다."""
+        return json.loads(self.last.content)
+
+    def header(self, name: str) -> str | None:
+        """헤더 값. 붙이지 않았으면 ``None``.
+
+        요청에는 httpx가 스스로 넣는 기본 헤더(host·accept 등)가 함께 실리므로 헤더
+        딕셔너리 전체를 비교하지 않고 우리 계약이 정한 헤더만 본다.
+        """
+        return self.last.headers.get(name)
+
+
+@pytest.fixture
+def mock_backend(monkeypatch):
+    """프로덕션의 ``httpx.AsyncClient``가 ``MockTransport``를 타게 만든다.
+
+    ``payload``(JSON 본문)나 ``status_code``·``text``로 응답을 정하고, 요청마다 다른
+    응답이 필요하면 ``handler``(``httpx.Request`` -> ``httpx.Response``)를 준다.
+    반환값은 :class:`RecordedBackend`.
+    """
+
+    def _install(payload=None, *, status_code: int = 200, text: str | None = None, handler=None):
+        recorded = RecordedBackend()
+
+        def _respond(request: httpx.Request) -> httpx.Response:
+            if handler is not None:
+                return handler(request)
+            if text is not None:
+                return httpx.Response(status_code, text=text)
+            return httpx.Response(status_code, json=payload if payload is not None else {})
+
+        def _dispatch(request: httpx.Request) -> httpx.Response:
+            recorded.requests.append(request)
+            # 응답은 요청마다 새로 만든다 — httpx.Response는 한 번 읽으면 스트림이 닫힌다.
+            return _respond(request)
+
+        transport = httpx.MockTransport(_dispatch)
+        real_client = finus_api.httpx.AsyncClient
+
+        def _client(*args, **kwargs):
+            # 프로덕션이 넘기는 인자는 그대로 진짜 AsyncClient에 흘린다 — 그래서 인자가
+            # 하나 더 붙어도 이 대역은 손댈 필요가 없다. transport만 우리 것으로 바꾼다.
+            kwargs["transport"] = transport
+            return real_client(*args, **kwargs)
+
+        monkeypatch.setattr(finus_api.httpx, "AsyncClient", _client)
+        return recorded
+
+    return _install

--- a/finus_nat/tests/test_finus_api.py
+++ b/finus_nat/tests/test_finus_api.py
@@ -100,6 +100,9 @@ def test_save_trading_diary_posts_to_backend(monkeypatch, mock_backend):
     # 키가 없는 배포에서는 헤더 자체를 붙이지 않는다. 빈 값을 보내면 backend가 그것을
     # "틀린 키"로 보므로(main.matches_api_key), 인증이 꺼진 배포에서까지 401이 된다.
     assert backend.header("X-API-Key") is None
+    # 타임아웃은 요청 객체에 남지 않지만 계약이다. 빠지면 httpx 기본값 5초가 적용돼
+    # 느린 backend에서 저장이 조용히 실패한다 (PR #359 리뷰).
+    assert backend.client_kwargs.get("timeout") == config.timeout_sec
     assert '"id": 1' in result
 
 
@@ -145,6 +148,9 @@ def test_list_trading_diaries_sends_the_api_key_header(monkeypatch, mock_backend
 
     assert backend.method == "GET"
     assert backend.header("X-API-Key") == "s3cr3t-key"
+    # 저장 쪽과 마찬가지로 조회 쪽 타임아웃도 여기서 고정한다 — 프로덕션은 두 곳에서
+    # 따로 넘기므로 한쪽만 잃는 회귀가 가능하다.
+    assert backend.client_kwargs.get("timeout") == config.timeout_sec
 
 
 def test_mcp_call_tool_passes_environment_to_child_process(monkeypatch, tmp_path):

--- a/finus_nat/tests/test_finus_api.py
+++ b/finus_nat/tests/test_finus_api.py
@@ -76,33 +76,8 @@ def test_save_diary_input_converter_accepts_multiline_content():
     assert inp.content == "line1\nline2"
 
 
-def test_save_trading_diary_posts_to_backend(monkeypatch):
-    captured = {}
-
-    class FakeResponse:
-        def raise_for_status(self):
-            return None
-
-        def json(self):
-            return {"status": "success", "data": {"id": 1, "title": "T", "content": "C"}}
-
-    class FakeClient:
-        def __init__(self, timeout):
-            captured["timeout"] = timeout
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb):
-            return False
-
-        async def post(self, url, json, headers=None):
-            captured["url"] = url
-            captured["json"] = json
-            captured["headers"] = headers
-            return FakeResponse()
-
-    monkeypatch.setattr(finus_api.httpx, "AsyncClient", FakeClient)
+def test_save_trading_diary_posts_to_backend(monkeypatch, mock_backend):
+    backend = mock_backend({"status": "success", "data": {"id": 1, "title": "T", "content": "C"}})
     # delenv가 아니라 빈 값이다 — dotenv 로딩이 지운 키를 되살릴 수 있고, 빈 값은
     # _finus_backend_headers가 "키 없음"으로 보는 값이라 판정 결과가 같다(PR #352 리뷰).
     monkeypatch.setenv("FINUS_API_KEY", "")
@@ -119,15 +94,16 @@ def test_save_trading_diary_posts_to_backend(monkeypatch):
 
     result = asyncio.run(run_tool())
 
-    assert captured["url"] == "http://test-backend:8000/api/v1/db/diary"
-    assert captured["json"] == {"title": "매매일지 2026-05-24", "content": "본문"}
+    assert backend.method == "POST"
+    assert backend.url == "http://test-backend:8000/api/v1/db/diary"
+    assert backend.json_body == {"title": "매매일지 2026-05-24", "content": "본문"}
     # 키가 없는 배포에서는 헤더 자체를 붙이지 않는다. 빈 값을 보내면 backend가 그것을
     # "틀린 키"로 보므로(main.matches_api_key), 인증이 꺼진 배포에서까지 401이 된다.
-    assert captured["headers"] == {}
+    assert backend.header("X-API-Key") is None
     assert '"id": 1' in result
 
 
-def test_save_trading_diary_sends_the_api_key_header(monkeypatch):
+def test_save_trading_diary_sends_the_api_key_header(monkeypatch, mock_backend):
     """backend가 인증을 켠 배포에서는 `X-API-Key`를 실어 보냅니다 (#266 2단계).
 
     NAT는 컴포즈 내부에서 backend를 부르는 비브라우저 클라이언트다. 이 헤더가 빠지면
@@ -138,30 +114,7 @@ def test_save_trading_diary_sends_the_api_key_header(monkeypatch):
     날에야 드러난다. 이 테스트가 잡는 mutation: headers 인자를 다시 빼거나 이름을
     바꾸는 회귀.
     """
-    captured = {}
-
-    class FakeResponse:
-        def raise_for_status(self):
-            return None
-
-        def json(self):
-            return {"status": "success", "data": {"id": 7}}
-
-    class FakeClient:
-        def __init__(self, timeout):
-            pass
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb):
-            return False
-
-        async def post(self, url, json, headers=None):
-            captured["headers"] = headers
-            return FakeResponse()
-
-    monkeypatch.setattr(finus_api.httpx, "AsyncClient", FakeClient)
+    backend = mock_backend({"status": "success", "data": {"id": 7}})
     monkeypatch.setenv("FINUS_API_KEY", "s3cr3t-key")
 
     config = finus_api.FinusSaveDiaryConfig(backend_url="http://test-backend:8000")
@@ -174,35 +127,12 @@ def test_save_trading_diary_sends_the_api_key_header(monkeypatch):
 
     asyncio.run(run_tool())
 
-    assert captured["headers"] == {"X-API-Key": "s3cr3t-key"}
+    assert backend.header("X-API-Key") == "s3cr3t-key"
 
 
-def test_list_trading_diaries_sends_the_api_key_header(monkeypatch):
+def test_list_trading_diaries_sends_the_api_key_header(monkeypatch, mock_backend):
     """조회 쪽도 같은 헤더를 붙입니다 — 한쪽만 붙이면 그쪽만 401이 된다."""
-    captured = {}
-
-    class FakeResponse:
-        def raise_for_status(self):
-            return None
-
-        def json(self):
-            return {"status": "success", "data": []}
-
-    class FakeClient:
-        def __init__(self, timeout):
-            pass
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb):
-            return False
-
-        async def get(self, url, headers=None):
-            captured["headers"] = headers
-            return FakeResponse()
-
-    monkeypatch.setattr(finus_api.httpx, "AsyncClient", FakeClient)
+    backend = mock_backend({"status": "success", "data": []})
     monkeypatch.setenv("FINUS_API_KEY", "s3cr3t-key")
 
     config = finus_api.FinusListDiariesConfig(backend_url="http://test-backend:8000")
@@ -213,7 +143,8 @@ def test_list_trading_diaries_sends_the_api_key_header(monkeypatch):
 
     asyncio.run(run_tool())
 
-    assert captured["headers"] == {"X-API-Key": "s3cr3t-key"}
+    assert backend.method == "GET"
+    assert backend.header("X-API-Key") == "s3cr3t-key"
 
 
 def test_mcp_call_tool_passes_environment_to_child_process(monkeypatch, tmp_path):

--- a/finus_nat/tests/test_pii_guard.py
+++ b/finus_nat/tests/test_pii_guard.py
@@ -361,35 +361,12 @@ class TestRestoreForInternal:
         text = f"사용자 입금 {backend_placeholder}"
         assert restore_for_internal(text) == text
 
-    async def test_save_diary_posts_unmasked_content_to_backend(self, monkeypatch, mapping_box, ledger):
+    async def test_save_diary_posts_unmasked_content_to_backend(self, mock_backend, mapping_box, ledger):
         """``finus_save_diary``가 실제로 역치환한 값을 backend에 POST하는지 배선을 확인한다.
 
         단위 함수만 테스트하면 도구가 그 함수를 부르지 않게 되는 회귀를 놓친다.
         """
-        captured: dict[str, object] = {}
-
-        class FakeResponse:
-            def raise_for_status(self):
-                return None
-
-            def json(self):
-                return {"status": "success", "data": {"id": 1}}
-
-        class FakeClient:
-            def __init__(self, timeout):
-                pass
-
-            async def __aenter__(self):
-                return self
-
-            async def __aexit__(self, exc_type, exc, tb):
-                return False
-
-            async def post(self, url, json, headers=None):
-                captured["json"] = json
-                return FakeResponse()
-
-        monkeypatch.setattr(finus_api.httpx, "AsyncClient", FakeClient)
+        backend = mock_backend({"status": "success", "data": {"id": 1}})
 
         # 에이전트는 마스킹된 잔고를 보고 일지를 쓴다.
         masked = mask_tool_result("finus_mcp_trading_get_balance", "삼성전자 3주 210,000원")
@@ -399,10 +376,10 @@ class TestRestoreForInternal:
                 finus_api.FinusSaveDiaryInput(title="매매일지", content=f"오늘 {masked}")
             )
 
-        assert captured["json"] == {"title": "매매일지", "content": "오늘 삼성전자 3주 210,000원"}
+        assert backend.json_body == {"title": "매매일지", "content": "오늘 삼성전자 3주 210,000원"}
 
     async def test_save_diary_response_does_not_echo_plaintext_back_to_llm(
-        self, monkeypatch, mapping_box, ledger
+        self, mock_backend, mapping_box, ledger
     ):
         """저장 응답이 방금 역치환한 본문을 Observation으로 되비추면 실패한다 (PR #335 리뷰).
 
@@ -414,36 +391,18 @@ class TestRestoreForInternal:
         plaintext_title = "매매일지 2026-05-24"
         plaintext_content = "삼성전자 3주 210,000원 매수"
 
-        class FakeResponse:
-            def raise_for_status(self):
-                return None
-
-            def json(self):
-                # backend/main.py::create_db_diary의 실제 응답 모양.
-                return {
-                    "status": "success",
-                    "data": {
-                        "id": 7,
-                        "title": plaintext_title,
-                        "content": plaintext_content,
-                        "created_at": "2026-05-24T09:00:00+00:00",
-                    },
-                }
-
-        class FakeClient:
-            def __init__(self, timeout):
-                pass
-
-            async def __aenter__(self):
-                return self
-
-            async def __aexit__(self, exc_type, exc, tb):
-                return False
-
-            async def post(self, url, json, headers=None):
-                return FakeResponse()
-
-        monkeypatch.setattr(finus_api.httpx, "AsyncClient", FakeClient)
+        # backend/main.py::create_db_diary의 실제 응답 모양 — data에 평문이 들어 있다.
+        mock_backend(
+            {
+                "status": "success",
+                "data": {
+                    "id": 7,
+                    "title": plaintext_title,
+                    "content": plaintext_content,
+                    "created_at": "2026-05-24T09:00:00+00:00",
+                },
+            }
+        )
 
         masked = mask_tool_result("finus_mcp_trading_get_balance", plaintext_content)
         config = finus_api.FinusSaveDiaryConfig(backend_url="http://test-backend:8000")
@@ -460,36 +419,20 @@ class TestRestoreForInternal:
         # (3) 원장에는 남는다 — 마스킹은 LLM 컨텍스트로 나가는 값에만 필요하다(#209).
         assert ledger.records[-1].tool_name == "finus_save_diary"
 
-    async def test_save_diary_error_detail_is_masked(self, monkeypatch, mapping_box, ledger):
+    async def test_save_diary_error_detail_is_masked(self, mock_backend, mapping_box, ledger):
         """저장 실패 응답이 요청 본문을 되비춰도 평문이 나가지 않는다 (PR #335 리뷰).
 
         성공 경로는 반환값을 메타데이터로 좁혀 되비춤을 없앴지만, 오류 경로는 그럴 수
         없다 — backend의 422 응답 ``detail``에는 방금 역치환한 본문이 그대로 실린다.
         ``finus_save_diary``가 ``MASKED_TOOLS``에 있어야 이 경로가 덮인다.
         """
-
-        class FakeResponse:
-            status_code = 422
-            # FastAPI 검증 오류는 입력을 그대로 되비춘다.
-            text = '{"detail":[{"loc":["body","content"],"input":"삼성전자 3주 210,000원 매수"}]}'
-
-            def raise_for_status(self):
-                raise finus_api.httpx.HTTPStatusError("422", request=None, response=self)
-
-        class FakeClient:
-            def __init__(self, timeout):
-                pass
-
-            async def __aenter__(self):
-                return self
-
-            async def __aexit__(self, exc_type, exc, tb):
-                return False
-
-            async def post(self, url, json, headers=None):
-                return FakeResponse()
-
-        monkeypatch.setattr(finus_api.httpx, "AsyncClient", FakeClient)
+        # FastAPI 검증 오류는 입력을 그대로 되비춘다. 422를 진짜 응답으로 돌려주면
+        # ``raise_for_status``도 진짜 ``HTTPStatusError``를 던진다 — 예외를 손으로
+        # 조립하지 않으므로 프로덕션이 읽는 필드가 실제 것과 어긋날 여지가 없다.
+        mock_backend(
+            status_code=422,
+            text='{"detail":[{"loc":["body","content"],"input":"삼성전자 3주 210,000원 매수"}]}',
+        )
 
         config = finus_api.FinusSaveDiaryConfig(backend_url="http://test-backend:8000")
         async with finus_api.finus_save_diary(config, None) as info:
@@ -514,35 +457,12 @@ class TestSaveDiaryRejectsUnrestorable:
     택했고, 이 클래스가 그 선택을 고정한다.
     """
 
-    @staticmethod
-    def _fake_client(captured: dict[str, object]):
-        class FakeResponse:
-            def raise_for_status(self):
-                return None
-
-            def json(self):
-                return {"status": "success", "data": {"id": 1, "created_at": "2026-09-03T00:00:00Z"}}
-
-        class FakeClient:
-            def __init__(self, timeout):
-                pass
-
-            async def __aenter__(self):
-                return self
-
-            async def __aexit__(self, exc_type, exc, tb):
-                return False
-
-            async def post(self, url, json, headers=None):
-                # headers를 받는다 — 프로덕션이 backend 호출에 `X-API-Key`를 싣기
-                # 때문이다 (#266 2단계). 받지 않으면 TypeError가 나는데, 그 예외는
-                # save_trading_diary의 넓은 except가 삼켜 오류 JSON으로 바뀌므로
-                # "저장이 안 됐다"는 얼굴로만 드러난다. 헤더 값 자체의 계약은
-                # test_finus_api.py의 *_sends_the_api_key_header가 고정한다.
-                captured["json"] = json
-                return FakeResponse()
-
-        return FakeClient
+    # 이 클래스의 단언은 대체로 "POST가 아예 일어나지 않았다"이므로 응답 본문은
+    # 저장 성공 모양이면 족하다. 요청을 받는 쪽이 ``MockTransport``라서 프로덕션이
+    # backend 호출 인자를 바꿔도(예: #266 2단계가 들여온 `X-API-Key`) 여기는
+    # 손대지 않는다. 헤더 값 자체의 계약은 test_finus_api.py의
+    # *_sends_the_api_key_header가 고정한다.
+    _SAVED = {"status": "success", "data": {"id": 1, "created_at": "2026-09-03T00:00:00Z"}}
 
     def test_reports_foreign_scope_placeholders(self, mapping_box):
         """backend가 만든 자리표시자는 이 요청의 박스에 없으므로 되돌릴 수 없다."""
@@ -567,14 +487,13 @@ class TestSaveDiaryRejectsUnrestorable:
         assert unrestorable_placeholders(restore_for_internal(masked)) == []
 
     async def test_save_diary_does_not_post_user_placeholder_to_db(
-        self, monkeypatch, mapping_box, ledger
+        self, mock_backend, mapping_box, ledger
     ):
         """이슈 본문의 경로 — "300만원 벌었어, 일지 써줘"가 DB에 자리표시자로 박히지 않는다."""
         _, backend_mapping = mask_pii("300만원 벌었어")
         backend_placeholder = next(iter(backend_mapping))
 
-        captured: dict[str, object] = {}
-        monkeypatch.setattr(finus_api.httpx, "AsyncClient", self._fake_client(captured))
+        backend = mock_backend(self._SAVED)
 
         config = finus_api.FinusSaveDiaryConfig(backend_url="http://test-backend:8000")
         async with finus_api.finus_save_diary(config, None) as info:
@@ -586,7 +505,7 @@ class TestSaveDiaryRejectsUnrestorable:
             )
 
         # (1) 저장 자체가 일어나지 않는다 — 손상된 본문이 DB에 들어가는 것을 막는 것이 요점이다.
-        assert "json" not in captured
+        assert not backend.called
         # (2) 에이전트는 원인과 실행 가능한 조치를 함께 받는다. **사용자 재질의는 조치가
         #     아니다** — backend `llm_chat`이 요청마다 `mask_pii(user_msg)`를 돌리므로
         #     사용자가 같은 금액을 다시 적어도 새 scope로 마스킹돼 똑같이 거부된다.
@@ -602,13 +521,12 @@ class TestSaveDiaryRejectsUnrestorable:
         # (4) 거부도 도구 호출이므로 원장에는 남는다.
         assert ledger.records[-1].tool_name == "finus_save_diary"
 
-    async def test_save_diary_checks_the_title_too(self, monkeypatch, mapping_box, ledger):
+    async def test_save_diary_checks_the_title_too(self, mock_backend, mapping_box, ledger):
         """본문만 검사하면 제목 경로로 같은 손상이 새어 들어간다."""
         _, backend_mapping = mask_pii("300만원 벌었어")
         backend_placeholder = next(iter(backend_mapping))
 
-        captured: dict[str, object] = {}
-        monkeypatch.setattr(finus_api.httpx, "AsyncClient", self._fake_client(captured))
+        backend = mock_backend(self._SAVED)
 
         config = finus_api.FinusSaveDiaryConfig(backend_url="http://test-backend:8000")
         async with finus_api.finus_save_diary(config, None) as info:
@@ -618,15 +536,14 @@ class TestSaveDiaryRejectsUnrestorable:
                 )
             )
 
-        assert "json" not in captured
+        assert not backend.called
         assert json.loads(observation)["error"] == "diary_unrestorable_placeholder"
 
     async def test_save_diary_still_stores_content_this_request_can_restore(
-        self, monkeypatch, mapping_box, ledger
+        self, mock_backend, mapping_box, ledger
     ):
         """가드가 정상 경로를 막지 않는다 — 되돌릴 수 있는 본문은 그대로 저장된다."""
-        captured: dict[str, object] = {}
-        monkeypatch.setattr(finus_api.httpx, "AsyncClient", self._fake_client(captured))
+        backend = mock_backend(self._SAVED)
 
         masked = mask_tool_result("finus_mcp_trading_get_balance", "삼성전자 3주 210,000원")
         config = finus_api.FinusSaveDiaryConfig(backend_url="http://test-backend:8000")
@@ -635,10 +552,10 @@ class TestSaveDiaryRejectsUnrestorable:
                 finus_api.FinusSaveDiaryInput(title="매매일지", content=f"오늘 {masked}")
             )
 
-        assert captured["json"] == {"title": "매매일지", "content": "오늘 삼성전자 3주 210,000원"}
+        assert backend.json_body == {"title": "매매일지", "content": "오늘 삼성전자 3주 210,000원"}
 
     async def test_save_diary_refuses_when_the_mapping_box_was_never_installed(
-        self, monkeypatch, ledger
+        self, mock_backend, ledger
     ):
         """박스를 물려받지 못한 실행 경로에서도 손상된 본문이 DB에 들어가지 않는다.
 
@@ -648,8 +565,7 @@ class TestSaveDiaryRejectsUnrestorable:
         """
         assert PII_MAPPING.get() is None
 
-        captured: dict[str, object] = {}
-        monkeypatch.setattr(finus_api.httpx, "AsyncClient", self._fake_client(captured))
+        backend = mock_backend(self._SAVED)
 
         masked = mask_tool_result("finus_mcp_trading_get_balance", "삼성전자 3주 210,000원")
         assert "<QTY" in masked  # 마스킹 자체는 박스 없이도 걸린다
@@ -660,7 +576,7 @@ class TestSaveDiaryRejectsUnrestorable:
                 finus_api.FinusSaveDiaryInput(title="매매일지", content=f"오늘 {masked}")
             )
 
-        assert "json" not in captured
+        assert not backend.called
         assert json.loads(observation)["error"] == "diary_unrestorable_placeholder"
 
 


### PR DESCRIPTION
## 📝 개요

finus_nat 테스트의 httpx 대역 7벌을 `httpx.MockTransport`로 전환해, 프로덕션이 backend 호출 인자를 바꿔도 테스트를 따라 고칠 일이 없게 했다. 테스트 전용 변경이고 프로덕션 코드는 건드리지 않았다.

## 🔍 발견된 문제

1. 대역이 프로덕션의 호출 시그니처를 손으로 복제한다. 인자가 하나 붙는 날 대역 7곳을 다시 찾아다녀야 하고, 실제로 두 PR이 병렬로 머지되며 한 벌이 누락돼 main이 빨개졌다.
2. 실패 양상이 원인을 가린다. 대역이 던진 `TypeError`를 넓은 `except`가 삼켜 오류 JSON으로 바꾸므로, "대역이 낡았다"가 아니라 "저장이 안 됐다"는 얼굴로 드러난다.
3. 오류 경로 대역은 예외를 손으로 조립했다. 응답 객체 없이 만든 예외라, 프로덕션이 실제 응답에서 읽는 필드가 어긋나도 테스트는 통과한다.

## 🔧 문제 해결 방법

1. 조립이 끝난 요청 객체를 통째로 받는 `MockTransport`로 옮겼다. 공용 픽스처가 프로덕션이 넘기는 인자를 그대로 진짜 클라이언트에 흘리고 transport만 갈아끼우므로, 클라이언트 생성 인자든 post/get 인자든 대역과 무관해진다.
2. 단언을 시그니처가 아니라 요청 객체(메서드·URL·본문·헤더)에서 읽게 옮겼다. 헤더는 라이브러리가 스스로 넣는 기본 헤더가 함께 실리므로 딕셔너리 전체 비교 대신 계약이 정한 키 하나만 본다.
3. 오류 경로도 진짜 422 응답을 돌려준다. `raise_for_status`가 진짜 예외를 던지므로 조립한 예외와 실제의 차이가 생길 여지가 사라진다.

## ✅ 검증

- 이슈의 검증 조건 실측 — 프로덕션의 backend POST/GET에 인자를 하나 더 붙이고(`follow_redirects=False`) 테스트 파일은 손대지 않은 채 실행: 전환 전 7 failed / 37 passed, 전환 후 44 passed.
- 헤더 계약이 유지되는지 실측 — 프로덕션에서 `headers=_finus_backend_headers()`를 다시 빼면 `*_sends_the_api_key_header` 2개가 실패한다(2 failed / 42 passed). 되돌리면 44 passed.

## 🔗 관련 이슈

- Closes #357
