### PR TITLE
fix: 폴러 재시도 예산을 재시작 너머로 잇는다 (#350)

### DIFF
--- a/backend/redis_state.py
+++ b/backend/redis_state.py
@@ -28,7 +28,7 @@ COOLDOWN_TTL_SEC = 60 * 10
 TELEGRAM_ALERT_MODES = {"urgent", "all", "off"}
 DEFAULT_TELEGRAM_ALERT_MODE = "urgent"
 
-# 폴러 상태(offset) TTL: 7일.
+# 폴러 상태(offset·재시도 예산) TTL: 7일.
 # Telegram 서버는 미확정 update를 24시간만 보관하므로, 그보다 오래된 offset은 보호할 대상이
 # 이미 없다. TTL은 값의 유효기간이 아니라 폴러가 영구히 내려간 뒤 남는 키를 정리하는 장치다.
 # 쓰기는 update를 처리할 때만 일어나므로 7일 내내 update가 없으면 만료된다 — 폴러가 살아
@@ -262,19 +262,54 @@ class RedisSchedulerState:
 
 
 @dataclass(frozen=True)
+class TelegramPollerFailure:
+    """poison 하나의 재시도 예산 중 재시작을 넘겨야 하는 부분 (#350).
+
+    ``first_at``만 **벽시계**(time.time())다. 폴러가 예산 경과를 재는 시계는 monotonic인데
+    (telegram_commands._now), monotonic의 원점은 프로세스마다 다르므로 그 값을 그대로
+    저장하면 재시작 뒤 비교 자체가 무의미하다. 재시작을 넘길 수 있는 시간 좌표는 벽시계뿐이라
+    영속화 경계에서만 벽시계를 쓰고, 복원 시 다시 monotonic 기준으로 환산한다
+    (telegram_commands.TelegramCommandPoller._restore_state).
+
+    그 대가는 벽시계의 점프다. 뒤로 뛰면 경과가 음수가 되어 복원 측이 0으로 접으므로 예산이
+    한 번 더 지급되고(= #350 이전 동작), 앞으로 뛰면 그만큼 일찍 폐기된다. 예산 창이 65초·
+    335초라 NTP step 정도로는 한 번의 재시도 사이클을 넘지 못하고, 무엇보다 monotonic으로는
+    이 문제를 해결할 수 없다 — 정지를 막는 쪽을 택했다.
+
+    ``attempts``까지 담는 이유는 백오프와 로그다. 유실되면 간격이 5초부터 다시 시작해 남은
+    창 안에서 재시도가 촘촘해지고(rate limit을 더 자극한다) "skipped after N attempts"
+    로그가 재시작 이후만 세게 된다. 같은 쓰기에 int 하나라 담는 값이 있다.
+    """
+
+    update_id: int
+    first_at: float
+    attempts: int = 1
+    send_failure: bool = False
+
+
+@dataclass(frozen=True)
 class TelegramPollerState:
     """폴러가 재시작을 넘겨 살려야 하는 최소 상태 (#248).
 
     #248은 offset과 함께 handled_ahead(poison 뒤에서 선행 실행한 update_id)를 담았다. 그
     필드는 #259 1단계에서 없앴다 — 배치가 poison에서 끊기게 되면서 선행 실행 자체가 사라져
-    기억할 것이 남지 않는다. 값이 하나뿐이어도 dataclass를 유지하는 이유는 저장소 계약
+    기억할 것이 남지 않는다. dataclass를 유지하는 이유는 저장소 계약
     (TelegramPollerStore)이 "한 번에 읽고 한 번에 쓰는 상태 덩어리"이기 때문이다.
 
-    재시도 예산(_UpdateFailure)은 일부러 담지 않는다. 유실되면 poison의 폐기 시점이
-    미뤄질 뿐 중복 실행으로 이어지지 않으므로, 매 update 쓰기에 얹을 값이 아니다.
+    ``failures``(재시도 예산)는 #248에서 일부러 빼 두었던 값이다. 근거는 "유실되면 poison의
+    폐기 시점이 미뤄질 뿐"이었는데, #259 1단계가 배치를 poison에서 끊게 만들면서 그 대가가
+    **그동안 그 채팅의 모든 명령이 정지**로 커졌다. backend/Dockerfile의 uvicorn --reload +
+    bind mount 때문에 파일 저장 하나가 리셋 계기라, 예산(65초·335초)보다 잦은 재시작이
+    이어지면 poison이 영원히 폐기되지 않는다. 그래서 #350에서 담기로 정했다.
+
+    dict가 아니라 순서 있는 튜플인 이유는 frozen dataclass의 필드로 쓰기 때문이다. 원소가
+    실제로는 최대 1개(폴러 _forget_passed_updates 독스트링 참조)여도 목록 형태를 쓰는 것은
+    그 상한이 배치 루프의 모양에 딸린 성질이라서다 — 루프가 다시 바뀌어 미해결 update가
+    여럿이 되면, 저장 형식이 1개만 담고 있으면 나머지가 조용히 유실된다.
     """
 
     offset: int | None = None
+    failures: tuple[TelegramPollerFailure, ...] = ()
 
 
 class TelegramPollerStore(Protocol):
@@ -312,11 +347,14 @@ class InMemoryTelegramPollerStore:
 
 
 class RedisTelegramPollerStore:
-    """폴러의 offset을 redis에 영속화한다 (#248).
+    """폴러의 offset과 재시도 예산을 redis에 영속화한다 (#248, #350).
 
-    #259 1단계 전에는 handled_ahead도 같은 키에 함께 썼다. 지금 남은 값은 offset 하나지만
-    JSON 오브젝트 형태는 유지한다 — 스칼라로 바꾸면 다음에 담을 값이 생길 때 저장 형식이
-    또 한 번 바뀌고, 그 사이 배포는 서로의 payload를 읽지 못한다.
+    #259 1단계 전에는 handled_ahead도 같은 키에 함께 썼다. JSON 오브젝트 형태를 유지해 둔
+    덕에 #350의 failures는 필드 하나를 되돌려 넣는 작업이 됐다 — 스칼라로 바꿨더라면 저장
+    형식이 또 한 번 바뀌고 그 사이 배포는 서로의 payload를 읽지 못했을 것이다.
+
+    failures는 비어 있으면 payload에서 아예 뺀다. 예산이 걸린 update가 있는 것은 예외
+    상황이고, 정상 경로의 쓰기(update마다 한 번)에 빈 배열을 얹을 이유가 없다.
 
     호출자(TelegramCommandPoller)가 예외를 삼키는 fail-open이다.
     RedisPendingOrderStore의 fail-closed와 갈리는 근거는 "redis가 죽었을 때 무엇이 중복될 수
@@ -401,7 +439,82 @@ class RedisTelegramPollerStore:
         # 모르는 키는 그냥 무시한다. 이 배포가 처음 읽는 값은 #259 1단계 이전이 쓴
         # {"offset": ..., "handled_ahead": [...]}이고, handled_ahead를 이제 안 읽는 것이
         # 곧 의도한 동작이다 — 되돌린 최적화의 상태이므로 복원할 대상이 아니다.
-        return TelegramPollerState(offset=offset)
+        return TelegramPollerState(
+            offset=offset,
+            failures=RedisTelegramPollerStore._deserialize_failures(data.get("failures")),
+        )
+
+    @staticmethod
+    def _deserialize_failures(raw: Any) -> tuple[TelegramPollerFailure, ...]:
+        """예산 목록을 복원한다. 손상됐으면 offset은 살리고 예산만 버린다 (#350).
+
+        offset 쪽과 달리 여기서는 raise하지 않는다. 두 값의 유실 대가가 다르기 때문이다:
+        예산 유실은 poison의 폐기가 한 창(최대 335초) 미뤄지는 것 — #350 이전의 동작 —
+        으로 degrade하지만, raise는 손상 키 삭제로 이어져 offset까지 함께 날린다. 그러면
+        Telegram이 미확정 update를 전부 재배달해 이미 실행한 명령이 다시 실행된다. 예산
+        한 창을 아끼려고 중복 주문 위험을 살 수는 없다.
+
+        타입 검증은 offset과 같은 이유로 촘촘하다: bool은 int의 하위 타입이라 isinstance만
+        으로 통과하고, 여기 새는 값은 update_id 비교(_forget_passed_updates)와 시간 산술
+        (경과 = 지금 - first_at) 양쪽으로 흘러간다.
+        """
+        if raw is None:
+            return ()
+        try:
+            if not isinstance(raw, list):
+                raise TypeError(f"failures must be a list, got {type(raw).__name__}")
+            return tuple(
+                RedisTelegramPollerStore._deserialize_failure(entry) for entry in raw
+            )
+        except (ValueError, TypeError, AttributeError) as exc:
+            # 원소 하나가 손상돼도 목록 전체를 버린다. 남은 원소만 살려도 그 payload를
+            # 신뢰할 근거가 없고, 예산은 없어도 되는 값이라 부분 복원의 값이 없다.
+            logger.error("telegram poller 재시도 예산 복원 실패, 예산 없이 시작: %s", exc)
+            return ()
+
+    @staticmethod
+    def _deserialize_failure(entry: Any) -> TelegramPollerFailure:
+        if not isinstance(entry, dict):
+            raise TypeError(f"failure must be an object, got {type(entry).__name__}")
+
+        update_id = entry.get("update_id")
+        if isinstance(update_id, bool) or not isinstance(update_id, int):
+            raise TypeError(f"failure update_id must be int, got {update_id!r}")
+        # offset과 같은 범위를 쓴다. update_id는 offset과 같은 축의 값이고, 범위를 벗어난
+        # 값이 들어오면 _forget_passed_updates의 비교가 그 항목을 영구히 남긴다.
+        if not 0 <= update_id <= MAX_OFFSET:
+            raise ValueError(f"failure update_id out of range: {update_id}")
+
+        first_at = entry.get("first_at")
+        if isinstance(first_at, bool) or not isinstance(first_at, (int, float)):
+            raise TypeError(f"failure first_at must be a number, got {first_at!r}")
+        # NaN·inf가 새면 경과 비교가 항상 False가 되어(NaN) poison이 영구히 재시도되거나,
+        # inf면 창을 즉시 넘겨 첫 실패에서 폐기된다. 둘 다 예산이 없는 것보다 나쁘다.
+        if first_at != first_at or first_at in (float("inf"), float("-inf")):
+            raise ValueError(f"failure first_at must be finite, got {first_at!r}")
+        # 벽시계 epoch 초라 0 이하는 정상값이 아니다(1970년 이전).
+        if first_at <= 0:
+            raise ValueError(f"failure first_at must be positive, got {first_at!r}")
+
+        attempts = entry.get("attempts")
+        if isinstance(attempts, bool) or not isinstance(attempts, int):
+            raise TypeError(f"failure attempts must be int, got {attempts!r}")
+        # 항목이 존재한다는 것 자체가 최소 1회 시도했다는 뜻이다. 0이나 음수가 새면
+        # _retry_delay의 인덱스 계산(min(attempts, len) - 1)이 음수 인덱스가 되어
+        # 백오프 튜플의 뒤에서부터 골라 가장 긴 간격을 쓴다.
+        if attempts < 1:
+            raise ValueError(f"failure attempts must be >= 1, got {attempts}")
+
+        send_failure = entry.get("send_failure")
+        if not isinstance(send_failure, bool):
+            raise TypeError(f"failure send_failure must be bool, got {send_failure!r}")
+
+        return TelegramPollerFailure(
+            update_id=update_id,
+            first_at=float(first_at),
+            attempts=attempts,
+            send_failure=send_failure,
+        )
 
     async def save(self, state: TelegramPollerState) -> None:
         # 상태가 그대로여도 같은 payload를 다시 쓴다. dirty check를 두지 않은 이유는 TTL
@@ -409,7 +522,10 @@ class RedisTelegramPollerStore:
         # 7일(604,800초)이라 만료까지 3자릿수 배수의 여유가 있고, 쓰기가 진짜 0인 유휴
         # 구간은 dirty check가 있든 없든 같다. 단일 채팅 규모에서 중복 SET의 비용이 무시
         # 가능해 상태를 하나 더 들일 값어치가 없다고 봤다 (PR #251 리뷰).
-        payload = json.dumps({"offset": state.offset})
+        payload_data: dict[str, Any] = {"offset": state.offset}
+        if state.failures:
+            payload_data["failures"] = [asdict(f) for f in state.failures]
+        payload = json.dumps(payload_data)
         await self.redis.set(
             self._keys.telegram_poller_state(), payload, ex=self.ttl_sec
         )

--- a/backend/redis_state.py
+++ b/backend/redis_state.py
@@ -265,16 +265,20 @@ class RedisSchedulerState:
 class TelegramPollerFailure:
     """poison 하나의 재시도 예산 중 재시작을 넘겨야 하는 부분 (#350).
 
-    ``first_at``만 **벽시계**(time.time())다. 폴러가 예산 경과를 재는 시계는 monotonic인데
+    ``first_wall_at``은 **벽시계**(time.time())다. 폴러가 예산 경과를 재는 시계는 monotonic인데
     (telegram_commands._now), monotonic의 원점은 프로세스마다 다르므로 그 값을 그대로
     저장하면 재시작 뒤 비교 자체가 무의미하다. 재시작을 넘길 수 있는 시간 좌표는 벽시계뿐이라
     영속화 경계에서만 벽시계를 쓰고, 복원 시 다시 monotonic 기준으로 환산한다
     (telegram_commands.TelegramCommandPoller._restore_state).
 
-    그 대가는 벽시계의 점프다. 뒤로 뛰면 경과가 음수가 되어 복원 측이 0으로 접으므로 예산이
-    한 번 더 지급되고(= #350 이전 동작), 앞으로 뛰면 그만큼 일찍 폐기된다. 예산 창이 65초·
-    335초라 NTP step 정도로는 한 번의 재시도 사이클을 넘지 못하고, 무엇보다 monotonic으로는
-    이 문제를 해결할 수 없다 — 정지를 막는 쪽을 택했다.
+    그 대가는 벽시계의 점프다. 뒤로 뛰면 복원 측이 경과를 0으로 접으며 앵커를 다시 찍고
+    (= 예산이 한 번 더 지급, #350 이전 동작), 앞으로 뛰면 그만큼 일찍 폐기된다. 예산 창이
+    65초·335초라 NTP step 정도로는 한 번의 재시도 사이클을 넘지 못하고, 무엇보다 monotonic
+    으로는 이 문제를 해결할 수 없다 — 정지를 막는 쪽을 택했다.
+
+    이름이 ``first_at``이 아닌 이유는 _UpdateFailure와의 혼동을 막기 위해서다 (PR #362 리뷰).
+    그쪽의 ``first_at``은 monotonic이고 둘 다 float이라, 이름까지 같으면 교차 대입이
+    타입 체커도 리뷰도 통과한다 — 결과는 "재시작을 못 넘기는 예산"이라 조용하다.
 
     ``attempts``까지 담는 이유는 백오프와 로그다. 유실되면 간격이 5초부터 다시 시작해 남은
     창 안에서 재시도가 촘촘해지고(rate limit을 더 자극한다) "skipped after N attempts"
@@ -282,7 +286,7 @@ class TelegramPollerFailure:
     """
 
     update_id: int
-    first_at: float
+    first_wall_at: float
     attempts: int = 1
     send_failure: bool = False
 
@@ -456,7 +460,7 @@ class RedisTelegramPollerStore:
 
         타입 검증은 offset과 같은 이유로 촘촘하다: bool은 int의 하위 타입이라 isinstance만
         으로 통과하고, 여기 새는 값은 update_id 비교(_forget_passed_updates)와 시간 산술
-        (경과 = 지금 - first_at) 양쪽으로 흘러간다.
+        (경과 = 지금 - first_wall_at) 양쪽으로 흘러간다.
         """
         if raw is None:
             return ()
@@ -485,16 +489,16 @@ class RedisTelegramPollerStore:
         if not 0 <= update_id <= MAX_OFFSET:
             raise ValueError(f"failure update_id out of range: {update_id}")
 
-        first_at = entry.get("first_at")
-        if isinstance(first_at, bool) or not isinstance(first_at, (int, float)):
-            raise TypeError(f"failure first_at must be a number, got {first_at!r}")
+        first_wall_at = entry.get("first_wall_at")
+        if isinstance(first_wall_at, bool) or not isinstance(first_wall_at, (int, float)):
+            raise TypeError(f"failure first_wall_at must be a number, got {first_wall_at!r}")
         # NaN·inf가 새면 경과 비교가 항상 False가 되어(NaN) poison이 영구히 재시도되거나,
         # inf면 창을 즉시 넘겨 첫 실패에서 폐기된다. 둘 다 예산이 없는 것보다 나쁘다.
-        if first_at != first_at or first_at in (float("inf"), float("-inf")):
-            raise ValueError(f"failure first_at must be finite, got {first_at!r}")
+        if first_wall_at != first_wall_at or first_wall_at in (float("inf"), float("-inf")):
+            raise ValueError(f"failure first_wall_at must be finite, got {first_wall_at!r}")
         # 벽시계 epoch 초라 0 이하는 정상값이 아니다(1970년 이전).
-        if first_at <= 0:
-            raise ValueError(f"failure first_at must be positive, got {first_at!r}")
+        if first_wall_at <= 0:
+            raise ValueError(f"failure first_wall_at must be positive, got {first_wall_at!r}")
 
         attempts = entry.get("attempts")
         if isinstance(attempts, bool) or not isinstance(attempts, int):
@@ -511,7 +515,7 @@ class RedisTelegramPollerStore:
 
         return TelegramPollerFailure(
             update_id=update_id,
-            first_at=float(first_at),
+            first_wall_at=float(first_wall_at),
             attempts=attempts,
             send_failure=send_failure,
         )

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -29,6 +29,7 @@ from .redis_state import (
     RedisSchedulerState,
     RedisPendingOrderStore,
     RedisTelegramPollerStore,
+    TelegramPollerFailure,
     TelegramPollerState,
     TelegramPollerStore,
     create_redis_client,
@@ -2239,11 +2240,23 @@ def _update_label(update: dict[str, Any]) -> str:
 
 @dataclass
 class _UpdateFailure:
-    """update별 재시도 예산. 기준은 횟수가 아니라 첫 실패 이후 흐른 시간이다 (#241)."""
+    """update별 재시도 예산. 기준은 횟수가 아니라 첫 실패 이후 흐른 시간이다 (#241).
+
+    시계가 둘인 이유는 예산이 재시작을 넘겨야 하기 때문이다 (#350). ``first_at``은
+    monotonic이라 경과 계산이 벽시계 조정에 흔들리지 않지만 프로세스가 죽으면 원점이
+    사라지고, ``first_wall_at``은 그 반대다. 그래서 진행 중인 판정은 monotonic으로 하고
+    영속화·복원 경계에서만 벽시계를 쓴다 — 복원은 벽시계 경과만큼 뒤로 민 monotonic 값을
+    ``first_at``에 넣어, 그 뒤의 코드가 계속 한 시계만 보게 한다.
+
+    ``first_wall_at``은 복원해도 원래 값을 그대로 유지한다. 복원 시점으로 새로 찍으면
+    재시작마다 앵커가 앞당겨져, 잦은 재시작이 다시 예산을 무한히 늘리는 #350의 경로가
+    벽시계 쪽으로 되살아난다.
+    """
 
     first_at: float
     attempts: int
     send_failure: bool
+    first_wall_at: float
 
 
 class TelegramCommandPoller:
@@ -2275,18 +2288,20 @@ class TelegramCommandPoller:
             state_store if state_store is not None else _create_poller_state_store()
         )
         self.offset: int | None = None
-        # update_id -> 재시도 예산. 유실돼도 poison 폐기가 미뤄질 뿐 중복 실행으로 이어지지
-        # 않으므로 영속화하지 않는다. 매 update 쓰기에 얹을 값이 아니다 (#248).
+        # update_id -> 재시도 예산. offset과 함께 영속화된다 (#350).
         #
-        # 대가가 #259 1단계로 커졌다: _restore_state가 이 값을 건드리지 않으므로 재시작마다
-        # poison에 예산이 새로 지급되는데, 이제 배치가 그 poison에서 끊기므로 예산보다 잦은
-        # 재시작이 이어지면 폐기가 무기한 미뤄지고 **그 채팅의 모든 명령이 정지한다**.
-        # #241 하에서는 뒤의 update가 선행 실행돼 "poison 폐기가 미뤄짐"에 그쳤다.
-        # 리셋 계기는 배포가 아니라 Dockerfile의 uvicorn --reload + bind mount다 — backend
-        # 파일 저장 하나면 된다. 영속화할지 알람으로 감지만 할지는 #350에서 정한다.
+        # #248은 이 값을 일부러 뺐다. 근거는 "유실돼도 poison 폐기가 미뤄질 뿐 중복 실행으로
+        # 이어지지 않는다"였는데, #259 1단계가 배치를 poison에서 끊게 만들면서 그 대가가
+        # **그동안 그 채팅의 모든 명령이 정지**로 커졌다. #241 하에서는 뒤의 update가 선행
+        # 실행돼 "폐기가 미뤄짐"에 그쳤다. 리셋 계기는 배포가 아니라 Dockerfile의
+        # uvicorn --reload + bind mount라 backend 파일 저장 하나면 되고, 예산(일반 65초·
+        # 전송 실패 335초)보다 잦은 재시작이 이어지면 poison은 영원히 폐기되지 않았다.
         #
         # 방향이 offset과 반대라는 점은 그대로다: offset은 "자신을 poison에 붙들어 매는
-        # 상태"이고 이건 "poison을 포기하게 해주는 유일한 상태"다 (PR #251 리뷰).
+        # 상태"이고 이건 "poison을 포기하게 해주는 유일한 상태"다 (PR #251 리뷰). 그래서
+        # 유실 시의 degrade 방향도 반대다 — offset이 없으면 재실행, 이게 없으면 정지.
+        # 복원 실패를 저장소가 offset과 다르게 다루는 근거가 그것이다
+        # (RedisTelegramPollerStore._deserialize_failures).
         self._failures: dict[int, _UpdateFailure] = {}
 
     async def run(self) -> None:
@@ -2367,6 +2382,14 @@ class TelegramCommandPoller:
                 # test_skip_notice_merges_updates_into_one_message가 helper 단위로 고정한다.
                 await self._notify_updates_skipped(skipped)
             if retry_pending:
+                # 예산을 여기서 쓴다 (#350). 위 루프의 쓰기 지점은 update를 통과시킨 뒤에만
+                # 도는데, RETRY는 배치를 그 자리에서 끊어 거기 닿지 못한다 — 이 한 줄이
+                # 없으면 예산은 영속화 대상이 되고도 실제로는 한 번도 저장되지 않는다.
+                #
+                # 이 쓰기는 재시도 사이클당 한 번(간격 5~45초)이라 정상 경로의 쓰기 빈도를
+                # 바꾸지 않는다. offset은 그대로고 바뀌는 것은 attempts뿐이지만, 상태를 통째로
+                # 덮어쓰는 계약이라 부분 갱신을 따로 만들 이유가 없다.
+                await self._persist_state()
                 # 실패한 update를 곧바로 다시 받아 예산을 순식간에 소진하지 않도록 쉬어 간다.
                 # 실패가 이어지면 간격을 늘려 복구 창을 벌고 rate limit도 덜 자극한다 (#241).
                 await self._sleep(self._retry_delay())
@@ -2414,7 +2437,12 @@ class TelegramCommandPoller:
             now = self._now()
             failure = self._failures.get(update_id)
             if failure is None:
-                failure = _UpdateFailure(first_at=now, attempts=1, send_failure=send_failure)
+                failure = _UpdateFailure(
+                    first_at=now,
+                    attempts=1,
+                    send_failure=send_failure,
+                    first_wall_at=self._wall_now(),
+                )
                 self._failures[update_id] = failure
             else:
                 failure.attempts += 1
@@ -2486,7 +2514,7 @@ class TelegramCommandPoller:
             logger.error("Telegram skip notice not delivered for %s updates", len(mine))
 
     async def _restore_state(self) -> None:
-        """재시작 전 offset을 복원한다 (#248).
+        """재시작 전 offset과 재시도 예산을 복원한다 (#248, #350).
 
         실패하면 빈 상태로 시작한다. Telegram이 미확정 update를 전부 재배달하므로 명령이
         유실되지는 않지만, 실행됐던 것이 다시 실행된다 — 영속화 이전과 같은 상태다.
@@ -2505,11 +2533,47 @@ class TelegramCommandPoller:
             logger.error("Telegram poller 상태 복원 실패, 빈 상태로 시작: %s", exc)
             return
         self.offset = state.offset
+        self._failures = self._restore_failures(state.failures)
         if state.offset is not None:
             logger.info("Telegram poller 상태 복원: offset=%s", state.offset)
+        for update_id, failure in self._failures.items():
+            # 재시작을 넘긴 예산은 그 자체로 조사 대상이다 — 이 로그가 없으면 "재시작 직후
+            # 첫 실패에서 바로 폐기됐다"가 원인 없는 사건으로 보인다.
+            logger.info(
+                "Telegram poller 재시도 예산 복원: update=%s attempts=%s elapsed=%.0fs",
+                update_id,
+                failure.attempts,
+                self._now() - failure.first_at,
+            )
+
+    def _restore_failures(
+        self, failures: tuple[TelegramPollerFailure, ...]
+    ) -> dict[int, _UpdateFailure]:
+        """저장된 벽시계 앵커를 이 프로세스의 monotonic 기준으로 환산한다 (#350).
+
+        경과가 음수면 0으로 접는다. 벽시계가 뒤로 뛴 상태라 그 update가 실제로 얼마나
+        기다렸는지 알 방법이 없고, 이 방향의 오차는 "예산을 한 번 더 준다"(= #350 이전
+        동작)로 떨어져 정지를 새로 만들지 않는다.
+
+        경과가 창을 이미 넘겼어도 여기서 폐기하지는 않는다. 폐기 판정은 _handle_one_update의
+        한 곳에 남겨 둔다 — 그 update가 재배달돼 다시 실패해야 폐기가 의미를 갖고, 재시작
+        사이에 원인이 사라졌다면 그냥 성공하고 예산은 pop된다.
+        """
+        wall_now = self._wall_now()
+        now = self._now()
+        restored: dict[int, _UpdateFailure] = {}
+        for failure in failures:
+            elapsed = max(0.0, wall_now - failure.first_at)
+            restored[failure.update_id] = _UpdateFailure(
+                first_at=now - elapsed,
+                attempts=failure.attempts,
+                send_failure=failure.send_failure,
+                first_wall_at=failure.first_at,
+            )
+        return restored
 
     async def _persist_state(self) -> None:
-        """offset을 저장한다 (#248).
+        """offset과 재시도 예산을 저장한다 (#248, #350).
 
         쓰기 실패는 삼킨다 — fail-open 근거는 RedisTelegramPollerStore 독스트링에 있다.
         폴링은 인메모리 상태로 계속되고, 다음 update의 쓰기가 성공하면 그 시점 상태가
@@ -2521,12 +2585,33 @@ class TelegramCommandPoller:
         """
         try:
             await asyncio.wait_for(
-                self.state_store.save(TelegramPollerState(offset=self.offset)),
+                self.state_store.save(
+                    TelegramPollerState(
+                        offset=self.offset, failures=self._failures_snapshot()
+                    )
+                ),
                 timeout=STATE_STORE_TIMEOUT_SECONDS,
             )
         except Exception as exc:
             # TimeoutError·CancelledError 취급은 _restore_state 주석 참조.
             logger.error("Telegram poller 상태 저장 실패, 인메모리로 계속: %s", exc)
+
+    def _failures_snapshot(self) -> tuple[TelegramPollerFailure, ...]:
+        """인메모리 예산을 저장 형식으로 옮긴다 — 나가는 시각은 벽시계다 (#350).
+
+        update_id 순으로 정렬하는 이유는 payload를 재현 가능하게 만들기 위해서다. dict의
+        삽입 순서가 그대로 나가면 같은 상태가 서로 다른 문자열이 되어, 저장된 값을 눈으로
+        비교하거나 테스트가 payload를 고정하기 어려워진다.
+        """
+        return tuple(
+            TelegramPollerFailure(
+                update_id=update_id,
+                first_at=failure.first_wall_at,
+                attempts=failure.attempts,
+                send_failure=failure.send_failure,
+            )
+            for update_id, failure in sorted(self._failures.items())
+        )
 
     def _forget_passed_updates(self, offset: int) -> None:
         """offset이 지나간 update_id 기록을 정리해 추적 상태가 무한히 커지지 않게 한다 (#241).
@@ -2558,6 +2643,14 @@ class TelegramCommandPoller:
     def _now(self) -> float:
         """재시도 예산용 단조 시계. 테스트에서 대체할 수 있도록 메서드로 둔다 (#241)."""
         return time.monotonic()
+
+    def _wall_now(self) -> float:
+        """예산을 재시작 너머로 나르기 위한 벽시계 (#350).
+
+        _now와 갈라 두는 이유는 _UpdateFailure 독스트링에 있다. 여기 값은 영속화 payload와
+        복원 시 경과 계산에만 쓰이고, 살아 있는 프로세스 안의 판정에는 쓰이지 않는다.
+        """
+        return time.time()
 
     async def _setup_bot_profile(self) -> None:
         # notifier는 주입 가능하고 이 능력은 선택 사항이라, 선언 타입이 아니라

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -2248,9 +2248,10 @@ class _UpdateFailure:
     영속화·복원 경계에서만 벽시계를 쓴다 — 복원은 벽시계 경과만큼 뒤로 민 monotonic 값을
     ``first_at``에 넣어, 그 뒤의 코드가 계속 한 시계만 보게 한다.
 
-    ``first_wall_at``은 복원해도 원래 값을 그대로 유지한다. 복원 시점으로 새로 찍으면
-    재시작마다 앵커가 앞당겨져, 잦은 재시작이 다시 예산을 무한히 늘리는 #350의 경로가
-    벽시계 쪽으로 되살아난다.
+    ``first_wall_at``은 복원해도 원래 값을 그대로 유지한다 — 앵커가 미래일 때(벽시계가 뒤로
+    조정된 경우)만 예외이고, 근거는 _restore_failures에 있다. 그 예외 밖에서 복원 시점으로
+    새로 찍으면 재시작마다 앵커가 앞당겨져, 잦은 재시작이 다시 예산을 무한히 늘리는 #350의
+    경로가 벽시계 쪽으로 되살아난다.
     """
 
     first_at: float
@@ -2303,6 +2304,10 @@ class TelegramCommandPoller:
         # 복원 실패를 저장소가 offset과 다르게 다루는 근거가 그것이다
         # (RedisTelegramPollerStore._deserialize_failures).
         self._failures: dict[int, _UpdateFailure] = {}
+        # 복원이 저장소를 실제로 읽어냈는가 (PR #362 리뷰). 거짓이면 저장된 offset이
+        # 무엇인지 이 프로세스는 모른다 — self.offset이 None인 것은 "없다"가 아니라
+        # "모른다"다. 그 구분이 필요한 곳은 아래 retry_pending의 쓰기 하나뿐이다.
+        self._state_restored = False
 
     async def run(self) -> None:
         if not self.notifier.enabled:
@@ -2389,7 +2394,17 @@ class TelegramCommandPoller:
                 # 이 쓰기는 재시도 사이클당 한 번(간격 5~45초)이라 정상 경로의 쓰기 빈도를
                 # 바꾸지 않는다. offset은 그대로고 바뀌는 것은 attempts뿐이지만, 상태를 통째로
                 # 덮어쓰는 계약이라 부분 갱신을 따로 만들 이유가 없다.
-                await self._persist_state()
+                #
+                # 다만 그 "통째로"가 여기서는 위험하다 (PR #362 리뷰). 복원이 실패했고 아직
+                # offset을 하나도 확정하지 못했다면, self.offset(None)을 쓰는 순간 저장된
+                # 정상 offset이 지워진다. 루프 안의 쓰기 지점은 offset을 전진시킨 직후라 이
+                # 상태로 도달하지 않지만 여기는 도달한다 — poison이 배치 맨 앞이면 "첫 성공한
+                # update"가 영영 오지 않아, 재시도 사이클마다 같은 쓰기가 반복된다. 그 offset은
+                # 재배달·재실행을 막는 마지막 방어선이므로 예산 한 창과 바꾸지 않는다
+                # (_deserialize_failures 독스트링의 판단과 같다). 예산은 그동안 인메모리로만
+                # 살고, offset을 하나라도 확정하는 순간부터 정상적으로 저장된다.
+                if self._state_restored or self.offset is not None:
+                    await self._persist_state()
                 # 실패한 update를 곧바로 다시 받아 예산을 순식간에 소진하지 않도록 쉬어 간다.
                 # 실패가 이어지면 간격을 늘려 복구 창을 벌고 rate limit도 덜 자극한다 (#241).
                 await self._sleep(self._retry_delay())
@@ -2532,9 +2547,15 @@ class TelegramCommandPoller:
             # CancelledError는 BaseException이라 걸리지 않고 정상 전파된다.
             logger.error("Telegram poller 상태 복원 실패, 빈 상태로 시작: %s", exc)
             return
+        self._state_restored = True
         self.offset = state.offset
         self._failures = self._restore_failures(state.failures)
         if state.offset is not None:
+            # payload가 두 값의 관계를 지킨다는 보장은 없다 (PR #362 리뷰). 정상 쓰기 경로는
+            # pop → offset 전진 → 저장 순이라 offset이 지나간 예산을 만들지 않지만,
+            # _deserialize도 여기도 그 관계를 검증하지 않는다. 그런 항목은 재배달되지 않아
+            # pop될 기회가 영영 없고, _retry_delay의 min(attempts)에 섞여 백오프만 줄인다.
+            self._forget_passed_updates(state.offset)
             logger.info("Telegram poller 상태 복원: offset=%s", state.offset)
         for update_id, failure in self._failures.items():
             # 재시작을 넘긴 예산은 그 자체로 조사 대상이다 — 이 로그가 없으면 "재시작 직후
@@ -2551,9 +2572,15 @@ class TelegramCommandPoller:
     ) -> dict[int, _UpdateFailure]:
         """저장된 벽시계 앵커를 이 프로세스의 monotonic 기준으로 환산한다 (#350).
 
-        경과가 음수면 0으로 접는다. 벽시계가 뒤로 뛴 상태라 그 update가 실제로 얼마나
-        기다렸는지 알 방법이 없고, 이 방향의 오차는 "예산을 한 번 더 준다"(= #350 이전
-        동작)로 떨어져 정지를 새로 만들지 않는다.
+        앵커가 미래면(= 벽시계가 뒤로 조정됐다) 경과를 0으로 접고 **앵커도 지금으로 다시
+        찍는다**. 접기만 하면 예산이 한 번 더 지급되는 것으로 끝나지 않는다 (PR #362 리뷰):
+        시계 오프셋은 재시작 뒤에도 그대로 남아 있으므로 저장된 앵커는 계속 미래고, 그러면
+        **매 재시작이 같은 클램프를 반복해** #350이 없애려던 무기한 정지가 되살아난다.
+        재각인하면 다음 재시작부터는 경과가 정상적으로 쌓여 폐기가 진행된다.
+
+        min을 쓰는 이유는 반대 방향을 건드리지 않기 위해서다. 앵커가 과거면(정상·정방향
+        점프) 저장된 값을 그대로 둔다 — 복원 시점으로 앞당기면 잦은 재시작이 예산을 무한히
+        늘리는 #350의 경로가 그대로 되살아난다.
 
         경과가 창을 이미 넘겼어도 여기서 폐기하지는 않는다. 폐기 판정은 _handle_one_update의
         한 곳에 남겨 둔다 — 그 update가 재배달돼 다시 실패해야 폐기가 의미를 갖고, 재시작
@@ -2563,12 +2590,12 @@ class TelegramCommandPoller:
         now = self._now()
         restored: dict[int, _UpdateFailure] = {}
         for failure in failures:
-            elapsed = max(0.0, wall_now - failure.first_at)
+            anchor = min(failure.first_wall_at, wall_now)
             restored[failure.update_id] = _UpdateFailure(
-                first_at=now - elapsed,
+                first_at=now - (wall_now - anchor),
                 attempts=failure.attempts,
                 send_failure=failure.send_failure,
-                first_wall_at=failure.first_at,
+                first_wall_at=anchor,
             )
         return restored
 
@@ -2606,7 +2633,7 @@ class TelegramCommandPoller:
         return tuple(
             TelegramPollerFailure(
                 update_id=update_id,
-                first_at=failure.first_wall_at,
+                first_wall_at=failure.first_wall_at,
                 attempts=failure.attempts,
                 send_failure=failure.send_failure,
             )

--- a/backend/tests/test_redis_state.py
+++ b/backend/tests/test_redis_state.py
@@ -346,7 +346,7 @@ async def test_poller_state_load_logs_when_corrupted_key_delete_fails(caplog):
 def _failure(**overrides) -> TelegramPollerFailure:
     values = {
         "update_id": 41,
-        "first_at": 1_700_000_000.5,
+        "first_wall_at": 1_700_000_000.5,
         "attempts": 3,
         "send_failure": True,
     }
@@ -358,7 +358,7 @@ def _failure(**overrides) -> TelegramPollerFailure:
 async def test_poller_state_round_trips_failures():
     """예산이 재시작을 넘으려면 네 필드가 전부 살아 돌아와야 한다 (#350).
 
-    first_at은 벽시계 epoch 초다 — monotonic이면 프로세스가 바뀐 순간 기준점이 사라져
+    first_wall_at은 벽시계 epoch 초다 — monotonic이면 프로세스가 바뀐 순간 기준점이 사라져
     저장한 값으로 경과를 잴 수 없다 (TelegramPollerFailure 독스트링).
     """
     redis = FakeRedis()
@@ -416,24 +416,24 @@ async def test_poller_state_load_without_failures_field_is_not_corruption():
         # 원소는 오브젝트여야 한다.
         "[41]",
         # bool은 int의 하위 타입이라 isinstance만으로는 통과한다.
-        '[{"update_id": true, "first_at": 1.0, "attempts": 1, "send_failure": false}]',
+        '[{"update_id": true, "first_wall_at": 1.0, "attempts": 1, "send_failure": false}]',
         # offset과 같은 축의 값이라 범위도 같이 닫는다. 벗어난 id는 _forget_passed_updates의
         # 비교가 영원히 지우지 못한다.
-        '[{"update_id": -1, "first_at": 1.0, "attempts": 1, "send_failure": false}]',
-        '[{"update_id": 99999999999, "first_at": 1.0, "attempts": 1, "send_failure": false}]',
-        # first_at이 없거나 숫자가 아니면 경과 산술이 TypeError로 터진다.
+        '[{"update_id": -1, "first_wall_at": 1.0, "attempts": 1, "send_failure": false}]',
+        '[{"update_id": 99999999999, "first_wall_at": 1.0, "attempts": 1, "send_failure": false}]',
+        # first_wall_at이 없거나 숫자가 아니면 경과 산술이 TypeError로 터진다.
         '[{"update_id": 41, "attempts": 1, "send_failure": false}]',
-        '[{"update_id": 41, "first_at": "1.0", "attempts": 1, "send_failure": false}]',
+        '[{"update_id": 41, "first_wall_at": "1.0", "attempts": 1, "send_failure": false}]',
         # NaN은 json.loads가 그대로 통과시킨다. 새면 경과 비교가 항상 False가 되어
         # poison이 영원히 재시도된다 — #350이 없애려던 바로 그 상태다.
-        '[{"update_id": 41, "first_at": NaN, "attempts": 1, "send_failure": false}]',
-        '[{"update_id": 41, "first_at": Infinity, "attempts": 1, "send_failure": false}]',
+        '[{"update_id": 41, "first_wall_at": NaN, "attempts": 1, "send_failure": false}]',
+        '[{"update_id": 41, "first_wall_at": Infinity, "attempts": 1, "send_failure": false}]',
         # 벽시계 epoch 초라 0 이하는 정상값이 아니다.
-        '[{"update_id": 41, "first_at": 0, "attempts": 1, "send_failure": false}]',
+        '[{"update_id": 41, "first_wall_at": 0, "attempts": 1, "send_failure": false}]',
         # attempts < 1이면 _retry_delay의 인덱스가 음수가 되어 가장 긴 간격을 고른다.
-        '[{"update_id": 41, "first_at": 1.0, "attempts": 0, "send_failure": false}]',
-        '[{"update_id": 41, "first_at": 1.0, "attempts": true, "send_failure": false}]',
-        '[{"update_id": 41, "first_at": 1.0, "attempts": 1, "send_failure": "yes"}]',
+        '[{"update_id": 41, "first_wall_at": 1.0, "attempts": 0, "send_failure": false}]',
+        '[{"update_id": 41, "first_wall_at": 1.0, "attempts": true, "send_failure": false}]',
+        '[{"update_id": 41, "first_wall_at": 1.0, "attempts": 1, "send_failure": "yes"}]',
     ],
 )
 async def test_poller_state_load_drops_corrupted_failures_but_keeps_offset(failures):
@@ -459,7 +459,7 @@ async def test_poller_state_load_drops_failures_when_offset_is_corrupted():
         {
             "offset": -1,
             "failures": [
-                {"update_id": 41, "first_at": 1.0, "attempts": 1, "send_failure": False}
+                {"update_id": 41, "first_wall_at": 1.0, "attempts": 1, "send_failure": False}
             ],
         }
     )

--- a/backend/tests/test_redis_state.py
+++ b/backend/tests/test_redis_state.py
@@ -13,6 +13,7 @@ from backend.redis_state import (
     RedisPendingOrderStore,
     RedisSchedulerState,
     RedisTelegramPollerStore,
+    TelegramPollerFailure,
     TelegramPollerState,
     TelegramPollerStore,
     signal_hash,
@@ -335,6 +336,137 @@ async def test_poller_state_load_logs_when_corrupted_key_delete_fails(caplog):
         assert await store.load() == TelegramPollerState()
 
     assert "손상 키 삭제 실패" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# 재시도 예산 영속화 (#350)
+# ---------------------------------------------------------------------------
+
+
+def _failure(**overrides) -> TelegramPollerFailure:
+    values = {
+        "update_id": 41,
+        "first_at": 1_700_000_000.5,
+        "attempts": 3,
+        "send_failure": True,
+    }
+    values.update(overrides)
+    return TelegramPollerFailure(**values)
+
+
+@pytest.mark.asyncio
+async def test_poller_state_round_trips_failures():
+    """예산이 재시작을 넘으려면 네 필드가 전부 살아 돌아와야 한다 (#350).
+
+    first_at은 벽시계 epoch 초다 — monotonic이면 프로세스가 바뀐 순간 기준점이 사라져
+    저장한 값으로 경과를 잴 수 없다 (TelegramPollerFailure 독스트링).
+    """
+    redis = FakeRedis()
+    store = RedisTelegramPollerStore(redis)
+
+    await store.save(TelegramPollerState(offset=41, failures=(_failure(),)))
+
+    assert await store.load() == TelegramPollerState(offset=41, failures=(_failure(),))
+
+
+@pytest.mark.asyncio
+async def test_poller_state_save_omits_empty_failures():
+    """예산이 없으면 payload에도 없다 — 정상 경로의 쓰기를 넓히지 않는다 (#350)."""
+    redis = FakeRedis()
+    store = RedisTelegramPollerStore(redis)
+
+    await store.save(TelegramPollerState(offset=45))
+
+    assert json.loads(redis.store["finus:telegram:poller_state"]) == {"offset": 45}
+
+
+@pytest.mark.asyncio
+async def test_poller_state_save_clears_a_previously_written_failure():
+    """예산이 사라진 상태를 쓰면 저장된 예산도 지워져야 한다 (#350).
+
+    남으면 그 update가 통과한 뒤에도 낡은 앵커가 살아, 한참 뒤 같은 id를 다시 쓰게 된
+    폴러가 "이미 예산을 다 썼다"고 판단해 첫 실패에서 곧장 폐기한다.
+    """
+    redis = FakeRedis()
+    store = RedisTelegramPollerStore(redis)
+
+    await store.save(TelegramPollerState(offset=41, failures=(_failure(),)))
+    await store.save(TelegramPollerState(offset=42))
+
+    assert await store.load() == TelegramPollerState(offset=42)
+
+
+@pytest.mark.asyncio
+async def test_poller_state_load_without_failures_field_is_not_corruption():
+    """#350 이전 배포가 남긴 payload는 예산 없는 정상 상태다 — 키를 지우면 안 된다."""
+    redis = FakeRedis()
+    redis.store["finus:telegram:poller_state"] = '{"offset": 44}'
+    store = RedisTelegramPollerStore(redis)
+
+    assert await store.load() == TelegramPollerState(offset=44)
+    assert "finus:telegram:poller_state" in redis.store
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failures",
+    [
+        # 목록이 아니면 원소를 셀 수조차 없다.
+        '"nope"',
+        # 원소는 오브젝트여야 한다.
+        "[41]",
+        # bool은 int의 하위 타입이라 isinstance만으로는 통과한다.
+        '[{"update_id": true, "first_at": 1.0, "attempts": 1, "send_failure": false}]',
+        # offset과 같은 축의 값이라 범위도 같이 닫는다. 벗어난 id는 _forget_passed_updates의
+        # 비교가 영원히 지우지 못한다.
+        '[{"update_id": -1, "first_at": 1.0, "attempts": 1, "send_failure": false}]',
+        '[{"update_id": 99999999999, "first_at": 1.0, "attempts": 1, "send_failure": false}]',
+        # first_at이 없거나 숫자가 아니면 경과 산술이 TypeError로 터진다.
+        '[{"update_id": 41, "attempts": 1, "send_failure": false}]',
+        '[{"update_id": 41, "first_at": "1.0", "attempts": 1, "send_failure": false}]',
+        # NaN은 json.loads가 그대로 통과시킨다. 새면 경과 비교가 항상 False가 되어
+        # poison이 영원히 재시도된다 — #350이 없애려던 바로 그 상태다.
+        '[{"update_id": 41, "first_at": NaN, "attempts": 1, "send_failure": false}]',
+        '[{"update_id": 41, "first_at": Infinity, "attempts": 1, "send_failure": false}]',
+        # 벽시계 epoch 초라 0 이하는 정상값이 아니다.
+        '[{"update_id": 41, "first_at": 0, "attempts": 1, "send_failure": false}]',
+        # attempts < 1이면 _retry_delay의 인덱스가 음수가 되어 가장 긴 간격을 고른다.
+        '[{"update_id": 41, "first_at": 1.0, "attempts": 0, "send_failure": false}]',
+        '[{"update_id": 41, "first_at": 1.0, "attempts": true, "send_failure": false}]',
+        '[{"update_id": 41, "first_at": 1.0, "attempts": 1, "send_failure": "yes"}]',
+    ],
+)
+async def test_poller_state_load_drops_corrupted_failures_but_keeps_offset(failures):
+    """손상된 예산은 버리되 offset은 살린다 (#350).
+
+    offset 쪽 검증과 달리 여기서는 raise하지 않는다. 유실 대가가 다르기 때문이다 —
+    예산이 없으면 폐기가 한 창 미뤄질 뿐이지만(#350 이전 동작), 손상 키 삭제로 offset까지
+    날아가면 Telegram이 미확정 update를 전부 재배달해 이미 실행한 명령이 다시 실행된다.
+    """
+    redis = FakeRedis()
+    redis.store["finus:telegram:poller_state"] = f'{{"offset": 44, "failures": {failures}}}'
+    store = RedisTelegramPollerStore(redis)
+
+    assert await store.load() == TelegramPollerState(offset=44)
+    assert "finus:telegram:poller_state" in redis.store
+
+
+@pytest.mark.asyncio
+async def test_poller_state_load_drops_failures_when_offset_is_corrupted():
+    """offset이 손상되면 예산도 함께 간다 — 앵커만 남겨도 짝이 없다 (#350)."""
+    redis = FakeRedis()
+    redis.store["finus:telegram:poller_state"] = json.dumps(
+        {
+            "offset": -1,
+            "failures": [
+                {"update_id": 41, "first_at": 1.0, "attempts": 1, "send_failure": False}
+            ],
+        }
+    )
+    store = RedisTelegramPollerStore(redis)
+
+    assert await store.load() == TelegramPollerState()
+    assert redis.store == {}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -3412,7 +3412,7 @@ async def test_poller_writes_the_budget_while_the_batch_is_stopped(monkeypatch):
         offset=None,
         failures=(
             TelegramPollerFailure(
-                update_id=41, first_at=WALL_EPOCH, attempts=1, send_failure=False
+                update_id=41, first_wall_at=WALL_EPOCH, attempts=1, send_failure=False
             ),
         ),
     )
@@ -3478,11 +3478,11 @@ async def test_send_failure_window_survives_a_restart(monkeypatch):
     assert notifier.messages == []
 
 
-def test_restored_budget_clamps_a_backwards_wall_clock(monkeypatch):
-    """벽시계가 뒤로 뛰면 경과를 0으로 접는다 (#350).
+def test_restored_budget_reanchors_a_backwards_wall_clock(monkeypatch):
+    """벽시계가 뒤로 뛰면 경과를 0으로 접고 앵커도 지금으로 다시 찍는다 (PR #362 리뷰).
 
-    음수 경과를 그대로 두면 창이 그만큼 늘어나 poison이 예산 밖에서 살아남는다. 0으로
-    접으면 예산을 한 번 더 주는 것 — #350 이전 동작 — 에 그친다.
+    접기만 하고 앵커를 두면 예산이 "한 번 더"가 아니라 무한이 된다 — 시계 오프셋은 재시작
+    뒤에도 남아 있어 저장된 앵커가 계속 미래고, 매 재시작이 같은 클램프를 반복한다.
     """
     notifier = FakeNotifier()
 
@@ -3499,7 +3499,7 @@ def test_restored_budget_clamps_a_backwards_wall_clock(monkeypatch):
             TelegramPollerFailure(
                 # 벽시계가 100초 뒤로 뛴 상황 = 저장된 앵커가 미래다.
                 update_id=41,
-                first_at=WALL_EPOCH + 100.0,
+                first_wall_at=WALL_EPOCH + 100.0,
                 attempts=2,
                 send_failure=False,
             ),
@@ -3507,10 +3507,155 @@ def test_restored_budget_clamps_a_backwards_wall_clock(monkeypatch):
     )
 
     assert restored[41].first_at == clock.now
-    # 앵커는 저장된 값 그대로 유지된다. 복원 시점으로 새로 찍으면 재시작마다 앵커가
-    # 앞당겨져 #350의 무한 연장이 벽시계 쪽으로 되살아난다.
-    assert restored[41].first_wall_at == WALL_EPOCH + 100.0
+    assert restored[41].first_wall_at == clock.wall
     assert restored[41].attempts == 2
+
+
+def test_restored_budget_keeps_the_anchor_when_the_clock_moved_forward(monkeypatch):
+    """정방향(정상)에서는 앵커를 건드리지 않는다 (#350).
+
+    복원 시점으로 앞당기면 잦은 재시작이 예산을 무한히 늘리는 #350의 경로가 그대로
+    되살아난다. 뒤로 뛴 경우의 재각인이 이 성질까지 함께 지우지 않았음을 고정한다.
+    """
+    notifier = FakeNotifier()
+
+    class NoopHandler:
+        async def handle_update(self, update):
+            return None
+
+    poller = _make_poller(notifier, handler=NoopHandler())
+    clock = FakePollerClock(wall=WALL_EPOCH + 40.0)
+    clock.install(monkeypatch, poller)
+
+    restored = poller._restore_failures(
+        (
+            TelegramPollerFailure(
+                update_id=41, first_wall_at=WALL_EPOCH, attempts=2, send_failure=False
+            ),
+        )
+    )
+
+    assert restored[41].first_wall_at == WALL_EPOCH
+    # 40초를 이미 쓴 예산으로 복원된다 — monotonic 기준점이 다른 프로세스에서도 그대로다.
+    assert restored[41].first_at == clock.now - 40.0
+
+
+@pytest.mark.asyncio
+async def test_poison_is_discarded_even_after_the_wall_clock_stepped_backwards(monkeypatch):
+    """벽시계가 뒤로 조정된 뒤에도 poison은 폐기된다 (PR #362 리뷰).
+
+    오프셋은 재시작 뒤에도 남으므로, 클램프만 하고 앵커를 저장값 그대로 두면 매 재시작이
+    같은 클램프를 반복해 #350이 없애려던 무기한 정지가 그대로 되살아난다. 아래 루프는
+    시계를 한 시간 뒤로 민 뒤 재시작을 반복한다 — 앵커 재각인이 없으면 10번을 돌아도
+    42는 실행되지 않는다.
+    """
+    notifier = FakeNotifier()
+    notifier.enabled = True
+    notifier.bot_token = "token"
+    store = InMemoryTelegramPollerStore()
+    handled = []
+
+    class PartialHandler:
+        async def handle_update(self, update):
+            if update["update_id"] == 41:
+                raise RuntimeError("poison update")
+            handled.append(update["update_id"])
+
+    wall = WALL_EPOCH
+    processes = 0
+    for index in range(10):
+        clock = FakePollerClock(stop_after=1, now=1000.0 * index, wall=wall)
+        poller = _restarting_poison_poller(
+            monkeypatch, notifier, store, PartialHandler(), clock, handled
+        )
+        with pytest.raises(asyncio.CancelledError):
+            await poller.run()
+        processes += 1
+        wall = clock.wall + 1.0
+        if processes == 1:
+            # 첫 재시작 직전에 시계가 한 시간 뒤로 조정된다. 이후 프로세스는 전부 그
+            # 오프셋 위에서 돈다 — 한 번의 점프가 아니라 지속되는 상태다.
+            wall -= 3600.0
+        if handled:
+            break
+
+    assert handled == [42]
+    assert processes > 1  # 점프 없이 첫 프로세스가 끝내버렸다면 시나리오가 성립하지 않는다
+
+
+@pytest.mark.asyncio
+async def test_retry_write_keeps_a_stored_offset_when_restore_failed(monkeypatch):
+    """복원이 실패한 상태에서는 배치 중단 시 쓰기를 건너뛴다 (PR #362 리뷰).
+
+    _persist_state는 상태를 통째로 덮어쓰므로, 복원 실패로 self.offset이 None인 채 쓰면
+    저장된 정상 offset이 지워진다. poison이 배치 맨 앞이면 offset을 전진시킬 "첫 성공한
+    update"가 영영 오지 않아 재시도 사이클마다 그 쓰기가 반복되고, 다음 재시작에서
+    미확정 update가 전부 재배달돼 이미 실행한 명령이 다시 실행된다.
+    """
+    notifier = FakeNotifier()
+    notifier.enabled = True
+    notifier.bot_token = "token"
+
+    class LoadFailingStore(InMemoryTelegramPollerStore):
+        async def load(self):
+            raise RuntimeError("redis unavailable")
+
+    store = LoadFailingStore(TelegramPollerState(offset=41))
+
+    class FailingHandler:
+        async def handle_update(self, update):
+            raise RuntimeError("poison update")
+
+    poller = _make_poller(notifier, handler=FailingHandler(), state_store=store)
+    clock = FakePollerClock(stop_after=1)
+    clock.install(monkeypatch, poller)
+
+    async def fake_get_updates():
+        return _poison_batch()
+
+    monkeypatch.setattr(poller, "_get_updates", fake_get_updates)
+
+    with pytest.raises(asyncio.CancelledError):
+        await poller.run()
+
+    assert store.state == TelegramPollerState(offset=41)
+    # 쓰기만 건너뛴다. 예산은 인메모리로 계속 쌓여 이 프로세스 안에서는 정상 동작한다.
+    assert poller._failures[41].attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_restore_drops_budget_the_offset_already_passed(monkeypatch):
+    """offset이 지나간 예산 항목은 복원 시 버린다 (PR #362 리뷰).
+
+    정상 쓰기 경로는 이 관계가 깨진 payload를 만들지 않지만 역직렬화도 복원도 그것을
+    검증하지 않는다. 남으면 재배달되지 않아 pop될 기회가 없고, _retry_delay의
+    min(attempts)에 섞여 백오프만 짧아진다.
+    """
+    notifier = FakeNotifier()
+
+    class NoopHandler:
+        async def handle_update(self, update):
+            return None
+
+    store = InMemoryTelegramPollerStore(
+        TelegramPollerState(
+            offset=42,
+            failures=(
+                TelegramPollerFailure(
+                    update_id=41, first_wall_at=WALL_EPOCH, attempts=5, send_failure=False
+                ),
+                TelegramPollerFailure(
+                    update_id=42, first_wall_at=WALL_EPOCH, attempts=1, send_failure=False
+                ),
+            ),
+        )
+    )
+    poller = _make_poller(notifier, handler=NoopHandler(), state_store=store)
+    FakePollerClock().install(monkeypatch, poller)
+
+    await poller._restore_state()
+
+    assert set(poller._failures) == {42}
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -47,6 +47,7 @@ from backend.redis_state import (
     InMemoryPendingOrderStore,
     InMemoryTelegramPollerStore,
     RedisPendingOrderStore,
+    TelegramPollerFailure,
     TelegramPollerState,
     TelegramPollerStore,
 )
@@ -2513,25 +2514,38 @@ async def test_poller_does_not_rerun_llm_when_nat_response_send_fails(monkeypatc
     assert poller._failures == {}
 
 
+# 가짜 벽시계의 기준점. monotonic 기준점(0.0)과 멀찍이 떨어뜨려야, 저장된 벽시계 값을
+# monotonic으로 착각해 쓰는 구현이 테스트에서 티가 난다 — 경과가 -1.7e9초가 되어 예산이
+# 영원히 남는다 (#350).
+WALL_EPOCH = 1_700_000_000.0
+
+
 class FakePollerClock:
-    """폴러의 _sleep/_now만 대체해 시간 기반 재시도 예산을 결정론적으로 진행시킨다 (#241).
+    """폴러의 _sleep/_now/_wall_now를 대체해 시간 기반 재시도 예산을 진행시킨다 (#241, #350).
 
     전역 asyncio.sleep을 패치하면 핸들러 내부의 실제 sleep(_handle_watch의 조회 간격)까지
     가로채므로 인스턴스 수준 간접층만 건드린다 (PR #242 리뷰).
+
+    두 시계를 같은 delay만큼 함께 민다. 재시작을 재현할 때는 새 클록을 만들어 monotonic은
+    다른 기준점에서(새 프로세스처럼), 벽시계는 앞 프로세스가 끝낸 지점부터 이어 붙인다 —
+    ``now``·``wall``이 그 두 기준점을 받는다 (#350).
     """
 
-    def __init__(self, *, stop_after=None):
-        self.now = 0.0
+    def __init__(self, *, stop_after=None, now=0.0, wall=WALL_EPOCH):
+        self.now = now
+        self.wall = wall
         self.sleeps = []
         self._stop_after = stop_after
 
     def install(self, monkeypatch, poller):
         monkeypatch.setattr(poller, "_sleep", self._sleep)
         monkeypatch.setattr(poller, "_now", lambda: self.now)
+        monkeypatch.setattr(poller, "_wall_now", lambda: self.wall)
 
     async def _sleep(self, delay):
         self.sleeps.append(delay)
         self.now += delay
+        self.wall += delay
         if self._stop_after is not None and len(self.sleeps) >= self._stop_after:
             raise asyncio.CancelledError
 
@@ -2753,7 +2767,7 @@ async def test_poller_retry_delay_follows_the_newest_failure(monkeypatch):
     clock.install(monkeypatch, poller)
     # 41은 이미 오래 재시도 중(45초 간격), 42는 이제 막 실패한다.
     poller._failures[41] = telegram_commands._UpdateFailure(
-        first_at=0.0, attempts=8, send_failure=False
+        first_at=0.0, attempts=8, send_failure=False, first_wall_at=WALL_EPOCH
     )
 
     async def fake_get_updates():
@@ -2784,7 +2798,7 @@ def test_forget_passed_updates_drops_only_what_the_offset_passed():
     poller = _make_poller(notifier, handler=NoopHandler())
     for update_id in (40, 41, 42):
         poller._failures[update_id] = telegram_commands._UpdateFailure(
-            first_at=0.0, attempts=1, send_failure=False
+            first_at=0.0, attempts=1, send_failure=False, first_wall_at=WALL_EPOCH
         )
 
     poller._forget_passed_updates(42)
@@ -3290,6 +3304,213 @@ async def test_poller_restores_offset_across_restart(monkeypatch):
         await poller.run()
 
     assert requested_offsets == [42]
+
+
+def _restarting_poison_poller(monkeypatch, notifier, store, handler, clock, handled):
+    """새 폴러 = 새 프로세스. 인메모리 상태는 버리고 store와 벽시계만 넘겨준다 (#350).
+
+    clock의 monotonic 기준점은 프로세스마다 다르게 준다 — 저장된 벽시계 값을 그대로
+    monotonic으로 쓰는 구현이면 여기서 경과가 음수로 튄다.
+    """
+    poller = _make_poller(notifier, handler=handler, state_store=store)
+    clock.install(monkeypatch, poller)
+
+    async def fake_get_updates():
+        if handled:
+            # poison 뒤의 명령이 실행됐으면 이 시나리오는 끝났다. 남겨두면 offset이 배치를
+            # 다 지나 빈 배열이 돌아오는 루프가 sleep 없이 돈다.
+            raise asyncio.CancelledError
+        offset = poller.offset
+        return [u for u in _poison_batch() if offset is None or u["update_id"] >= offset]
+
+    monkeypatch.setattr(poller, "_get_updates", fake_get_updates)
+    return poller
+
+
+@pytest.mark.asyncio
+async def test_poison_budget_survives_restarts_faster_than_the_window(monkeypatch):
+    """재시작이 예산보다 잦아도 poison은 결국 폐기되고 뒤의 명령이 실행된다 (#350).
+
+    #248은 예산을 일부러 영속화하지 않았고, #259 1단계가 배치를 poison에서 끊게 만들면서
+    그 선택의 대가가 "폐기가 미뤄짐"에서 "그 채팅의 모든 명령이 정지"로 커졌다. 리셋 계기는
+    배포가 아니라 backend/Dockerfile의 uvicorn --reload + bind mount라 파일 저장 하나면
+    되므로, 아래처럼 매 프로세스가 재시도 한 번 만에 죽는 상황이 현실적이다.
+
+    각 프로세스는 sleep 한 번(stop_after=1) 만에 죽으므로 혼자서는 60초 창을 절대 채우지
+    못한다. 예산이 재시작을 넘지 못하면 41은 영원히 재시도되고 42는 영원히 실행되지 않는다.
+    """
+    notifier = FakeNotifier()
+    notifier.enabled = True
+    notifier.bot_token = "token"
+    store = InMemoryTelegramPollerStore()
+    handled = []
+
+    class PartialHandler:
+        async def handle_update(self, update):
+            if update["update_id"] == 41:
+                raise RuntimeError("poison update")
+            handled.append(update["update_id"])
+
+    # 재시작 자체에 걸리는 시간. 창(60초)에 비해 무시할 만해야 "재시작이 예산보다 잦다"는
+    # 전제가 성립한다.
+    restart_seconds = 1.0
+    wall = WALL_EPOCH
+    processes = 0
+    for index in range(10):
+        clock = FakePollerClock(stop_after=1, now=1000.0 * index, wall=wall)
+        poller = _restarting_poison_poller(
+            monkeypatch, notifier, store, PartialHandler(), clock, handled
+        )
+        with pytest.raises(asyncio.CancelledError):
+            await poller.run()
+        processes += 1
+        wall = clock.wall + restart_seconds
+        if handled:
+            break
+
+    # 폐기는 t=0/5/20/65의 네 번째 시도에서 일어난다. 재시작 간격이 끼어 있어도 시도 횟수는
+    # 그대로다 — 예산이 시간 기준이기 때문이다.
+    assert handled == [42]
+    assert processes == 4
+    assert poller.offset == 43
+    assert notifier.messages == [
+        f"{telegram_commands.UPDATE_SKIPPED_NOTICE}\n실패한 요청: /alerts off"
+    ]
+    # 폐기된 예산은 저장소에서도 사라져야 한다. 남으면 다음 재시작이 낡은 앵커를 되살린다.
+    assert store.state == TelegramPollerState(offset=43)
+
+
+@pytest.mark.asyncio
+async def test_poller_writes_the_budget_while_the_batch_is_stopped(monkeypatch):
+    """RETRY는 배치를 끊어 update별 쓰기 지점에 닿지 못한다 — 거기서도 써야 한다 (#350).
+
+    이 쓰기가 없으면 예산은 영속화 대상이 되고도 실제로는 한 번도 저장되지 않는다.
+    저장되는 시각이 벽시계라는 것도 함께 고정한다.
+    """
+    notifier = FakeNotifier()
+    notifier.enabled = True
+    notifier.bot_token = "token"
+    store = InMemoryTelegramPollerStore()
+
+    class FailingHandler:
+        async def handle_update(self, update):
+            raise RuntimeError("poison update")
+
+    poller = _make_poller(notifier, handler=FailingHandler(), state_store=store)
+    clock = FakePollerClock(stop_after=1)
+    clock.install(monkeypatch, poller)
+
+    async def fake_get_updates():
+        return [{"update_id": 41, "message": {"chat": {"id": 123}, "text": "/alerts off"}}]
+
+    monkeypatch.setattr(poller, "_get_updates", fake_get_updates)
+
+    with pytest.raises(asyncio.CancelledError):
+        await poller.run()
+
+    assert store.state == TelegramPollerState(
+        offset=None,
+        failures=(
+            TelegramPollerFailure(
+                update_id=41, first_at=WALL_EPOCH, attempts=1, send_failure=False
+            ),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_failure_window_survives_a_restart(monkeypatch):
+    """전송 실패 창(335초)도 재시작을 넘는다 — 넘지 못하면 이르게 폐기된다 (#350).
+
+    send_failure를 흘리면 복원된 예산이 일반 창(60초)으로 판정된다. 이미 100초를 지나온
+    update는 그 순간 첫 시도에서 곧장 폐기되는데, 429·5xx는 update의 문제가 아니라 전역
+    장애라 그 폐기는 명령을 잃는 회귀다 (PR #242 리뷰의 근거 그대로).
+
+    두 프로세스가 서로 다른 예외를 던지는 것이 이 테스트의 핵심이다. 재시작 후에도 전송
+    실패가 이어지면 그 실패가 send_failure를 다시 세워 창을 되살리므로, 복원이 필드를
+    흘려도 티가 나지 않는다. 흘림이 드러나는 것은 "전송 실패로 창을 벌어 둔 update가
+    재시작 뒤 다른 오류로 실패하는" 경우뿐이다 — _handle_one_update가 창을 마지막 예외
+    종류로 다시 고르지 않는 이유(PR #242 리뷰)와 같은 상황이다.
+    """
+    notifier = FakeNotifier()
+    notifier.enabled = True
+    notifier.bot_token = "token"
+    store = InMemoryTelegramPollerStore()
+    processes = []
+
+    class ProcessScopedHandler:
+        """첫 프로세스는 전송 실패, 두 번째 프로세스는 평범한 오류를 던진다."""
+
+        def __init__(self):
+            processes.append(self)
+
+        async def handle_update(self, update):
+            if len(processes) == 1:
+                raise telegram_commands.TelegramSendError("telegram send failed")
+            raise RuntimeError("redis unavailable")
+
+    def run_process(clock):
+        poller = _make_poller(notifier, handler=ProcessScopedHandler(), state_store=store)
+        clock.install(monkeypatch, poller)
+
+        async def fake_get_updates():
+            offset = poller.offset
+            return [u for u in _poison_batch() if offset is None or u["update_id"] >= offset]
+
+        monkeypatch.setattr(poller, "_get_updates", fake_get_updates)
+        return poller
+
+    first_clock = FakePollerClock(stop_after=1)
+    with pytest.raises(asyncio.CancelledError):
+        await run_process(first_clock).run()
+
+    # 일반 창(60초)은 넘고 전송 실패 창(300초)은 넘지 않는 지점에서 재시작한다.
+    second_clock = FakePollerClock(
+        stop_after=1, now=9_000.0, wall=first_clock.wall + 100.0
+    )
+    second = run_process(second_clock)
+    with pytest.raises(asyncio.CancelledError):
+        await second.run()
+
+    assert second._failures[41].send_failure is True
+    # 폐기됐다면 offset이 42로 전진하고 스킵 통지가 나갔을 것이다.
+    assert second.offset is None
+    assert notifier.messages == []
+
+
+def test_restored_budget_clamps_a_backwards_wall_clock(monkeypatch):
+    """벽시계가 뒤로 뛰면 경과를 0으로 접는다 (#350).
+
+    음수 경과를 그대로 두면 창이 그만큼 늘어나 poison이 예산 밖에서 살아남는다. 0으로
+    접으면 예산을 한 번 더 주는 것 — #350 이전 동작 — 에 그친다.
+    """
+    notifier = FakeNotifier()
+
+    class NoopHandler:
+        async def handle_update(self, update):
+            return None
+
+    poller = _make_poller(notifier, handler=NoopHandler())
+    clock = FakePollerClock()
+    clock.install(monkeypatch, poller)
+
+    restored = poller._restore_failures(
+        (
+            TelegramPollerFailure(
+                # 벽시계가 100초 뒤로 뛴 상황 = 저장된 앵커가 미래다.
+                update_id=41,
+                first_at=WALL_EPOCH + 100.0,
+                attempts=2,
+                send_failure=False,
+            ),
+        )
+    )
+
+    assert restored[41].first_at == clock.now
+    # 앵커는 저장된 값 그대로 유지된다. 복원 시점으로 새로 찍으면 재시작마다 앵커가
+    # 앞당겨져 #350의 무한 연장이 벽시계 쪽으로 되살아난다.
+    assert restored[41].first_wall_at == WALL_EPOCH + 100.0
+    assert restored[41].attempts == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 📝 개요

재시도 예산이 재시작을 넘지 못해 poison 하나가 그 채팅의 모든 명령을 무기한 정지시킬 수 있었다. 이슈에서 정한 A안(예산 영속화)을 구현한다.

## 🔍 발견된 문제

1. 폴러가 처리하지 못하는 update(poison)의 재시도 예산이 프로세스 메모리에만 있어, 재시작마다 예산이 처음부터 다시 지급된다. 배치가 poison에서 끊기게 된 뒤로 그 대가는 "폐기가 미뤄짐"이 아니라 "그동안 그 채팅의 모든 명령이 무응답"이다.
2. 리셋 계기가 배포가 아니다. 개발 구성이 backend 파일 저장마다 프로세스를 재시작하므로, 예산 창(일반 65초·전송 실패 335초)보다 잦은 저장이 이어지면 poison은 영원히 폐기되지 않는다. 이슈 #347 본문의 "최대 335초 지연"은 재시작이 없을 때만 성립하는 상한이었다.
3. 예산을 저장하려 해도 시각을 그대로 옮길 수 없다. 경과 측정에 쓰는 단조 시계는 원점이 프로세스마다 달라, 저장된 값으로는 재시작 뒤 경과를 계산할 수 없다.

## 🔧 문제 해결 방법

1. 예산을 폴러 상태와 함께 저장소에 얹어 재시작을 넘긴다. 저장 형식이 이미 확장 가능한 오브젝트라 필드 하나를 되돌려 넣는 작업이고, 예산이 없을 때는 그 필드 자체가 빠져 정상 경로의 쓰기가 넓어지지 않는다.
2. 예산이 갱신되는 시점은 배치가 끊기는 순간이라, 기존 쓰기 지점(update를 통과시킨 뒤)에 닿지 못한다. 배치를 끊고 대기에 들어가기 전에도 쓴다 — 빈도는 재시도 사이클당 한 번이다.
3. 시계를 둘로 나눈다. 살아 있는 동안의 판정은 단조 시계 그대로 두고, 영속화·복원 경계에서만 벽시계를 쓴다. 복원은 벽시계 경과만큼 뒤로 민 단조 값을 되돌려주므로 그 뒤의 코드는 계속 시계 하나만 본다. 벽시계가 뒤로 조정되면 경과를 0으로 접고 앵커도 그 시점으로 다시 찍는다 — 접기만 하면 시계 오프셋이 남아 있는 내내 매 재시작이 같은 클램프를 반복해 정지가 되살아난다.
4. 저장된 예산이 손상됐을 때는 예산만 버리고 offset은 살린다. 예산 유실은 폐기가 한 창 미뤄지는 degrade지만, offset까지 날리면 미확정 update가 전부 재배달돼 이미 실행한 명령이 다시 실행되기 때문이다.

## ✅ 검증

- 새로 추가한 회귀 테스트 13종을 뮤테이션으로 실측했다. 복원 무시 / 배치 중단 시 미저장 / 저장에 단조 시계 사용 / 전송 실패 플래그 흘림 / 음수 경과 미보정 / 정방향 점프에서 앵커 앞당김 / 시도 횟수 미저장 / payload 미검증 / 빈 예산 기록 / 손상 시 offset 동반 폐기 / 복원 실패 상태의 배치 중단 쓰기 / 뒤로 조정된 벽시계에서 앵커 재각인 누락 / 복원 후 지나간 예산 미정리 — 13건 전부 되돌리면 해당 테스트가 빨간불이 된다.
- 전송 실패 플래그 흘림은 재시작 뒤에도 전송 실패가 이어지면 그 실패가 플래그를 다시 세워 가려진다. 두 프로세스가 서로 다른 예외를 던지는 형태여야 검출되는 것을 확인하고 그렇게 짰다.
- 재시작 시나리오는 프로세스마다 단조 시계 원점을 다르게 주고 벽시계만 이어 붙여 재현한다. 저장된 벽시계 값을 단조 시계로 착각해 쓰는 구현이면 경과가 음수로 튀어 테스트가 잡는다.

## 🔗 관련 이슈

- Closes #350
